### PR TITLE
Make a way to disable extism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ tokio = { version = "1.40", features = [
     "sync",
 ] }
 rayon = "1.10.0"
-uuid = { version = "1.10.0", features = ["serde", "v3"] }
+uuid = { version = "1.10.0", features = ["serde", "v3", "v4"] }
 derive_more = { version = "1.0.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/pumpkin-plugin/Cargo.toml
+++ b/pumpkin-plugin/Cargo.toml
@@ -3,7 +3,11 @@ name = "pumpkin-plugin"
 version.workspace = true
 edition.workspace = true
 
+[features]
+default = []
+plugins = ["dep:extism"]
+
 [dependencies]
 serde.workspace = true
 log.workspace = true
-extism = "1.6.0"
+extism = { version = "1.6.0", optional = true }

--- a/pumpkin-plugin/src/api/identifer.rs
+++ b/pumpkin-plugin/src/api/identifer.rs
@@ -1,15 +1,17 @@
+#[cfg(feature = "plugins")]
 use extism::{convert::Msgpack, host_fn, FromBytes, ToBytes};
-use serde::{Deserialize, Serialize};
 
 /// Used to keep track of things created by plugins.
 /// This can include things like events, commands, etc.
-#[derive(Hash, PartialEq, Eq, ToBytes, FromBytes, Serialize, Deserialize)]
+#[derive(Hash, PartialEq, Eq, ToBytes, FromBytes, serde::Serialize, serde::Deserialize)]
+#[cfg(feature = "plugins")]
 #[encoding(Msgpack)] // TODO: Switch to protocal buffers for smaller size
 struct Identifier {
     namespace: String,
     path: String,
 }
 
+#[cfg(feature = "plugins")]
 host_fn!(new(namespace: String, path: String) -> Result<Identifier, _> {
     Ok(Identifier { namespace, path })
 });

--- a/pumpkin-plugin/src/lib.rs
+++ b/pumpkin-plugin/src/lib.rs
@@ -1,51 +1,65 @@
 mod api;
 
-use std::path::Path;
-
+#[cfg(feature = "plugins")]
 use extism::{Manifest, Plugin, Wasm};
 
 pub const PLUGIN_DIR: &str = "plugins";
 
+pub struct PumpkinPlugin {
+    #[cfg(feature = "plugins")]
+    _plugin: Plugin,
+}
+
 pub struct PluginLoader {
-    plugins: Vec<Plugin>,
+    plugins: Vec<PumpkinPlugin>,
 }
 
 impl PluginLoader {
     pub fn load() -> Self {
-        let plugin_dir = Path::new(PLUGIN_DIR);
-        if !plugin_dir.exists() || !plugin_dir.is_dir() {
-            log::info!("Creating plugins dir...");
-            std::fs::create_dir(plugin_dir).expect("Failed to create Plugin dir");
-            return Self { plugins: vec![] };
-        }
-        let files = std::fs::read_dir(plugin_dir).expect("Failed to read plugin dir");
-        let mut plugins = Vec::new();
-        for file in files {
-            let file = file.expect("Failed to get Plugin file");
-            let path = file.path();
-            if path
-                .extension()
-                .expect("Failed to get Plugin file extension")
-                == "wasm"
-            {
-                log::info!(
-                    "Loading Plugin {:?}",
-                    path.file_name().expect("Failed to get Plugin file name")
-                );
-                let wasm = Wasm::file(path);
-                let manifest = Manifest::new([wasm]);
-                let mut plugin = Plugin::new(&manifest, [], true).unwrap();
-                plugin
-                    .call::<(), ()>("on_enable", ())
-                    .expect("Failed to call on_enable funcation");
-                plugins.push(plugin);
+        #[cfg(feature = "plugins")]
+        {
+            use std::path::Path;
+            let plugin_dir = Path::new(PLUGIN_DIR);
+            if !plugin_dir.exists() || !plugin_dir.is_dir() {
+                log::info!("Creating plugins dir...");
+                std::fs::create_dir(plugin_dir).expect("Failed to create Plugin dir");
+                return Self { plugins: vec![] };
             }
+            let files = std::fs::read_dir(plugin_dir).expect("Failed to read plugin dir");
+            let mut plugins = Vec::new();
+            for file in files {
+                let file = file.expect("Failed to get Plugin file");
+                let path = file.path();
+                if path
+                    .extension()
+                    .expect("Failed to get Plugin file extension")
+                    == "wasm"
+                {
+                    log::info!(
+                        "Loading Plugin {:?}",
+                        path.file_name().expect("Failed to get Plugin file name")
+                    );
+                    let wasm = Wasm::file(path);
+                    let manifest = Manifest::new([wasm]);
+                    let mut plugin = Plugin::new(&manifest, [], true).unwrap();
+                    plugin
+                        .call::<(), ()>("on_enable", ())
+                        .expect("Failed to call on_enable funcation");
+                    let pumpkin_plugin = PumpkinPlugin { _plugin: plugin };
+                    plugins.push(pumpkin_plugin);
+                }
+            }
+
+            Self { plugins }
         }
 
-        Self { plugins }
+        #[cfg(not(feature = "plugins"))]
+        Self {
+            plugins: Vec::new(),
+        }
     }
 
-    pub fn plugins(&mut self) -> &mut Vec<Plugin> {
+    pub fn plugins(&mut self) -> &mut Vec<PumpkinPlugin> {
         &mut self.plugins
     }
 }

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -5,7 +5,8 @@ description = "Empowering everyone to host fast and efficient Minecraft servers.
 edition = "2021"
 
 [features]
-default = []
+default = ["plugins"]
+plugins = ["pumpkin-plugin/plugins"]
 
 [dependencies]
 # pumpkin


### PR DESCRIPTION
- Made a `plugins` feature in `pumpkin-plugin`
- Made a `plugins` feature in `pumpkin`, which enables the `plugins` feature in `pumpkin-plugin`
- Made the feature default

To run the project without plugins, use `cargo run --no-default-features`