### PR TITLE
create rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+[toolchain]
+# Anything in the latest stable version of rust is fine to use.
+channel = "stable"
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,8 @@
 # Anything in the latest stable version of rust is fine to use.
 channel = "stable"
 targets = [
-    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-pc-windows-gnu",
     "x86_64-pc-windows-msvc",
+    "x86_64-unknown-linux-gnu",
 ]


### PR DESCRIPTION
This restricts people to using the stable toolchain.

If someone, (like myself) has the default toolchain be `nightly`, this will prevent the project from being built on a different toolchain accidentally.

You can see an example of this here:
```
~/Projects/Pumpkin> rustup show 
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/monkey/.rustup

installed toolchains
--------------------

stable-x86_64-unknown-linux-gnu
nightly-x86_64-unknown-linux-gnu (default)
1.65.0-x86_64-unknown-linux-gnu
[snip]

installed targets for active toolchain
--------------------------------------

x86_64-apple-darwin
x86_64-pc-windows-gnu
x86_64-pc-windows-msvc
x86_64-unknown-linux-gnu

active toolchain
----------------

stable-x86_64-unknown-linux-gnu (overridden by '/home/monkey/Projects/Pumpkin/rust-toolchain.toml')
rustc 1.80.1 (3f5fd8dd4 2024-08-06)
```

Notice that the `(default)` by `nightly-...`