### PR TITLE
Cleanup Server struct

### DIFF
--- a/pumpkin-inventory/src/open_container.rs
+++ b/pumpkin-inventory/src/open_container.rs
@@ -1,14 +1,14 @@
 use crate::{Container, WindowType};
 use pumpkin_world::item::ItemStack;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 pub struct OpenContainer {
     players: Vec<i32>,
-    container: Mutex<Box<dyn Container>>,
+    container: Arc<Mutex<Box<dyn Container>>>,
 }
 
 impl OpenContainer {
-    pub fn try_open(&self, player_id: i32) -> Option<&Mutex<Box<dyn Container>>> {
+    pub fn try_open(&self, player_id: i32) -> Option<&Arc<Mutex<Box<dyn Container>>>> {
         if !self.players.contains(&player_id) {
             dbg!("couldn't open container");
             return None;
@@ -38,7 +38,7 @@ impl OpenContainer {
     pub fn empty(player_id: i32) -> Self {
         Self {
             players: vec![player_id],
-            container: Mutex::new(Box::new(Chest::new())),
+            container: Arc::new(Mutex::new(Box::new(Chest::new()))),
         }
     }
 

--- a/pumpkin/src/client/authentication.rs
+++ b/pumpkin/src/client/authentication.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::IpAddr};
+use std::{collections::HashMap, net::IpAddr, sync::Arc};
 
 use base64::{engine::general_purpose, Engine};
 use num_bigint::BigInt;
@@ -13,13 +13,13 @@ use uuid::Uuid;
 use crate::server::Server;
 
 #[derive(Deserialize, Clone, Debug)]
-#[expect(non_snake_case)]
 #[expect(dead_code)]
+#[serde(rename_all = "camelCase")]
 pub struct ProfileTextures {
     timestamp: i64,
-    profileId: Uuid,
-    profileName: String,
-    signatureRequired: bool,
+    profile_id: Uuid,
+    profile_name: String,
+    signature_required: bool,
     textures: HashMap<String, Texture>,
 }
 
@@ -43,7 +43,7 @@ pub async fn authenticate(
     username: &str,
     server_hash: &str,
     ip: &IpAddr,
-    server: &mut Server,
+    server: &Arc<Server>,
 ) -> Result<GameProfile, AuthError> {
     assert!(ADVANCED_CONFIG.authentication.enabled);
     assert!(server.auth_client.is_some());

--- a/pumpkin/src/client/container.rs
+++ b/pumpkin/src/client/container.rs
@@ -19,11 +19,12 @@ use pumpkin_world::item::ItemStack;
 use std::sync::{Arc, Mutex};
 
 impl Player {
-    pub fn open_container(&mut self, server: &mut Server, minecraft_menu_id: &str) {
+    pub fn open_container(&mut self, server: &Arc<Server>, minecraft_menu_id: &str) {
         self.inventory.state_id = 0;
         let total_opened_containers = self.inventory.total_opened_containers;
-        let mut container = self
-            .get_open_container(server)
+        let container = self.get_open_container(server);
+        let mut container = container
+            .as_ref()
             .map(|container| container.lock().unwrap());
         let menu_protocol_id = (*pumpkin_world::global_registry::REGISTRY
             .get("minecraft:menu")
@@ -97,11 +98,12 @@ impl Player {
 
     pub async fn handle_click_container(
         &mut self,
-        server: &mut Server,
+        server: &Arc<Server>,
         packet: SClickContainer,
     ) -> Result<(), InventoryError> {
-        let mut opened_container = self
-            .get_open_container(server)
+        let opened_container = self.get_open_container(server);
+        let mut opened_container = opened_container
+            .as_ref()
             .map(|container| container.lock().unwrap());
         let drag_handler = &server.drag_handler;
 
@@ -165,7 +167,10 @@ impl Player {
                 }
                 self.mouse_drag(drag_handler, opened_container.as_deref_mut(), drag_state)
             }
-            ClickType::DropType(_drop_type) => {dbg!("todo"); Ok(())},
+            ClickType::DropType(_drop_type) => {
+                dbg!("todo");
+                Ok(())
+            }
         }?;
         if let Some(mut opened_container) = opened_container {
             if update_whole_container {
@@ -355,14 +360,19 @@ impl Player {
         &mut self,
         server: &Server,
     ) -> Vec<Arc<Mutex<Player>>> {
-        let player_ids = server
-            .open_containers
-            .get(&self.open_container.unwrap())
-            .unwrap()
-            .all_player_ids()
-            .into_iter()
-            .filter(|player_id| *player_id != self.entity_id())
-            .collect_vec();
+        let player_ids = {
+            let open_containers = server
+                .open_containers
+                .read()
+                .expect("open_containers is poisoned");
+            open_containers
+                .get(&self.open_container.unwrap())
+                .unwrap()
+                .all_player_ids()
+                .into_iter()
+                .filter(|player_id| *player_id != self.entity_id())
+                .collect_vec()
+        };
         let player_token = self.client.token;
 
         // TODO: Figure out better way to get only the players from player_ids
@@ -415,19 +425,14 @@ impl Player {
 
         for player in players {
             let mut player = player.lock().unwrap();
-            let mut container = player
-                .get_open_container(server)
-                .map(|container| container.lock().unwrap());
+            let container = player.get_open_container(server);
+            let mut container = container.as_ref().map(|v| v.lock().unwrap());
             player.set_container_content(container.as_deref_mut());
-            drop(container)
         }
         Ok(())
     }
 
-    pub fn get_open_container<'a>(
-        &self,
-        server: &'a Server,
-    ) -> Option<&'a Mutex<Box<dyn Container>>> {
+    pub fn get_open_container(&self, server: &Server) -> Option<Arc<Mutex<Box<dyn Container>>>> {
         if let Some(id) = self.open_container {
             server.try_get_container(self.entity_id(), id)
         } else {

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     io::{self, Write},
     net::SocketAddr,
+    sync::Arc,
 };
 
 use crate::{
@@ -148,7 +149,7 @@ impl Client {
         Ok(())
     }
 
-    pub async fn process_packets(&mut self, server: &mut Server) {
+    pub async fn process_packets(&mut self, server: &Arc<Server>) {
         while let Some(mut packet) = self.client_packets_queue.pop() {
             match self.handle_packet(server, &mut packet).await {
                 Ok(_) => {}
@@ -164,7 +165,7 @@ impl Client {
     /// Handles an incoming decoded not Play state Packet
     pub async fn handle_packet(
         &mut self,
-        server: &mut Server,
+        server: &Arc<Server>,
         packet: &mut RawPacket,
     ) -> Result<(), DeserializerError> {
         // TODO: handle each packet's Error instead of calling .unwrap()

--- a/pumpkin/src/commands/cmd_echest.rs
+++ b/pumpkin/src/commands/cmd_echest.rs
@@ -12,13 +12,19 @@ pub(crate) fn init_command_tree<'a>() -> CommandTree<'a> {
         if let Some(player) = sender.as_mut_player() {
             let entity_id = player.entity_id();
             player.open_container = Some(0);
-            match server.open_containers.get_mut(&0) {
-                Some(ender_chest) => {
-                    ender_chest.add_player(entity_id);
-                }
-                None => {
-                    let open_container = OpenContainer::empty(entity_id);
-                    server.open_containers.insert(0, open_container);
+            {
+                let mut open_containers = server
+                    .open_containers
+                    .write()
+                    .expect("open_containers got poisoned");
+                match open_containers.get_mut(&0) {
+                    Some(ender_chest) => {
+                        ender_chest.add_player(entity_id);
+                    }
+                    None => {
+                        let open_container = OpenContainer::empty(entity_id);
+                        open_containers.insert(0, open_container);
+                    }
                 }
             }
             player.open_container(server, "minecraft:generic_9x3");

--- a/pumpkin/src/commands/dispatcher.rs
+++ b/pumpkin/src/commands/dispatcher.rs
@@ -7,6 +7,7 @@ use crate::commands::tree::{Command, CommandTree, ConsumedArgs, NodeType, RawArg
 use crate::commands::CommandSender;
 use crate::server::Server;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub(crate) enum InvalidTreeError {
@@ -26,7 +27,7 @@ pub struct CommandDispatcher<'a> {
 
 /// Stores registered [CommandTree]s and dispatches commands to them.
 impl<'a> CommandDispatcher<'a> {
-    pub fn handle_command(&self, sender: &mut CommandSender, server: &mut Server, cmd: &str) {
+    pub fn handle_command(&self, sender: &mut CommandSender, server: &Arc<Server>, cmd: &str) {
         if let Err(err) = self.dispatch(sender, server, cmd) {
             sender.send_message(
                 TextComponent::text(&err).color_named(pumpkin_core::text::color::NamedColor::Red),
@@ -38,7 +39,7 @@ impl<'a> CommandDispatcher<'a> {
     pub(crate) fn dispatch(
         &'a self,
         src: &mut CommandSender,
-        server: &mut Server,
+        server: &Arc<Server>,
         cmd: &str,
     ) -> Result<(), String> {
         let mut parts = cmd.split_ascii_whitespace();
@@ -86,7 +87,7 @@ impl<'a> CommandDispatcher<'a> {
 
     fn try_is_fitting_path(
         src: &mut CommandSender,
-        server: &mut Server,
+        server: &Arc<Server>,
         path: Vec<usize>,
         tree: &CommandTree,
         mut raw_args: RawArgs,

--- a/pumpkin/src/commands/mod.rs
+++ b/pumpkin/src/commands/mod.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+
+use dispatcher::InvalidTreeError;
 use pumpkin_core::text::TextComponent;
+use tree::ConsumedArgs;
 
 use crate::commands::dispatcher::CommandDispatcher;
 use crate::entity::player::Player;
+use crate::server::Server;
 mod arg_player;
 mod cmd_echest;
 mod cmd_gamemode;
@@ -73,3 +78,6 @@ pub fn default_dispatcher<'a>() -> CommandDispatcher<'a> {
 
     dispatcher
 }
+
+type RunFunctionType = (dyn Fn(&mut CommandSender, &Arc<Server>, &ConsumedArgs) -> Result<(), InvalidTreeError>
+     + Sync);

--- a/pumpkin/src/commands/tree.rs
+++ b/pumpkin/src/commands/tree.rs
@@ -1,8 +1,6 @@
-use std::collections::{HashMap, VecDeque};
-
-use crate::commands::dispatcher::InvalidTreeError;
+use super::RunFunctionType;
 use crate::commands::CommandSender;
-use crate::server::Server;
+use std::collections::{HashMap, VecDeque};
 
 /// see [crate::commands::tree_builder::argument]
 pub(crate) type RawArgs<'a> = Vec<&'a str>;
@@ -20,8 +18,7 @@ pub(crate) struct Node<'a> {
 
 pub(crate) enum NodeType<'a> {
     ExecuteLeaf {
-        run: &'a (dyn Fn(&mut CommandSender, &mut Server, &ConsumedArgs) -> Result<(), InvalidTreeError>
-                 + Sync),
+        run: &'a RunFunctionType,
     },
     Literal {
         string: &'a str,

--- a/pumpkin/src/commands/tree_builder.rs
+++ b/pumpkin/src/commands/tree_builder.rs
@@ -1,7 +1,7 @@
-use crate::commands::dispatcher::InvalidTreeError;
-use crate::commands::tree::{ArgumentConsumer, CommandTree, ConsumedArgs, Node, NodeType};
+use crate::commands::tree::{ArgumentConsumer, CommandTree, Node, NodeType};
 use crate::commands::CommandSender;
-use crate::server::Server;
+
+use super::RunFunctionType;
 
 impl<'a> CommandTree<'a> {
     /// Add a child [Node] to the root of this [CommandTree].
@@ -40,11 +40,7 @@ impl<'a> CommandTree<'a> {
     /// desired type.
     ///
     /// Also see [NonLeafNodeBuilder::execute].
-    pub fn execute(
-        mut self,
-        run: &'a (dyn Fn(&mut CommandSender, &mut Server, &ConsumedArgs) -> Result<(), InvalidTreeError>
-                 + Sync),
-    ) -> Self {
+    pub fn execute(mut self, run: &'a RunFunctionType) -> Self {
         let node = Node {
             node_type: NodeType::ExecuteLeaf { run },
             children: Vec::new(),
@@ -117,11 +113,7 @@ impl<'a> NonLeafNodeBuilder<'a> {
     /// desired type.
     ///
     /// Also see [CommandTree::execute].
-    pub fn execute(
-        mut self,
-        run: &'a (dyn Fn(&mut CommandSender, &mut Server, &ConsumedArgs) -> Result<(), InvalidTreeError>
-                 + Sync),
-    ) -> Self {
+    pub fn execute(mut self, run: &'a RunFunctionType) -> Self {
         self.leaf_nodes.push(LeafNodeBuilder {
             node_type: NodeType::ExecuteLeaf { run },
         });

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -263,7 +263,7 @@ impl Player {
 }
 
 impl Player {
-    pub async fn process_packets(&mut self, server: &mut Server) {
+    pub async fn process_packets(&mut self, server: &Arc<Server>) {
         while let Some(mut packet) = self.client.client_packets_queue.pop() {
             match self.handle_play_packet(server, &mut packet).await {
                 Ok(_) => {}
@@ -278,7 +278,7 @@ impl Player {
 
     pub async fn handle_play_packet(
         &mut self,
-        server: &mut Server,
+        server: &Arc<Server>,
         packet: &mut RawPacket,
     ) -> Result<(), DeserializerError> {
         let bytebuf = &mut packet.bytebuf;


### PR DESCRIPTION
This cleanup's goal is to make all `Server` functions only require &self. This means that `Server` can now be a `Arc<Server>` instead of `Arc<Mutex<Server>>`, which solves a lot of deadlock problems.