### PR TITLE
Buffer check for varint decoding

### DIFF
--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -44,6 +44,9 @@ impl VarInt {
     pub fn decode_partial(r: &mut &[u8]) -> Result<i32, VarIntDecodeError> {
         let mut val = 0;
         for i in 0..Self::MAX_SIZE {
+            if !r.has_remaining() {
+                return Err(VarIntDecodeError::Incomplete);
+            }
             let byte = r.get_u8();
             val |= (i32::from(byte) & 0b01111111) << (i * 7);
             if byte & 0b10000000 == 0 {
@@ -71,6 +74,9 @@ impl VarInt {
     pub fn decode(r: &mut &[u8]) -> Result<Self, VarIntDecodeError> {
         let mut val = 0;
         for i in 0..Self::MAX_SIZE {
+            if !r.has_remaining() {
+                return Err(VarIntDecodeError::Incomplete);
+            }
             let byte = r.get_u8();
             val |= (i32::from(byte) & 0b01111111) << (i * 7);
             if byte & 0b10000000 == 0 {


### PR DESCRIPTION
My public facing server received another error:
```
thread 'main' panicked at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.7.1/src/lib.rs:138:5:
advance out of bounds: the len is 0 but advancing by 1
stack backtrace:
   0: rust_begin_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:74:14
   2: bytes::panic_advance
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.7.1/src/lib.rs:138:5
   3: bytes::buf::buf_impl::Buf::get_u8
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.7.1/src/buf/buf_impl.rs:304:13
   4: pumpkin_protocol::VarInt::decode
             at ./pumpkin-protocol/src/lib.rs:74:24
   5: pumpkin_protocol::packet_decoder::PacketDecoder::decode
             at ./pumpkin-protocol/src/packet_decoder.rs:88:25
   6: pumpkin::client::Client::poll::{{closure}}
             at ./pumpkin/src/client/mod.rs:297:23
   7: pumpkin::main::{{closure}}
             at ./pumpkin/src/main.rs:178:48
   8: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/future/future.rs:123:9
   9: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/park.rs:281:63
  10: tokio::runtime::coop::with_budget
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:107:5
  11: tokio::runtime::coop::budget
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/coop.rs:73:5
  12: tokio::runtime::park::CachedParkThread::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/park.rs:281:31
  13: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/blocking.rs:66:9
  14: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/mod.rs:87:13
  15: tokio::runtime::context::runtime::enter_runtime
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/context/runtime.rs:65:16
  16: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/scheduler/multi_thread/mod.rs:86:9
  17: tokio::runtime::runtime::Runtime::block_on_inner
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/runtime.rs:363:45
  18: tokio::runtime::runtime::Runtime::block_on
             at /home/minecraft/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.40.0/src/runtime/runtime.rs:333:13
  19: pumpkin::main
             at ./pumpkin/src/main.rs:57:5
  20: core::ops::function::FnOnce::call_once
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
This fix checks if there are bytes left to be read in the buffer before reading