### PR TITLE
Add release profile optimiztion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,9 @@ version = "0.1.0"
 edition = "2021"
 
 [profile.release]
+strip = true
 lto = true
+codegen-units = 1
 
 [workspace.dependencies]
 tokio = { version = "1.39.2", features = ["net", "macros", "rt-multi-thread", "fs", "io-util"] }


### PR DESCRIPTION
`codegen-units = 1` increase compile times but it improve both runtime speed and reduce binary size.
`strip = true` strip debug info and symbols from the compiled binary. so it can reduce binary size.

I made simple table for pumpkin binary size and compile times comparison.

| Configuration Option              | Description                                                | Increases Compile Time | Reduces Binary Size   | Improves Runtime Performance | Compile Result (Time; Size)  |
|-----------------------------------|------------------------------------------------------------|-----------------------|-----------------------|------------------------------|--------------------------------------|
| `codegen-units = 1`               | Improves runtime speed and reduces binary size             | Yes                   | Yes                   | Yes                          | `1m 19s; 4.0M`                       |
| `strip = true`                    | Strips debug info and symbols from the compiled binary     | No                  | Yes                   | No                           | `1m 10s; 3.7M`                       |
| `codegen-units = 1` + `strip = true` | Applies both to improve runtime speed and reduce binary size | Yes                   | Yes                   | Yes                          | `1m 19s; 3.5M`                       |
| None                              | Uses default settings                                      | No                    | No                    | No                           | `1m 14s; 4.2M`                       |