### PR TITLE
Fix compilation of individual packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ lto = true
 codegen-units = 1
 
 [workspace.dependencies]
-tokio = { version = "1.39.2", features = ["net", "macros", "rt-multi-thread", "fs", "io-util"] }
+tokio = { version = "1.39.2", features = ["net", "macros", "rt-multi-thread", "fs", "io-util", "sync"] }
 rayon = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ codegen-units = 1
 [workspace.dependencies]
 tokio = { version = "1.39.2", features = ["net", "macros", "rt-multi-thread", "fs", "io-util", "sync"] }
 rayon = "1.10.0"
+uuid = { version = "1.10.0", features = ["serde", "v3"] }

--- a/pumpkin-protocol/Cargo.toml
+++ b/pumpkin-protocol/Cargo.toml
@@ -10,7 +10,7 @@ pumpkin-text = { path = "../pumpkin-text" }
 
 bytes = "1.7"
 
-uuid = "1.10"
+uuid.workspace = true
 
 serde = { version = "1.0", features = ["derive"] }
 # to parse strings to json responses

--- a/pumpkin-text/Cargo.toml
+++ b/pumpkin-text/Cargo.toml
@@ -6,4 +6,4 @@ edition.workspace = true
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 fastnbt = { git = "https://github.com/owengage/fastnbt.git" }
-uuid = "1.10"
+uuid.workspace = true

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -61,7 +61,6 @@ log = "0.4"
 mio = { version = "1.0.1", features = ["os-poll", "net"]}
 crossbeam-channel = "0.5.13"
 
-uuid = { version = "1.10", features = ["serde", "v3"]}
-
+uuid.workspace = true
 tokio.workspace = true
 rayon.workspace = true


### PR DESCRIPTION
Previously `pumpkin-text`, `pumkin-protocol` and `pumkin-world` would not compile on their own.
This happened because we didn't specify the required features, but since a dependency (or `pumkin`) enabled them, the error went unnoticed.
Check out https://doc.rust-lang.org/cargo/reference/features.html#feature-unification for more information.

This PR enables the `sync` feature for `tokio` which is required by `pumkin-world` and moves `uuid` to the workspace so that every crate uses the same feature set (specifically, `pumkin-text` and `pumkin-protocol` also require it's `serde` feature).