### PR TITLE
Superflat Worldgeneration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1980,11 +1980,13 @@ dependencies = [
  "futures",
  "itertools 0.13.0",
  "lazy_static",
+ "log",
  "num-derive",
  "num-traits",
  "rayon",
  "serde",
  "serde_json",
+ "static_assertions",
  "thiserror",
  "tokio",
 ]
@@ -2564,6 +2566,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"

--- a/pumpkin-protocol/src/client/play/c_chunk_data.rs
+++ b/pumpkin-protocol/src/client/play/c_chunk_data.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{bytebuf::ByteBuffer, BitSet, ClientPacket, VarInt};
 use itertools::Itertools;
 use pumpkin_macros::packet;
-use pumpkin_world::{block::block_registry::BlockId, chunk::ChunkData, DIRECT_PALETTE_BITS};
+use pumpkin_world::{chunk::ChunkData, DIRECT_PALETTE_BITS};
 
 #[packet(0x27)]
 pub struct CChunkData<'a>(pub &'a ChunkData);
@@ -23,15 +23,7 @@ impl<'a> ClientPacket for CChunkData<'a> {
 
         let mut data_buf = ByteBuffer::empty();
         self.0.blocks.iter_subchunks().for_each(|chunk| {
-            let block_count = chunk
-                .iter()
-                .dedup()
-                .filter(|block| {
-                    !block.is_air()
-                        && **block != BlockId::from_id(12959)
-                        && **block != BlockId::from_id(12958)
-                })
-                .count() as i16;
+            let block_count = chunk.iter().dedup().filter(|block| !block.is_air()).count() as i16;
             // Block count
             data_buf.put_i16(block_count);
             //// Block states

--- a/pumpkin-protocol/src/client/play/c_chunk_data.rs
+++ b/pumpkin-protocol/src/client/play/c_chunk_data.rs
@@ -11,9 +11,9 @@ pub struct CChunkData<'a>(pub &'a ChunkData);
 impl<'a> ClientPacket for CChunkData<'a> {
     fn write(&self, buf: &mut crate::bytebuf::ByteBuffer) {
         // Chunk X
-        buf.put_i32(self.0.position.0);
+        buf.put_i32(self.0.position.x);
         // Chunk Z
-        buf.put_i32(self.0.position.1);
+        buf.put_i32(self.0.position.z);
 
         let heightmap_nbt =
             fastnbt::to_bytes_with_opts(&self.0.heightmaps, fastnbt::SerOpts::network_nbt())

--- a/pumpkin-protocol/src/client/play/c_chunk_data.rs
+++ b/pumpkin-protocol/src/client/play/c_chunk_data.rs
@@ -23,7 +23,7 @@ impl<'a> ClientPacket for CChunkData<'a> {
 
         let mut data_buf = ByteBuffer::empty();
         self.0.blocks.iter_subchunks().for_each(|chunk| {
-            let block_count = chunk.iter().dedup().filter(|block| !block.is_air()).count() as i16;
+            let block_count = chunk.iter().filter(|block| !block.is_air()).count() as i16;
             // Block count
             data_buf.put_i16(block_count);
             //// Block states

--- a/pumpkin-protocol/src/client/play/c_chunk_data.rs
+++ b/pumpkin-protocol/src/client/play/c_chunk_data.rs
@@ -16,13 +16,13 @@ impl<'a> ClientPacket for CChunkData<'a> {
         buf.put_i32(self.0.position.z);
 
         let heightmap_nbt =
-            fastnbt::to_bytes_with_opts(&self.0.heightmaps, fastnbt::SerOpts::network_nbt())
+            fastnbt::to_bytes_with_opts(&self.0.blocks.heightmap, fastnbt::SerOpts::network_nbt())
                 .unwrap();
         // Heightmaps
         buf.put_slice(&heightmap_nbt);
 
         let mut data_buf = ByteBuffer::empty();
-        self.0.blocks.chunks(16 * 16 * 16).for_each(|chunk| {
+        self.0.blocks.iter_subchunks().for_each(|chunk| {
             let block_count = chunk
                 .iter()
                 .dedup()

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -16,6 +16,8 @@ flate2 = "1.0.33"
 serde = { version = "1.0", features = ["derive"] }
 lazy_static = "1.5.0"
 serde_json = "1.0"
+static_assertions = "1.1.0"
+log.workspace = true
 
 num-traits = "0.2"
 num-derive = "0.4"

--- a/pumpkin-world/src/biome.rs
+++ b/pumpkin-world/src/biome.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+
+// TODO make this work with the protocol
+#[derive(Serialize, Deserialize, Clone, Copy)]
+#[non_exhaustive]
+pub enum Biome {
+    Plains,
+    // TODO list all Biomes
+}

--- a/pumpkin-world/src/block/block_id.rs
+++ b/pumpkin-world/src/block/block_id.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use super::block_registry::BLOCKS;
+use crate::level::WorldError;
+
+// 0 is air -> reasonable default
+#[derive(Default, Deserialize, Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct BlockId {
+    data: u16,
+}
+
+impl BlockId {
+    pub const AIR: Self = Self::from_id(0);
+
+    pub fn new(
+        text_id: &str,
+        properties: Option<&HashMap<String, String>>,
+    ) -> Result<Self, WorldError> {
+        let mut block_states = BLOCKS
+            .get(text_id)
+            .ok_or(WorldError::BlockIdentifierNotFound)?
+            .states
+            .iter();
+
+        let block_state = match properties {
+            Some(properties) => match block_states.find(|state| &state.properties == properties) {
+                Some(state) => state,
+                None => return Err(WorldError::BlockStateIdNotFound),
+            },
+            None => block_states
+                .find(|state| state.is_default)
+                .expect("Every Block should have at least 1 default state"),
+        };
+
+        Ok(block_state.id)
+    }
+
+    pub const fn from_id(id: u16) -> Self {
+        // TODO: add check if the id is actually valid
+        Self { data: id }
+    }
+
+    pub fn is_air(&self) -> bool {
+        self.data == 0 || self.data == 12959 || self.data == 12958
+    }
+
+    pub fn get_id(&self) -> u16 {
+        self.data
+    }
+
+    /// An i32 is the way mojang internally represents their Blocks
+    pub fn get_id_mojang_repr(&self) -> i32 {
+        self.data as i32
+    }
+}

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -21,7 +21,7 @@ impl BlockId {
     ) -> Result<Self, WorldError> {
         let mut block_states = BLOCKS
             .get(block_id)
-            .ok_or(WorldError::BlockStateIdNotFound)?
+            .ok_or(WorldError::BlockIdentifierNotFound)?
             .states
             .iter();
 

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -1,26 +1,27 @@
 use std::collections::HashMap;
 
 use lazy_static::lazy_static;
+use serde::Deserialize;
 
 use crate::level::WorldError;
 
 const BLOCKS_JSON: &str = include_str!("../../assets/blocks.json");
 
-#[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BlockDefinition {
     #[serde(rename = "type")]
     kind: String,
     block_set_type: Option<String>,
 }
 
-#[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BlockState {
     default: Option<bool>,
     id: i64,
     properties: Option<HashMap<String, String>>,
 }
 
-#[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BlocksElement {
     definition: BlockDefinition,
     properties: Option<HashMap<String, Vec<String>>>,

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -3,101 +3,50 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use serde::Deserialize;
 
-use crate::level::WorldError;
+use super::block_id::BlockId;
 
-const BLOCKS_JSON: &str = include_str!("../../assets/blocks.json");
-
-// 0 is air -> reasonable default
-#[derive(Default, Deserialize, Debug, Hash, Clone, Copy, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct BlockId {
-    data: u16,
-}
-
-impl BlockId {
-    pub fn new(
-        block_id: &str,
-        properties: Option<&HashMap<String, String>>,
-    ) -> Result<Self, WorldError> {
-        let mut block_states = BLOCKS
-            .get(block_id)
-            .ok_or(WorldError::BlockIdentifierNotFound)?
-            .states
-            .iter();
-
-        let block_state = match properties {
-            Some(properties) => match block_states.find(|state| &state.properties == properties) {
-                Some(state) => state,
-                None => return Err(WorldError::BlockStateIdNotFound),
-            },
-            None => block_states
-                .find(|state| state.is_default)
-                .expect("Every Block should have at least 1 default state"),
-        };
-
-        Ok(block_state.id)
-    }
-
-    pub fn from_id(id: u16) -> Self {
-        // TODO: add check if the id is actually valid
-        Self { data: id }
-    }
-
-    pub fn is_air(&self) -> bool {
-        self.data == 0
-    }
-
-    pub fn get_id(&self) -> u16 {
-        self.data
-    }
-
-    /// An i32 is the way mojang internally represents their Blocks
-    pub fn get_id_mojang_repr(&self) -> i32 {
-        self.data as i32
-    }
+lazy_static! {
+    pub static ref BLOCKS: HashMap<String, RegistryBlockType> =
+        serde_json::from_str(include_str!("../../assets/blocks.json"))
+            .expect("Could not parse block.json registry.");
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct BlockDefinition {
+pub struct RegistryBlockDefinition {
     /// e.g. minecraft:door or minecraft:button
     #[serde(rename = "type")]
-    category: String,
+    pub category: String,
 
     /// Specifies the variant of the blocks category.
     /// e.g. minecraft:iron_door has the variant iron
     #[serde(rename = "block_set_type")]
-    variant: Option<String>,
+    pub variant: Option<String>,
 }
 
 /// One possible state of a Block.
 /// This could e.g. be an extended piston facing left.
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct BlockState {
-    id: BlockId,
+pub struct RegistryBlockState {
+    pub id: BlockId,
 
     /// Whether this is the default state of the Block
     #[serde(default, rename = "default")]
-    is_default: bool,
+    pub is_default: bool,
 
     /// The propertise active for this `BlockState`.
     #[serde(default)]
-    properties: HashMap<String, String>,
+    pub properties: HashMap<String, String>,
 }
 
 /// A fully-fledged block definition.
 /// Stores the category, variant, all of the possible states and all of the possible properties.
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct BlockType {
-    definition: BlockDefinition,
-    states: Vec<BlockState>,
+pub struct RegistryBlockType {
+    pub definition: RegistryBlockDefinition,
+    pub states: Vec<RegistryBlockState>,
 
     // TODO is this safe to remove? It's currently not used in the Project. @lukas0008 @Snowiiii
     /// A list of valid property keys/values for a block.
     #[serde(default, rename = "properties")]
     valid_properties: HashMap<String, Vec<String>>,
-}
-
-lazy_static! {
-    pub static ref BLOCKS: HashMap<String, BlockType> =
-        serde_json::from_str(BLOCKS_JSON).expect("Could not parse block.json registry.");
 }

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -9,27 +9,46 @@ const BLOCKS_JSON: &str = include_str!("../../assets/blocks.json");
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BlockDefinition {
+    /// e.g. minecraft:door or minecraft:button
     #[serde(rename = "type")]
-    kind: String,
-    block_set_type: Option<String>,
+    category: String,
+
+    /// Specifies the variant of the blocks category.
+    /// e.g. minecraft:iron_door has the variant iron
+    #[serde(rename = "block_set_type")]
+    variant: Option<String>,
 }
 
+/// One possible state of a Block.
+/// This could e.g. be an extended piston facing left.
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct BlockState {
-    default: Option<bool>,
     id: i64,
-    properties: Option<HashMap<String, String>>,
+
+    /// Whether this is the default state of the Block
+    #[serde(default, rename = "default")]
+    is_default: bool,
+
+    /// The propertise active for this `BlockState`.
+    #[serde(default)]
+    properties: HashMap<String, String>,
 }
 
+/// A fully-fledged block definition.
+/// Stores the category, variant, all of the possible states and all of the possible properties.
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct BlocksElement {
+pub struct BlockType {
     definition: BlockDefinition,
-    properties: Option<HashMap<String, Vec<String>>>,
     states: Vec<BlockState>,
+
+    // TODO is this safe to remove? It's currently not used in the Project. @lukas0008 @Snowiiii
+    /// A list of valid property keys/values for a block.
+    #[serde(default, rename = "properties")]
+    valid_properties: HashMap<String, Vec<String>>,
 }
 
 lazy_static! {
-    pub static ref BLOCKS: HashMap<String, BlocksElement> =
+    pub static ref BLOCKS: HashMap<String, BlockType> =
         serde_json::from_str(BLOCKS_JSON).expect("Could not parse block.json registry.");
 }
 
@@ -45,13 +64,13 @@ pub fn block_id_and_properties_to_block_state_id(
         None => Ok(block
             .states
             .iter()
-            .find(|state| state.default.unwrap_or(false))
+            .find(|state| state.is_default)
             .expect("Each block should have at least one default state")
             .id),
         Some(properties) => block
             .states
             .iter()
-            .find(|state| state.properties.as_ref() == Some(properties))
+            .find(|state| &state.properties == properties)
             .map(|state| state.id)
             .ok_or(WorldError::BlockStateIdNotFound),
     };

--- a/pumpkin-world/src/block/mod.rs
+++ b/pumpkin-world/src/block/mod.rs
@@ -1,9 +1,11 @@
+use crate::vector3::Vector3;
 use num_derive::FromPrimitive;
 
-use crate::vector3::Vector3;
+pub mod block_id;
+mod block_registry;
 
-pub mod block_registry;
-pub use block_registry::BLOCKS;
+pub use block_id::BlockId;
+
 #[derive(FromPrimitive)]
 pub enum BlockFace {
     Bottom = 0,

--- a/pumpkin-world/src/chunk.rs
+++ b/pumpkin-world/src/chunk.rs
@@ -6,7 +6,7 @@ use fastnbt::LongArray;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    block::block_registry::BlockId,
+    block::BlockId,
     coordinates::{ChunkCoordinates, ChunkRelativeBlockCoordinates, Height},
     level::WorldError,
     WORLD_HEIGHT,

--- a/pumpkin-world/src/chunk.rs
+++ b/pumpkin-world/src/chunk.rs
@@ -80,7 +80,7 @@ impl ChunkData {
                 Some(d) => d,
             }
             .into_inner();
-            let block_size = {
+            let block_bit_size = {
                 let size = 64 - (palette.len() as i64 - 1).leading_zeros();
                 if size >= 4 {
                     size
@@ -89,16 +89,16 @@ impl ChunkData {
                 }
             };
 
-            let mask = (1 << block_size) - 1;
+            let mask = (1 << block_bit_size) - 1;
             let mut blocks_left = 16 * 16 * 16;
             'block_loop: for (j, block) in block_data.iter().enumerate() {
-                for i in 0..64 / block_size {
+                for i in 0..64 / block_bit_size {
                     if blocks_left <= 0 {
                         break 'block_loop;
                     }
-                    let index = (block >> (i * block_size)) & mask;
+                    let index = (block >> (i * block_bit_size)) & mask;
                     let block = palette[index as usize];
-                    blocks[k * 16 * 16 * 16 + j * ((64 / block_size) as usize) + i as usize] =
+                    blocks[k * 16 * 16 * 16 + j * ((64 / block_bit_size) as usize) + i as usize] =
                         block;
                     blocks_left -= 1;
                 }

--- a/pumpkin-world/src/chunk.rs
+++ b/pumpkin-world/src/chunk.rs
@@ -70,15 +70,25 @@ struct ChunkNbt {
     heightmaps: ChunkHeightmaps,
 }
 
-// TODO @DaniD3v implement once Fre is done with heightmaps
-// impl Default for ChunkBlocks {
-//     fn default() -> Self {
-//         Self {
-//             blocks: Box::new([BlockId::default(); CHUNK_VOLUME]),
-//             heightmap: todo!(),
-//         }
-//     }
-// }
+/// The Heightmap for a completely empty chunk
+impl Default for ChunkHeightmaps {
+    fn default() -> Self {
+        Self {
+            // 0 packed into an i64 7 times.
+            motion_blocking: LongArray::new(vec![0; 37]),
+            world_surface: LongArray::new(vec![0; 37]),
+        }
+    }
+}
+
+impl Default for ChunkBlocks {
+    fn default() -> Self {
+        Self {
+            blocks: Box::new([BlockId::default(); CHUNK_VOLUME]),
+            heightmap: ChunkHeightmaps::default(),
+        }
+    }
+}
 
 impl ChunkBlocks {
     pub fn empty_with_heightmap(heightmap: ChunkHeightmaps) -> Self {

--- a/pumpkin-world/src/chunk.rs
+++ b/pumpkin-world/src/chunk.rs
@@ -61,12 +61,14 @@ struct ChunkSection {
 }
 
 #[derive(Deserialize, Debug)]
-#[allow(dead_code)]
+#[serde(rename_all = "PascalCase")]
 struct ChunkNbt {
-    #[serde(rename = "DataVersion")]
+    #[allow(dead_code)]
     data_version: usize,
+
+    #[serde(rename = "sections")]
     sections: Vec<ChunkSection>,
-    #[serde(rename = "Heightmaps")]
+
     heightmaps: ChunkHeightmaps,
 }
 

--- a/pumpkin-world/src/chunk.rs
+++ b/pumpkin-world/src/chunk.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use fastnbt::LongArray;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     coordinates::{ChunkCoordinates, ChunkRelativeBlockCoordinates},
@@ -14,27 +15,27 @@ pub struct ChunkData {
     pub heightmaps: ChunkHeightmaps,
 }
 
-#[derive(serde::Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct PaletteEntry {
     name: String,
     properties: Option<HashMap<String, String>>,
 }
 
-#[derive(serde::Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 struct ChunkSectionBlockStates {
     data: Option<LongArray>,
     palette: Vec<PaletteEntry>,
 }
 
-#[derive(serde::Deserialize, serde::Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "UPPERCASE")]
 pub struct ChunkHeightmaps {
     motion_blocking: LongArray,
     world_surface: LongArray,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[allow(dead_code)]
 struct ChunkSection {
     #[serde(rename = "Y")]
@@ -42,7 +43,7 @@ struct ChunkSection {
     block_states: Option<ChunkSectionBlockStates>,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 #[allow(dead_code)]
 struct ChunkNbt {
     #[serde(rename = "DataVersion")]

--- a/pumpkin-world/src/coordinates.rs
+++ b/pumpkin-world/src/coordinates.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{WORLD_HEIGHT, WORLD_Y_START_AT};
+use crate::{WORLD_LOWEST_Y, WORLD_MAX_Y};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Height {
@@ -9,20 +9,20 @@ pub struct Height {
 
 impl Height {
     pub fn new(height: i16) -> Self {
-        assert!(height <= (WORLD_HEIGHT as i16 - WORLD_Y_START_AT.abs() as i16));
-        assert!(height >= WORLD_Y_START_AT as i16);
+        assert!(height <= WORLD_MAX_Y);
+        assert!(height >= WORLD_LOWEST_Y);
 
         Self { height }
     }
 
     pub fn from_absolute(height: u16) -> Self {
-        Self::new(height as i16 - WORLD_Y_START_AT.abs() as i16)
+        Self::new(height as i16 - WORLD_LOWEST_Y.abs())
     }
 
     /// Absolute height ranges from `0..WORLD_HEIGHT`
-    /// instead of `WORLD_Y_START_AT..(WORLD_HEIGHT-WORLD_Y_START_AT)`
+    /// instead of `WORLD_LOWEST_Y..WORLD_MAX_Y`
     pub fn get_absolute(&self) -> u16 {
-        (self.height + WORLD_Y_START_AT.abs() as i16) as u16
+        (self.height + WORLD_LOWEST_Y.abs()) as u16
     }
 }
 

--- a/pumpkin-world/src/coordinates.rs
+++ b/pumpkin-world/src/coordinates.rs
@@ -1,0 +1,133 @@
+use std::ops::Deref;
+
+use crate::{WORLD_HEIGHT, WORLD_Y_START_AT};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Height {
+    height: i16,
+}
+
+impl Height {
+    pub fn new(height: i16) -> Self {
+        assert!(height <= (WORLD_HEIGHT as i16 - WORLD_Y_START_AT.abs() as i16));
+        assert!(height >= WORLD_Y_START_AT as i16);
+
+        Self { height }
+    }
+
+    pub fn from_absolute(height: u16) -> Self {
+        Self::new(height as i16 - WORLD_Y_START_AT.abs() as i16)
+    }
+
+    /// Absolute height ranges from `0..WORLD_HEIGHT`
+    /// instead of `WORLD_Y_START_AT..(WORLD_HEIGHT-WORLD_Y_START_AT)`
+    pub fn get_absolute(&self) -> u16 {
+        (self.height + WORLD_Y_START_AT.abs() as i16) as u16
+    }
+}
+
+impl Deref for Height {
+    type Target = i16;
+
+    fn deref(&self) -> &Self::Target {
+        &self.height
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkRelativeScalar {
+    scalar: u8,
+}
+
+macro_rules! derive_chunk_relative_scalar_from_int_impl {
+    ($integer:ty) => {
+        impl From<$integer> for ChunkRelativeScalar {
+            fn from(scalar: $integer) -> Self {
+                assert!(scalar < 16);
+                Self {
+                    scalar: scalar as u8,
+                }
+            }
+        }
+    };
+}
+
+derive_chunk_relative_scalar_from_int_impl! {u8}
+derive_chunk_relative_scalar_from_int_impl! {u16}
+derive_chunk_relative_scalar_from_int_impl! {u32}
+derive_chunk_relative_scalar_from_int_impl! {u64}
+derive_chunk_relative_scalar_from_int_impl! {u128}
+derive_chunk_relative_scalar_from_int_impl! {usize}
+
+impl Deref for ChunkRelativeScalar {
+    type Target = u8;
+
+    fn deref(&self) -> &Self::Target {
+        &self.scalar
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlockCoordinates {
+    pub x: i32,
+    pub y: Height,
+    pub z: i32,
+}
+
+/// BlockCoordinates that do not specify a height.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct XZBlockCoordinates {
+    pub x: i32,
+    pub z: i32,
+}
+
+/// Coordinates of a block relative to a chunk
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkRelativeBlockCoordinates {
+    pub x: ChunkRelativeScalar,
+    pub y: Height,
+    pub z: ChunkRelativeScalar,
+}
+
+impl ChunkRelativeBlockCoordinates {
+    pub fn with_chunk_coordinates(&self, chunk_coordinates: ChunkCoordinates) -> BlockCoordinates {
+        BlockCoordinates {
+            x: *self.x as i32 + chunk_coordinates.x * 16,
+            y: self.y,
+            z: *self.z as i32 + chunk_coordinates.z * 16,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkRelativeXZBlockCoordinates {
+    pub x: ChunkRelativeScalar,
+    pub z: ChunkRelativeScalar,
+}
+
+impl ChunkRelativeXZBlockCoordinates {
+    pub fn with_chunk_coordinates(
+        &self,
+        chunk_coordinates: ChunkCoordinates,
+    ) -> XZBlockCoordinates {
+        XZBlockCoordinates {
+            x: *self.x as i32 + chunk_coordinates.x * 16,
+            z: *self.z as i32 + chunk_coordinates.z * 16,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChunkCoordinates {
+    pub x: i32,
+    pub z: i32,
+}
+
+macro_rules! impl_get_absolute_height {
+    ($struct_name:ident) => {
+        impl $struct_name {}
+    };
+}
+
+impl_get_absolute_height! {BlockCoordinates}
+impl_get_absolute_height! {ChunkRelativeBlockCoordinates}

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::OpenOptions,
     io::{Read, Seek},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use flate2::{bufread::ZlibDecoder, read::GzDecoder};
@@ -24,12 +24,10 @@ pub enum WorldError {
     // using ErrorKind instead of Error, beacuse the function read_chunks and read_region_chunks is designed to return an error on a per-chunk basis, while std::io::Error does not implement Copy or Clone
     #[error("Io error: {0}")]
     IoError(std::io::ErrorKind),
-    #[error("Region not found")]
-    RegionNotFound,
     #[error("Region is invalid")]
     RegionIsInvalid,
-    #[error("Chunk not found")]
-    ChunkNotFound,
+    #[error("The chunk isn't generated yet: {0}")]
+    ChunkNotGenerated(ChunkNotGeneratedError),
     #[error("Compression Error")]
     Compression(CompressionError),
     #[error("Error deserializing chunk: {0}")]
@@ -40,6 +38,18 @@ pub enum WorldError {
     BlockStateIdNotFound,
     #[error("The block is not inside of the chunk")]
     BlockOutsideChunk,
+}
+
+#[derive(Error, Debug)]
+pub enum ChunkNotGeneratedError {
+    #[error("The region file does not exist.")]
+    RegionFileMissing,
+
+    #[error("The chunks generation is incomplete.")]
+    IncompleteGeneration,
+
+    #[error("Chunk not found.")]
+    NotFound,
 }
 
 #[derive(Error, Debug)]
@@ -98,130 +108,108 @@ impl Level {
     //         .1
     // }
 
-    /// Read many chunks in a world
+    /// Reads/Generates many chunks in a world
     /// MUST be called from a tokio runtime thread
     ///
     /// Note: The order of the output chunks will almost never be in the same order as the order of input chunks
-    pub async fn read_chunks(
+    pub async fn fetch_chunks(
         &self,
-        chunks: Vec<ChunkCoordinates>,
-        channel: mpsc::Sender<(ChunkCoordinates, Result<ChunkData, WorldError>)>,
+        chunks: &[ChunkCoordinates],
+        channel: mpsc::Sender<Result<ChunkData, WorldError>>,
     ) {
-        chunks.into_par_iter().for_each(|chunk| {
-            let region = (
-                ((chunk.x as f32) / 32.0).floor() as i32,
-                ((chunk.z as f32) / 32.0).floor() as i32,
-            );
+        chunks.into_par_iter().copied().for_each(|at| {
             let channel = channel.clone();
-
-            // return different error when file is not found (because that means that the chunks have just not been generated yet)
-            let mut region_file = match OpenOptions::new().read(true).open(
-                self.region_folder
-                    .join(format!("r.{}.{}.mca", region.0, region.1)),
-            ) {
-                Ok(f) => f,
-                Err(err) => match err.kind() {
-                    std::io::ErrorKind::NotFound => {
-                        let _ = channel.blocking_send((chunk, Err(WorldError::RegionNotFound)));
-                        return;
-                    }
-                    _ => {
-                        let _ =
-                            channel.blocking_send((chunk, Err(WorldError::IoError(err.kind()))));
-                        return;
-                    }
-                },
-            };
-
-            let mut location_table: [u8; 4096] = [0; 4096];
-            let mut timestamp_table: [u8; 4096] = [0; 4096];
-
-            // fill the location and timestamp tables
-            {
-                match region_file.read_exact(&mut location_table) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        let _ =
-                            channel.blocking_send((chunk, Err(WorldError::IoError(err.kind()))));
-                        return;
-                    }
-                }
-                match region_file.read_exact(&mut timestamp_table) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        let _ =
-                            channel.blocking_send((chunk, Err(WorldError::IoError(err.kind()))));
-                        return;
-                    }
-                }
-            }
-
-            let modulus = |a: i32, b: i32| ((a % b) + b) % b;
-            let chunk_x = modulus(chunk.x, 32) as u32;
-            let chunk_z = modulus(chunk.z, 32) as u32;
-            let channel = channel.clone();
-            let table_entry = (chunk_x + chunk_z * 32) * 4;
-
-            let mut offset = vec![0u8];
-            offset
-                .extend_from_slice(&location_table[table_entry as usize..table_entry as usize + 3]);
-            let offset = u32::from_be_bytes(offset.try_into().unwrap()) as u64 * 4096;
-            let size = location_table[table_entry as usize + 3] as usize * 4096;
-
-            if offset == 0 && size == 0 {
-                let _ = channel.blocking_send((chunk, Err(WorldError::ChunkNotFound)));
-                return;
-            }
-            // Read the file using the offset and size
-            let mut file_buf = {
-                let seek_result = region_file.seek(std::io::SeekFrom::Start(offset));
-                if seek_result.is_err() {
-                    let _ = channel.blocking_send((chunk, Err(WorldError::RegionIsInvalid)));
-                    return;
-                }
-                let mut out = vec![0; size];
-                let read_result = region_file.read_exact(&mut out);
-                if read_result.is_err() {
-                    let _ = channel.blocking_send((chunk, Err(WorldError::RegionIsInvalid)));
-                    return;
-                }
-                out
-            };
-
-            // TODO: check checksum to make sure chunk is not corrupted
-            let header = file_buf.drain(0..5).collect_vec();
-
-            let compression = match Compression::from_byte(header[4]) {
-                Some(c) => c,
-                None => {
-                    let _ = channel.blocking_send((
-                        chunk,
-                        Err(WorldError::Compression(
-                            CompressionError::UnknownCompression,
-                        )),
-                    ));
-                    return;
-                }
-            };
-
-            let size = u32::from_be_bytes(header[..4].try_into().unwrap());
-
-            // size includes the compression scheme byte, so we need to subtract 1
-            let chunk_data = file_buf.drain(0..size as usize - 1).collect_vec();
-            let decompressed_chunk = match Self::decompress_data(compression, chunk_data) {
-                Ok(data) => data,
-                Err(e) => {
-                    channel
-                        .blocking_send((chunk, Err(WorldError::Compression(e))))
-                        .expect("Failed to send Compression error");
-                    return;
-                }
-            };
 
             channel
-                .blocking_send((chunk, ChunkData::from_bytes(decompressed_chunk, chunk)))
-                .expect("Error sending decompressed chunk");
+                .blocking_send(match Self::read_chunk(&self.region_folder, at) {
+                    Err(WorldError::ChunkNotGenerated(_)) => {
+                        // This chunk was not generated yet.
+                        todo!("generate chunk here")
+                    }
+                    // TODO this doesn't warn the user about the error. fix.
+                    result => result,
+                })
+                .expect("Failed sending ChunkData.");
         })
+    }
+
+    fn read_chunk(region_folder: &Path, at: ChunkCoordinates) -> Result<ChunkData, WorldError> {
+        let region = (
+            ((at.x as f32) / 32.0).floor() as i32,
+            ((at.z as f32) / 32.0).floor() as i32,
+        );
+
+        let mut region_file = OpenOptions::new()
+            .read(true)
+            .open(region_folder.join(format!("r.{}.{}.mca", region.0, region.1)))
+            .map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => {
+                    WorldError::ChunkNotGenerated(ChunkNotGeneratedError::RegionFileMissing)
+                }
+                kind => WorldError::IoError(kind),
+            })?;
+
+        let mut location_table: [u8; 4096] = [0; 4096];
+        let mut timestamp_table: [u8; 4096] = [0; 4096];
+
+        // fill the location and timestamp tables
+        region_file
+            .read_exact(&mut location_table)
+            .map_err(|err| WorldError::IoError(err.kind()))?;
+        region_file
+            .read_exact(&mut timestamp_table)
+            .map_err(|err| WorldError::IoError(err.kind()))?;
+
+        let modulus = |a: i32, b: i32| ((a % b) + b) % b;
+        let chunk_x = modulus(at.x, 32) as u32;
+        let chunk_z = modulus(at.z, 32) as u32;
+        let table_entry = (chunk_x + chunk_z * 32) * 4;
+
+        let mut offset = vec![0u8];
+        offset.extend_from_slice(&location_table[table_entry as usize..table_entry as usize + 3]);
+        let offset = u32::from_be_bytes(offset.try_into().unwrap()) as u64 * 4096;
+        let size = location_table[table_entry as usize + 3] as usize * 4096;
+
+        if offset == 0 && size == 0 {
+            return Err(WorldError::ChunkNotGenerated(
+                ChunkNotGeneratedError::NotFound,
+            ));
+        }
+
+        // Read the file using the offset and size
+        let mut file_buf = {
+            let seek_result = region_file.seek(std::io::SeekFrom::Start(offset));
+            if seek_result.is_err() {
+                return Err(WorldError::RegionIsInvalid);
+            }
+            let mut out = vec![0; size];
+            let read_result = region_file.read_exact(&mut out);
+            if read_result.is_err() {
+                return Err(WorldError::RegionIsInvalid);
+            }
+            out
+        };
+
+        // TODO: check checksum to make sure chunk is not corrupted
+        let header = file_buf.drain(0..5).collect_vec();
+
+        let compression = match Compression::from_byte(header[4]) {
+            Some(c) => c,
+            None => {
+                return Err(WorldError::Compression(
+                    CompressionError::UnknownCompression,
+                ))
+            }
+        };
+
+        let size = u32::from_be_bytes(header[..4].try_into().unwrap());
+
+        // size includes the compression scheme byte, so we need to subtract 1
+        let chunk_data = file_buf.drain(0..size as usize - 1).collect_vec();
+        let decompressed_chunk =
+            Self::decompress_data(compression, chunk_data).map_err(WorldError::Compression)?;
+
+        ChunkData::from_bytes(decompressed_chunk, at)
     }
 
     fn decompress_data(

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -34,6 +34,8 @@ pub enum WorldError {
     Compression(CompressionError),
     #[error("Error deserializing chunk: {0}")]
     ErrorDeserializingChunk(String),
+    #[error("The requested block identifier does not exist")]
+    BlockIdentifierNotFound,
     #[error("The requested block state id does not exist")]
     BlockStateIdNotFound,
     #[error("The block is not inside of the chunk")]

--- a/pumpkin-world/src/lib.rs
+++ b/pumpkin-world/src/lib.rs
@@ -1,6 +1,7 @@
 use level::Level;
 
 pub mod chunk;
+pub mod coordinates;
 pub mod dimension;
 pub const WORLD_HEIGHT: usize = 384;
 pub const WORLD_Y_START_AT: i32 = -64;

--- a/pumpkin-world/src/lib.rs
+++ b/pumpkin-world/src/lib.rs
@@ -1,5 +1,6 @@
 use level::Level;
 
+pub mod biome;
 pub mod block;
 pub mod chunk;
 pub mod coordinates;

--- a/pumpkin-world/src/lib.rs
+++ b/pumpkin-world/src/lib.rs
@@ -10,6 +10,7 @@ pub mod item;
 mod level;
 pub mod radial_chunk_iterator;
 pub mod vector3;
+mod world_gen;
 
 pub const WORLD_HEIGHT: usize = 384;
 pub const WORLD_LOWEST_Y: i16 = -64;

--- a/pumpkin-world/src/lib.rs
+++ b/pumpkin-world/src/lib.rs
@@ -1,17 +1,19 @@
 use level::Level;
 
+pub mod block;
 pub mod chunk;
 pub mod coordinates;
 pub mod dimension;
-pub const WORLD_HEIGHT: usize = 384;
-pub const WORLD_Y_START_AT: i32 = -64;
-pub const DIRECT_PALETTE_BITS: u32 = 15;
-pub mod block;
 pub mod global_registry;
 pub mod item;
 mod level;
 pub mod radial_chunk_iterator;
 pub mod vector3;
+
+pub const WORLD_HEIGHT: usize = 384;
+pub const WORLD_LOWEST_Y: i16 = -64;
+pub const WORLD_MAX_Y: i16 = WORLD_HEIGHT as i16 - WORLD_LOWEST_Y.abs();
+pub const DIRECT_PALETTE_BITS: u32 = 15;
 
 pub struct World {
     pub level: Level,

--- a/pumpkin-world/src/radial_chunk_iterator.rs
+++ b/pumpkin-world/src/radial_chunk_iterator.rs
@@ -1,7 +1,9 @@
+use crate::coordinates::ChunkCoordinates;
+
 pub struct RadialIterator {
     radius: u32,
     direction: usize,
-    current: (i32, i32),
+    current: ChunkCoordinates,
     step_size: i32,
     steps_taken: u32,
     steps_in_direction: i32,
@@ -12,7 +14,7 @@ impl RadialIterator {
         RadialIterator {
             radius,
             direction: 0,
-            current: (0, 0),
+            current: ChunkCoordinates { x: 0, z: 0 },
             step_size: 1,
             steps_taken: 0,
             steps_in_direction: 0,
@@ -21,7 +23,7 @@ impl RadialIterator {
 }
 
 impl Iterator for RadialIterator {
-    type Item = (i32, i32);
+    type Item = ChunkCoordinates;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.steps_taken >= self.radius * self.radius * 4 {
@@ -34,10 +36,10 @@ impl Iterator for RadialIterator {
 
         // Move in the current direction
         match self.direction {
-            0 => self.current.0 += 1, // Right
-            1 => self.current.1 += 1, // Up
-            2 => self.current.0 -= 1, // Left
-            3 => self.current.1 -= 1, // Down
+            0 => self.current.x += 1, // East
+            1 => self.current.z += 1, // North
+            2 => self.current.x -= 1, // West
+            3 => self.current.z -= 1, // South
             _ => {}
         }
 

--- a/pumpkin-world/src/world_gen/generator.rs
+++ b/pumpkin-world/src/world_gen/generator.rs
@@ -1,0 +1,25 @@
+use static_assertions::assert_obj_safe;
+
+use crate::biome::Biome;
+use crate::block::BlockId;
+use crate::chunk::ChunkData;
+use crate::coordinates::{BlockCoordinates, ChunkCoordinates, XZBlockCoordinates};
+use crate::world_gen::Seed;
+
+pub trait GeneratorInit {
+    fn new(seed: Seed) -> Self;
+}
+
+pub trait WorldGenerator: Sync + Send {
+    #[allow(dead_code)]
+    fn generate_chunk(&self, at: ChunkCoordinates) -> ChunkData;
+}
+assert_obj_safe! {WorldGenerator}
+
+pub(crate) trait BiomeGenerator: Sync + Send {
+    fn generate_biome(&self, at: XZBlockCoordinates) -> Biome;
+}
+
+pub(crate) trait TerrainGenerator: Sync + Send {
+    fn generate_block(&self, at: BlockCoordinates, biome: Biome) -> BlockId;
+}

--- a/pumpkin-world/src/world_gen/generic_generator.rs
+++ b/pumpkin-world/src/world_gen/generic_generator.rs
@@ -1,0 +1,66 @@
+use crate::{
+    chunk::{ChunkBlocks, ChunkData},
+    coordinates::{
+        ChunkCoordinates, ChunkRelativeBlockCoordinates, ChunkRelativeXZBlockCoordinates,
+    },
+    WORLD_LOWEST_Y, WORLD_MAX_Y,
+};
+
+use super::{
+    generator::{BiomeGenerator, GeneratorInit, TerrainGenerator, WorldGenerator},
+    Seed,
+};
+
+pub struct GenericGenerator<B: BiomeGenerator, T: TerrainGenerator> {
+    biome_generator: B,
+    terrain_generator: T,
+}
+
+impl<B: BiomeGenerator + GeneratorInit, T: TerrainGenerator + GeneratorInit> GeneratorInit
+    for GenericGenerator<B, T>
+{
+    fn new(seed: Seed) -> Self {
+        Self {
+            biome_generator: B::new(seed),
+            terrain_generator: T::new(seed),
+        }
+    }
+}
+
+impl<B: BiomeGenerator, T: TerrainGenerator> WorldGenerator for GenericGenerator<B, T> {
+    fn generate_chunk(&self, at: ChunkCoordinates) -> ChunkData {
+        let mut blocks = ChunkBlocks::default();
+
+        for x in 0..16u8 {
+            for z in 0..16u8 {
+                let biome = self.biome_generator.generate_biome(
+                    ChunkRelativeXZBlockCoordinates {
+                        x: x.into(),
+                        z: z.into(),
+                    }
+                    .with_chunk_coordinates(at),
+                );
+
+                // Iterate from the highest block to the lowest, in order to minimize the heightmap updates
+                for y in (WORLD_LOWEST_Y..WORLD_MAX_Y).rev() {
+                    let coordinates = ChunkRelativeBlockCoordinates {
+                        x: x.into(),
+                        y: y.into(),
+                        z: z.into(),
+                    };
+
+                    blocks.set_block(
+                        coordinates,
+                        self.terrain_generator
+                            .generate_block(coordinates.with_chunk_coordinates(at), biome),
+                    );
+                }
+            }
+        }
+
+        ChunkData {
+            blocks,
+            position: at,
+        }
+    }
+}

--- a/pumpkin-world/src/world_gen/implementations/mod.rs
+++ b/pumpkin-world/src/world_gen/implementations/mod.rs
@@ -1,0 +1,1 @@
+pub mod superflat;

--- a/pumpkin-world/src/world_gen/implementations/superflat.rs
+++ b/pumpkin-world/src/world_gen/implementations/superflat.rs
@@ -1,0 +1,48 @@
+use crate::{
+    biome::Biome,
+    block::BlockId,
+    coordinates::{BlockCoordinates, XZBlockCoordinates},
+    world_gen::{
+        generator::{BiomeGenerator, GeneratorInit, TerrainGenerator},
+        generic_generator::GenericGenerator,
+        Seed,
+    },
+};
+
+#[allow(dead_code)]
+pub type SuperflatGenerator = GenericGenerator<SuperflatBiomeGenerator, SuperflatTerrainGenerator>;
+
+pub(crate) struct SuperflatBiomeGenerator {}
+
+impl GeneratorInit for SuperflatBiomeGenerator {
+    fn new(_: Seed) -> Self {
+        Self {}
+    }
+}
+
+impl BiomeGenerator for SuperflatBiomeGenerator {
+    // TODO make generic over Biome and allow changing the Biome in the config.
+    fn generate_biome(&self, _: XZBlockCoordinates) -> Biome {
+        Biome::Plains
+    }
+}
+
+pub(crate) struct SuperflatTerrainGenerator {}
+
+impl GeneratorInit for SuperflatTerrainGenerator {
+    fn new(_: Seed) -> Self {
+        Self {}
+    }
+}
+
+impl TerrainGenerator for SuperflatTerrainGenerator {
+    // TODO allow specifying which blocks should be at which height in the config.
+    fn generate_block(&self, at: BlockCoordinates, _: Biome) -> BlockId {
+        match *at.y {
+            -64 => BlockId::from_id(79),       // Bedrock
+            -63..=-62 => BlockId::from_id(10), // Dirt
+            -61 => BlockId::from_id(9),        // Grass
+            _ => BlockId::AIR,
+        }
+    }
+}

--- a/pumpkin-world/src/world_gen/mod.rs
+++ b/pumpkin-world/src/world_gen/mod.rs
@@ -1,0 +1,1 @@
+mod seed;

--- a/pumpkin-world/src/world_gen/mod.rs
+++ b/pumpkin-world/src/world_gen/mod.rs
@@ -1,11 +1,16 @@
 mod generator;
 mod generic_generator;
+mod implementations;
 mod seed;
 
 pub use generator::WorldGenerator;
 pub use seed::Seed;
 
+use generator::GeneratorInit;
+use implementations::superflat::SuperflatGenerator;
+
 #[allow(dead_code)]
-pub fn get_world_gen(_: Seed) -> Box<dyn WorldGenerator> {
-    todo!()
+pub fn get_world_gen(seed: Seed) -> Box<dyn WorldGenerator> {
+    // TODO decide which WorldGenerator to pick based on config.
+    Box::new(SuperflatGenerator::new(seed))
 }

--- a/pumpkin-world/src/world_gen/mod.rs
+++ b/pumpkin-world/src/world_gen/mod.rs
@@ -1,1 +1,11 @@
+mod generator;
+mod generic_generator;
 mod seed;
+
+pub use generator::WorldGenerator;
+pub use seed::Seed;
+
+#[allow(dead_code)]
+pub fn get_world_gen(_: Seed) -> Box<dyn WorldGenerator> {
+    todo!()
+}

--- a/pumpkin-world/src/world_gen/seed.rs
+++ b/pumpkin-world/src/world_gen/seed.rs
@@ -1,0 +1,16 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+pub struct Seed(pub i64);
+
+impl From<&str> for Seed {
+    fn from(value: &str) -> Self {
+        // TODO replace with a deterministic hasher (the same as vanilla?)
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+
+        // TODO use cast_signed once the feature is stabilized.
+        Self(hasher.finish() as i64)
+    }
+}

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -25,7 +25,7 @@ use pumpkin_protocol::{
         SUseItemOn, Status,
     },
 };
-use pumpkin_world::block::{block_registry::BlockId, BlockFace};
+use pumpkin_world::block::{BlockFace, BlockId};
 use pumpkin_world::global_registry;
 
 use super::PlayerConfig;

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -25,7 +25,7 @@ use pumpkin_protocol::{
         SUseItemOn, Status,
     },
 };
-use pumpkin_world::block::BlockFace;
+use pumpkin_world::block::{block_registry::BlockId, BlockFace};
 use pumpkin_world::global_registry;
 
 use super::PlayerConfig;
@@ -400,21 +400,16 @@ impl Player {
             let minecraft_id =
                 global_registry::find_minecraft_id(global_registry::ITEM_REGISTRY, item.item_id)
                     .expect("All item ids are in the global registry");
-            if let Ok(block_state_id) =
-                pumpkin_world::block::block_registry::block_id_and_properties_to_block_state_id(
-                    minecraft_id,
-                    None,
-                )
-            {
+            if let Ok(block_state_id) = BlockId::new(minecraft_id, None) {
                 server.broadcast_packet(
                     self,
-                    &CBlockUpdate::new(&location, (block_state_id as i32).into()),
+                    &CBlockUpdate::new(&location, block_state_id.get_id_mojang_repr().into()),
                 );
                 server.broadcast_packet(
                     self,
                     &CBlockUpdate::new(
                         &WorldPosition(location.0 + face.to_offset()),
-                        (block_state_id as i32).into(),
+                        block_state_id.get_id_mojang_repr().into(),
                     ),
                 );
             }

--- a/pumpkin/src/server.rs
+++ b/pumpkin/src/server.rs
@@ -102,7 +102,6 @@ impl Server {
         log::info!("Loading Plugins");
         let plugin_loader = PluginLoader::load();
 
-        log::warn!("Pumpkin does currently not have World or Chunk generation, Using ../world folder with vanilla pregenerated chunks");
         let world = World::load(Dimension::OverWorld.into_level(
             // TODO: load form config
             "./world".parse().unwrap(),

--- a/pumpkin/src/server.rs
+++ b/pumpkin/src/server.rs
@@ -374,7 +374,7 @@ impl Server {
                 Err(_) => continue,
             };
             #[cfg(debug_assertions)]
-            if _chunk_pos == (0, 0) {
+            if _chunk_pos == (pumpkin_world::coordinates::ChunkCoordinates { x: 0, z: 0 }) {
                 use pumpkin_protocol::bytebuf::ByteBuffer;
                 let mut test = ByteBuffer::empty();
                 CChunkData(&chunk_data).write(&mut test);


### PR DESCRIPTION
This PR adds Superflat Worldgeneration.

![image](https://github.com/user-attachments/assets/1b6e3246-529f-4f47-91bf-2e3e981d85ae)

By default the vanilla `./world` file is still read but chunks that are not generated yet are replaced by newly generated chunks.

This is currently not configurable because I plan on making it configurable after the "move config to `LazyLock`" PR will be rejected/merged.

If I went a bit overboard with all the refactors tell me and I'll cherry-pick the commits into another branch.

All of the commits compile individually and were checked with
```
cargo clippy -- -W clippy::complexity -W clippy::correctness -W clippy::perf -W clippy::style -W clippy::suspicious
cargo build
cargo check --release
cargo fmt --check
```

related to #36 