### PR TITLE
Fix `set_slot` armor indexing (Off-by-one error)

### DIFF
--- a/pumpkin-inventory/src/player.rs
+++ b/pumpkin-inventory/src/player.rs
@@ -51,7 +51,7 @@ impl PlayerInventory {
             1..=4 => self.crafting[slot - 1] = item,
             5..=8 => {
                 match item {
-                    None => self.armor[slot - 4] = None,
+                    None => self.armor[slot - 5] = None,
                     Some(item) => {
                         // TODO: Replace asserts with error handling
                         match slot - 5 {


### PR DESCRIPTION
The correct value was already used in the second match arm.
`slot - 4` goes up to value `4` (`8` - `4`), `self.armor` has 4 elements (max index is `3`)