### PR TITLE
Remove lazy static in favor of LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2018,7 +2018,6 @@ dependencies = [
  "flate2",
  "futures",
  "itertools 0.13.0",
- "lazy_static",
  "log",
  "num-derive",
  "num-traits",

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -15,7 +15,6 @@ thiserror = "1.0.63"
 futures = "0.3.30"
 flate2 = "1.0.33"
 serde = { version = "1.0", features = ["derive"] }
-lazy_static = "1.5.0"
 serde_json = "1.0"
 static_assertions = "1.1.0"
 log.workspace = true

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -1,15 +1,13 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 
-use lazy_static::lazy_static;
 use serde::Deserialize;
 
 use super::block_id::BlockId;
 
-lazy_static! {
-    pub static ref BLOCKS: HashMap<String, RegistryBlockType> =
-        serde_json::from_str(include_str!("../../assets/blocks.json"))
-            .expect("Could not parse block.json registry.");
-}
+pub static BLOCKS: LazyLock<HashMap<String, RegistryBlockType>> = LazyLock::new(|| {
+    serde_json::from_str(include_str!("../../assets/blocks.json"))
+        .expect("Could not parse block.json registry.")
+});
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct RegistryBlockDefinition {

--- a/pumpkin-world/src/global_registry.rs
+++ b/pumpkin-world/src/global_registry.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use lazy_static::lazy_static;
+use std::{collections::HashMap, sync::LazyLock};
 
 pub const ITEM_REGISTRY: &str = "minecraft:item";
 
@@ -12,10 +10,9 @@ pub struct RegistryElement {
     pub entries: HashMap<String, HashMap<String, u32>>,
 }
 
-lazy_static! {
-    pub static ref REGISTRY: HashMap<String, RegistryElement> =
-        serde_json::from_str(REGISTRY_JSON).expect("Could not parse registry.json registry.");
-}
+pub static REGISTRY: LazyLock<HashMap<String, RegistryElement>> = LazyLock::new(|| {
+    serde_json::from_str(REGISTRY_JSON).expect("Could not parse registry.json registry.")
+});
 
 pub fn get_protocol_id(category: &str, entry: &str) -> u32 {
     *REGISTRY

--- a/pumpkin-world/src/item/item_registry.rs
+++ b/pumpkin-world/src/item/item_registry.rs
@@ -1,12 +1,13 @@
-use std::collections::HashMap;
-
-use lazy_static::lazy_static;
-
-use crate::global_registry::{self, ITEM_REGISTRY};
+use std::{collections::HashMap, sync::LazyLock};
 
 use super::Rarity;
+use crate::global_registry::{self, ITEM_REGISTRY};
 
 const ITEMS_JSON: &str = include_str!("../../assets/items.json");
+
+pub static ITEMS: LazyLock<HashMap<String, ItemElement>> = LazyLock::new(|| {
+    serde_json::from_str(ITEMS_JSON).expect("Could not parse items.json registry.")
+});
 
 #[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ItemComponents {
@@ -25,11 +26,6 @@ pub struct ItemComponents {
 #[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ItemElement {
     components: ItemComponents,
-}
-
-lazy_static! {
-    pub static ref ITEMS: HashMap<String, ItemElement> =
-        serde_json::from_str(ITEMS_JSON).expect("Could not parse items.json registry.");
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Remove lazy static in favor of `LazyLock`

- Increases MSRV
- Removes a dependency (-compiletime)

there's no change in program behavior in this PR.