### PR TITLE
Improve docs, include README.md files in crate level documentation

### DIFF
--- a/pumpkin-protocol/README.md
+++ b/pumpkin-protocol/README.md
@@ -1,5 +1,9 @@
 ### Pumpkin Protocol
-Contains all Serverbound(Client->Server) and Clientbound(Server->Client) Packets.
+Contains all serverbound and clientbound packets.
+
+**Clientbound** meaning that it's a packet being sent from the server to the client. (Server->Client)
+
+**Serverbound** meaning that it's a packet the client sends to the server. (Client->Server)
 
 Packets in the Pumpkin protocol are organized by functionality and state.
 

--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use bytebuf::{packet_id::Packet, ByteBuffer, DeserializerError};
 use bytes::Buf;
 use serde::{Deserialize, Serialize};

--- a/pumpkin-registry/README.md
+++ b/pumpkin-registry/README.md
@@ -1,5 +1,5 @@
 ### Pumpkin Registry
 Here you find all the registry data we have.
 Registries are repositories of data that contain entries pertaining to certain aspects of the game, such as the world, the player, among others. 
-Registry data usually send by the Clientbound Registry data Packet.
+Registry data is usually send by the clientbound CRegistryData packet.
 A list of Registry entries can be found at https://wiki.vg/Registry_Data

--- a/pumpkin-registry/src/lib.rs
+++ b/pumpkin-registry/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use biomes::Biome;
 use chat_type::ChatType;
 use dimensions::Dimension;

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -60,6 +60,7 @@ impl Default for PlayerConfig {
     }
 }
 
+/// Represents a Minecraft client connected to, or attempting to connect to the server. 
 pub struct Client {
     pub gameprofile: Option<GameProfile>,
 

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -34,7 +34,8 @@ fn modulus(a: f32, b: f32) -> f32 {
     ((a % b) + b) % b
 }
 
-/// Handles all Play Packets send by a real Player
+/// Contains method implementations for handling play packets regarding a specific Minecraft player connected to the server.
+/// Handles all Play packets sent by a real Player
 /// NEVER TRUST THE CLIENT. HANDLE EVERY ERROR, UNWRAP/EXPECT ARE FORBIDDEN
 impl Player {
     pub fn handle_confirm_teleport(

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -1,3 +1,6 @@
+#![doc = include_str!("../../README.md")]
+#![doc = include_str!("../../STRUCTURE.md")]
+
 #![allow(clippy::await_holding_refcell_ref)]
 #![allow(clippy::await_holding_lock)]
 


### PR DESCRIPTION
When running cargo doc --no-deps --open you are greeted with this beautiful documentation:

![image](https://github.com/user-attachments/assets/dfbcd4df-9c3b-43a9-a67e-242158518cd8)

Or for the pumpkin_protocol crate: 

![image](https://github.com/user-attachments/assets/ec103f0d-9abc-460c-a7ee-a8d89eb764ef)

Also fixed some typos here and there ...
