### PR TITLE
Incoming Packet Validation

### DIFF
--- a/pumpkin-protocol/src/bytebuf/deserializer.rs
+++ b/pumpkin-protocol/src/bytebuf/deserializer.rs
@@ -45,77 +45,77 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_bool(self.inner.get_bool())
+        visitor.visit_bool(self.inner.get_bool()?)
     }
 
     fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_i8(self.inner.get_i8())
+        visitor.visit_i8(self.inner.get_i8()?)
     }
 
     fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_i16(self.inner.get_i16())
+        visitor.visit_i16(self.inner.get_i16()?)
     }
 
     fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_i32(self.inner.get_i32())
+        visitor.visit_i32(self.inner.get_i32()?)
     }
 
     fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_i64(self.inner.get_i64())
+        visitor.visit_i64(self.inner.get_i64()?)
     }
 
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_u8(self.inner.get_u8())
+        visitor.visit_u8(self.inner.get_u8()?)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_u16(self.inner.get_u16())
+        visitor.visit_u16(self.inner.get_u16()?)
     }
 
     fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_u32(self.inner.get_u32())
+        visitor.visit_u32(self.inner.get_u32()?)
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_u64(self.inner.get_u64())
+        visitor.visit_u64(self.inner.get_u64()?)
     }
 
     fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_f32(self.inner.get_f32())
+        visitor.visit_f32(self.inner.get_f32()?)
     }
 
     fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_f64(self.inner.get_f64())
+        visitor.visit_f64(self.inner.get_f64()?)
     }
 
     fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
@@ -129,7 +129,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: de::Visitor<'de>,
     {
-        let string = self.inner.get_string().map_err(DeserializerError::Stdio)?;
+        let string = self.inner.get_string()?;
         visitor.visit_str(&string)
     }
 
@@ -137,7 +137,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: de::Visitor<'de>,
     {
-        let string = self.inner.get_string().map_err(DeserializerError::Stdio)?;
+        let string = self.inner.get_string()?;
         visitor.visit_str(&string)
     }
 

--- a/pumpkin-protocol/src/bytebuf/mod.rs
+++ b/pumpkin-protocol/src/bytebuf/mod.rs
@@ -84,6 +84,14 @@ impl ByteBuffer {
                 "String length is bigger than max size",
             ));
         }
+
+        if size as usize > self.buffer.len() {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "String length is bigger than packet",
+            ));
+        }
+
         let data = self.buffer.copy_to_bytes(size as usize);
         if data.len() > max_size {
             return Err(Error::new(

--- a/pumpkin-protocol/src/bytebuf/mod.rs
+++ b/pumpkin-protocol/src/bytebuf/mod.rs
@@ -359,19 +359,23 @@ impl ByteBuffer {
     }
 
     pub fn copy_to_bytes(&mut self, len: usize) -> Result<bytes::Bytes, DeserializerError> {
-        if self.buffer.remaining() >= len {
+        if self.buffer.len() >= len {
             Ok(self.buffer.copy_to_bytes(len))
         } else {
-            Err(DeserializerError::Message("Unable to copy".to_string()))
+            Err(DeserializerError::Message(
+                "Unable to copy bytes".to_string(),
+            ))
         }
     }
 
     pub fn copy_to_slice(&mut self, dst: &mut [u8]) -> Result<(), DeserializerError> {
-        if self.buffer.remaining() > dst.len() {
+        if self.buffer.remaining() >= dst.len() {
             self.buffer.copy_to_slice(dst);
             Ok(())
         } else {
-            Err(DeserializerError::Message("Unable to copy".to_string()))
+            Err(DeserializerError::Message(
+                "Unable to copy slice".to_string(),
+            ))
         }
     }
 

--- a/pumpkin-protocol/src/server/handshake/mod.rs
+++ b/pumpkin-protocol/src/server/handshake/mod.rs
@@ -16,10 +16,10 @@ pub struct SHandShake {
 impl ServerPacket for SHandShake {
     fn read(bytebuf: &mut ByteBuffer) -> Result<Self, DeserializerError> {
         Ok(Self {
-            protocol_version: bytebuf.get_var_int(),
-            server_address: bytebuf.get_string_len(255).unwrap(),
-            server_port: bytebuf.get_u16(),
-            next_state: bytebuf.get_var_int().into(),
+            protocol_version: bytebuf.get_var_int()?,
+            server_address: bytebuf.get_string_len(255)?,
+            server_port: bytebuf.get_u16()?,
+            next_state: bytebuf.get_var_int()?.into(),
         })
     }
 }

--- a/pumpkin-protocol/src/server/login/s_encryption_response.rs
+++ b/pumpkin-protocol/src/server/login/s_encryption_response.rs
@@ -15,10 +15,10 @@ pub struct SEncryptionResponse {
 
 impl ServerPacket for SEncryptionResponse {
     fn read(bytebuf: &mut ByteBuffer) -> Result<Self, DeserializerError> {
-        let shared_secret_length = bytebuf.get_var_int();
-        let shared_secret = bytebuf.copy_to_bytes(shared_secret_length.0 as usize);
-        let verify_token_length = bytebuf.get_var_int();
-        let verify_token = bytebuf.copy_to_bytes(shared_secret_length.0 as usize);
+        let shared_secret_length = bytebuf.get_var_int()?;
+        let shared_secret = bytebuf.copy_to_bytes(shared_secret_length.0 as usize)?;
+        let verify_token_length = bytebuf.get_var_int()?;
+        let verify_token = bytebuf.copy_to_bytes(shared_secret_length.0 as usize)?;
         Ok(Self {
             shared_secret_length,
             shared_secret: shared_secret.to_vec(),

--- a/pumpkin-protocol/src/server/login/s_login_start.rs
+++ b/pumpkin-protocol/src/server/login/s_login_start.rs
@@ -14,8 +14,8 @@ pub struct SLoginStart {
 impl ServerPacket for SLoginStart {
     fn read(bytebuf: &mut ByteBuffer) -> Result<Self, DeserializerError> {
         Ok(Self {
-            name: bytebuf.get_string_len(16).unwrap(),
-            uuid: bytebuf.get_uuid(),
+            name: bytebuf.get_string_len(16)?,
+            uuid: bytebuf.get_uuid()?,
         })
     }
 }

--- a/pumpkin-protocol/src/server/login/s_plugin_response.rs
+++ b/pumpkin-protocol/src/server/login/s_plugin_response.rs
@@ -16,9 +16,9 @@ pub struct SLoginPluginResponse {
 impl ServerPacket for SLoginPluginResponse {
     fn read(bytebuf: &mut ByteBuffer) -> Result<Self, DeserializerError> {
         Ok(Self {
-            message_id: bytebuf.get_var_int(),
-            successful: bytebuf.get_bool(),
-            data: bytebuf.get_option(|v| v.get_slice()),
+            message_id: bytebuf.get_var_int()?,
+            successful: bytebuf.get_bool()?,
+            data: bytebuf.get_option(|v| Ok(v.get_slice()))?,
         })
     }
 }

--- a/pumpkin-protocol/src/server/play/s_chat_message.rs
+++ b/pumpkin-protocol/src/server/play/s_chat_message.rs
@@ -21,12 +21,12 @@ pub struct SChatMessage {
 impl ServerPacket for SChatMessage {
     fn read(bytebuf: &mut ByteBuffer) -> Result<Self, DeserializerError> {
         Ok(Self {
-            message: bytebuf.get_string().unwrap(),
-            timestamp: bytebuf.get_i64(),
-            salt: bytebuf.get_i64(),
-            signature: bytebuf.get_option(|v| v.copy_to_bytes(256)),
-            message_count: bytebuf.get_var_int(),
-            acknowledged: bytebuf.get_fixed_bitset(20),
+            message: bytebuf.get_string()?,
+            timestamp: bytebuf.get_i64()?,
+            salt: bytebuf.get_i64()?,
+            signature: bytebuf.get_option(|v| v.copy_to_bytes(256))?,
+            message_count: bytebuf.get_var_int()?,
+            acknowledged: bytebuf.get_fixed_bitset(20)?,
         })
     }
 }

--- a/pumpkin-protocol/src/server/play/s_interact.rs
+++ b/pumpkin-protocol/src/server/play/s_interact.rs
@@ -18,8 +18,8 @@ impl ServerPacket for SInteract {
     fn read(
         bytebuf: &mut crate::bytebuf::ByteBuffer,
     ) -> Result<Self, crate::bytebuf::DeserializerError> {
-        let entity_id = bytebuf.get_var_int();
-        let typ = bytebuf.get_var_int();
+        let entity_id = bytebuf.get_var_int()?;
+        let typ = bytebuf.get_var_int()?;
         let action = ActionType::from_i32(typ.0).ok_or(DeserializerError::Message(
             "invalid action type".to_string(),
         ))?;
@@ -27,13 +27,13 @@ impl ServerPacket for SInteract {
             ActionType::Interact => None,
             ActionType::Attack => None,
             ActionType::InteractAt => {
-                Some((bytebuf.get_f32(), bytebuf.get_f32(), bytebuf.get_f32()))
+                Some((bytebuf.get_f32()?, bytebuf.get_f32()?, bytebuf.get_f32()?))
             }
         };
         let hand = match action {
-            ActionType::Interact => Some(bytebuf.get_var_int()),
+            ActionType::Interact => Some(bytebuf.get_var_int()?),
             ActionType::Attack => None,
-            ActionType::InteractAt => Some(bytebuf.get_var_int()),
+            ActionType::InteractAt => Some(bytebuf.get_var_int()?),
         };
 
         Ok(Self {
@@ -41,7 +41,7 @@ impl ServerPacket for SInteract {
             typ,
             target_position,
             hand,
-            sneaking: bytebuf.get_bool(),
+            sneaking: bytebuf.get_bool()?,
         })
     }
 }

--- a/pumpkin-protocol/src/server/play/s_player_command.rs
+++ b/pumpkin-protocol/src/server/play/s_player_command.rs
@@ -25,9 +25,9 @@ pub enum Action {
 impl ServerPacket for SPlayerCommand {
     fn read(bytebuf: &mut crate::bytebuf::ByteBuffer) -> Result<Self, DeserializerError> {
         Ok(Self {
-            entity_id: bytebuf.get_var_int(),
-            action: bytebuf.get_var_int(),
-            jump_boost: bytebuf.get_var_int(),
+            entity_id: bytebuf.get_var_int()?,
+            action: bytebuf.get_var_int()?,
+            jump_boost: bytebuf.get_var_int()?,
         })
     }
 }

--- a/pumpkin/src/proxy/velocity.rs
+++ b/pumpkin/src/proxy/velocity.rs
@@ -52,7 +52,7 @@ pub fn receive_plugin_response(
         buf.put_slice(data_without_signature);
 
         // check velocity version
-        let version = buf.get_var_int();
+        let version = buf.get_var_int().unwrap();
         let version = version.0;
         if version > MAX_SUPPORTED_FORWARDING_VERSION {
             client.kick(&format!(


### PR DESCRIPTION
Got this error after leaving the server on a public ip:

```
thread 'main' panicked at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.7.1/src/bytes_mut.rs:394:9:
split_to out of bounds: 3 <= 2
stack backtrace:
   0: rust_begin_unwind
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/panicking.rs:72:14
   2: bytes::bytes_mut::BytesMut::split_to
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.7.1/src/bytes_mut.rs:394:9
   3: <bytes::bytes_mut::BytesMut as bytes::buf::buf_impl::Buf>::copy_to_bytes
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.7.1/src/bytes_mut.rs:1165:9
   4: pumpkin_protocol::bytebuf::ByteBuffer::get_string_len
             at ./pumpkin-protocol/src/bytebuf/mod.rs:87:20
   5: <pumpkin_protocol::server::handshake::SHandShake as pumpkin_protocol::ServerPacket>::read
             at ./pumpkin-protocol/src/server/handshake/mod.rs:20:29
   6: pumpkin::client::Client::handle_packet::{{closure}}
             at ./pumpkin/src/client/mod.rs:172:51
   7: pumpkin::client::Client::process_packets::{{closure}}
             at ./pumpkin/src/client/mod.rs:150:59
   8: pumpkin::main::{{closure}}
             at ./pumpkin/src/main.rs:186:69
   9: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/future/future.rs:123:9
  10: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/park.rs:281:63
  11: tokio::runtime::coop::with_budget
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/coop.rs:107:5
  12: tokio::runtime::coop::budget
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/coop.rs:73:5
  13: tokio::runtime::park::CachedParkThread::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/park.rs:281:31
  14: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context/blocking.rs:66:9
  15: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/multi_thread/mod.rs:87:13
  16: tokio::runtime::context::runtime::enter_runtime
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context/runtime.rs:65:16
  17: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/multi_thread/mod.rs:86:9
  18: tokio::runtime::runtime::Runtime::block_on_inner
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/runtime.rs:363:45
  19: tokio::runtime::runtime::Runtime::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/runtime.rs:333:13
  20: pumpkin::main
             at ./pumpkin/src/main.rs:58:5
  21: core::ops::function::FnOnce::call_once
             at /rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This PR hopes to prevent these panics in the case of bad packets, instead propagating errors up