### PR TITLE
Improved synchronization primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +571,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1410,6 +1441,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1713,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1922,7 @@ version = "0.1.0-dev"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "crossbeam",
  "ctrlc",
  "digest 0.11.0-pre.9",
  "hmac",
@@ -1868,6 +1933,7 @@ dependencies = [
  "num-bigint",
  "num-derive",
  "num-traits",
+ "parking_lot",
  "pumpkin-config",
  "pumpkin-core",
  "pumpkin-entity",
@@ -1922,9 +1988,11 @@ version = "0.1.0"
 name = "pumpkin-inventory"
 version = "0.1.0"
 dependencies = [
+ "crossbeam",
  "itertools 0.13.0",
  "num-derive",
  "num-traits",
+ "parking_lot",
  "pumpkin-world",
  "thiserror",
 ]
@@ -1991,6 +2059,7 @@ dependencies = [
  "noise",
  "num-derive",
  "num-traits",
+ "parking_lot",
  "pumpkin-core",
  "rand",
  "rayon",
@@ -2115,6 +2184,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2375,6 +2453,12 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,12 @@ tokio = { version = "1.40", features = [
     "io-util",
     "sync",
 ] }
+
+# Concurrency/Parallelism and Synchronization
 rayon = "1.10.0"
+parking_lot = "0.12.3"
+crossbeam = "0.8.4"
+
 uuid = { version = "1.10.0", features = ["serde", "v3", "v4"] }
 derive_more = { version = "1.0.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/pumpkin-core/src/math/position.rs
+++ b/pumpkin-core/src/math/position.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::vector3::Vector3;
 
+#[derive(Clone, Copy)]
 /// Aka Block Position
 pub struct WorldPosition(pub Vector3<i32>);
 

--- a/pumpkin-core/src/math/vector3.rs
+++ b/pumpkin-core/src/math/vector3.rs
@@ -93,7 +93,6 @@ impl<T: Math + Copy> Neg for Vector3<T> {
 }
 
 impl<T> From<(T, T, T)> for Vector3<T> {
-    
     #[inline(always)]
     fn from((x, y, z): (T, T, T)) -> Self {
         Vector3 { x, y, z }
@@ -101,7 +100,6 @@ impl<T> From<(T, T, T)> for Vector3<T> {
 }
 
 impl<T> From<Vector3<T>> for (T, T, T) {
-    
     #[inline(always)]
     fn from(vector: Vector3<T>) -> Self {
         (vector.x, vector.y, vector.z)

--- a/pumpkin-core/src/math/vector3.rs
+++ b/pumpkin-core/src/math/vector3.rs
@@ -93,12 +93,16 @@ impl<T: Math + Copy> Neg for Vector3<T> {
 }
 
 impl<T> From<(T, T, T)> for Vector3<T> {
+    
+    #[inline(always)]
     fn from((x, y, z): (T, T, T)) -> Self {
         Vector3 { x, y, z }
     }
 }
 
 impl<T> From<Vector3<T>> for (T, T, T) {
+    
+    #[inline(always)]
     fn from(vector: Vector3<T>) -> Self {
         (vector.x, vector.y, vector.z)
     }

--- a/pumpkin-inventory/Cargo.toml
+++ b/pumpkin-inventory/Cargo.toml
@@ -11,3 +11,5 @@ num-traits = "0.2"
 num-derive = "0.4"
 thiserror = "1.0.63"
 itertools = "0.13.0"
+parking_lot.workspace = true
+crossbeam.workspace = true

--- a/pumpkin-inventory/src/lib.rs
+++ b/pumpkin-inventory/src/lib.rs
@@ -1,6 +1,5 @@
 use crate::container_click::MouseClick;
 use crate::player::PlayerInventory;
-use crossbeam::atomic::AtomicCell;
 use num_derive::{FromPrimitive, ToPrimitive};
 use pumpkin_world::item::ItemStack;
 

--- a/pumpkin-inventory/src/lib.rs
+++ b/pumpkin-inventory/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::container_click::MouseClick;
 use crate::player::PlayerInventory;
+use crossbeam::atomic::AtomicCell;
 use num_derive::{FromPrimitive, ToPrimitive};
 use pumpkin_world::item::ItemStack;
 

--- a/pumpkin-inventory/src/open_container.rs
+++ b/pumpkin-inventory/src/open_container.rs
@@ -1,6 +1,7 @@
 use crate::{Container, WindowType};
 use pumpkin_world::item::ItemStack;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 
 pub struct OpenContainer {
     players: Vec<i32>,

--- a/pumpkin-inventory/src/open_container.rs
+++ b/pumpkin-inventory/src/open_container.rs
@@ -1,7 +1,7 @@
 use crate::{Container, WindowType};
+use parking_lot::Mutex;
 use pumpkin_world::item::ItemStack;
 use std::sync::Arc;
-use parking_lot::Mutex;
 
 pub struct OpenContainer {
     players: Vec<i32>,

--- a/pumpkin-inventory/src/player.rs
+++ b/pumpkin-inventory/src/player.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::AtomicU32;
 
 use crate::container_click::MouseClick;
 use crate::{handle_item_change, Container, InventoryError, WindowType};
-use crossbeam::atomic::AtomicCell;
 use pumpkin_world::item::ItemStack;
 
 pub struct PlayerInventory {

--- a/pumpkin-inventory/src/player.rs
+++ b/pumpkin-inventory/src/player.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::AtomicU32;
 
 use crate::container_click::MouseClick;
 use crate::{handle_item_change, Container, InventoryError, WindowType};
+use crossbeam::atomic::AtomicCell;
 use pumpkin_world::item::ItemStack;
 
 pub struct PlayerInventory {

--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -151,7 +151,7 @@ pub enum PacketError {
     MalformedLength,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ConnectionState {
     HandShake,
     Status,

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -19,6 +19,8 @@ serde_json = "1.0"
 static_assertions = "1.1.0"
 log.workspace = true
 
+parking_lot.workspace = true
+
 noise = "0.9.0"
 
 rand = "0.8.5"

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -186,7 +186,6 @@ impl Level {
                 .blocking_send(Ok(data.clone()))
                 .expect("Failed sending ChunkData.");
             loaded_chunks.insert(at, data);
-            
         })
     }
 

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -62,6 +62,8 @@ log.workspace = true
 # networking
 mio = { version = "1.0.2", features = ["os-poll", "net"]}
 
+parking_lot.workspace = true
+crossbeam.workspace = true
 uuid.workspace = true
 tokio.workspace = true
 rayon.workspace = true

--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -238,7 +238,7 @@ impl Client {
         _server: &Arc<Server>,
         client_information: SClientInformationConfig,
     ) {
-        dbg!("got client settings"); 
+        dbg!("got client settings");
         *self.config.lock() = Some(PlayerConfig {
             locale: client_information.locale,
             view_distance: client_information.view_distance,

--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -42,10 +42,9 @@ impl Client {
         let version = handshake.protocol_version.0;
         self.protocol_version
             .store(version, std::sync::atomic::Ordering::Relaxed);
-        let mut connection_state = self.connection_state.lock().unwrap();
 
-        *connection_state = handshake.next_state;
-        if *connection_state != ConnectionState::Status {
+        self.connection_state.store(handshake.next_state);
+        if self.connection_state.load() != ConnectionState::Status {
             let protocol = version;
             match protocol.cmp(&(CURRENT_MC_PROTOCOL as i32)) {
                 std::cmp::Ordering::Less => {
@@ -85,7 +84,7 @@ impl Client {
         }
         // default game profile, when no online mode
         // TODO: make offline uuid
-        let mut gameprofile = self.gameprofile.lock().unwrap();
+        let mut gameprofile = self.gameprofile.lock();
         *gameprofile = Some(GameProfile {
             id: login_start.uuid,
             name: login_start.name,
@@ -125,7 +124,7 @@ impl Client {
         self.enable_encryption(&shared_secret)
             .unwrap_or_else(|e| self.kick(&e.to_string()));
 
-        let mut gameprofile = self.gameprofile.lock().unwrap();
+        let mut gameprofile = self.gameprofile.lock();
 
         if BASIC_CONFIG.online_mode {
             let hash = Sha1::new()
@@ -133,7 +132,7 @@ impl Client {
                 .chain_update(&server.public_key_der)
                 .finalize();
             let hash = auth_digest(&hash);
-            let ip = self.address.lock().unwrap().ip();
+            let ip = self.address.lock().ip();
             match authentication::authenticate(
                 &gameprofile.as_ref().unwrap().name,
                 &hash,
@@ -204,7 +203,7 @@ impl Client {
         server: &Arc<Server>,
         _login_acknowledged: SLoginAcknowledged,
     ) {
-        *self.connection_state.lock().unwrap() = ConnectionState::Config;
+        self.connection_state.store(ConnectionState::Config);
         server.send_brand(self);
 
         let resource_config = &ADVANCED_CONFIG.resource_pack;
@@ -239,8 +238,8 @@ impl Client {
         _server: &Arc<Server>,
         client_information: SClientInformationConfig,
     ) {
-        dbg!("got client settings");
-        *self.config.lock().unwrap() = Some(PlayerConfig {
+        dbg!("got client settings"); 
+        *self.config.lock() = Some(PlayerConfig {
             locale: client_information.locale,
             view_distance: client_information.view_distance,
             chat_mode: ChatMode::from_i32(client_information.chat_mode.into()).unwrap(),
@@ -258,7 +257,7 @@ impl Client {
         {
             dbg!("got a client brand");
             match String::from_utf8(plugin_message.data) {
-                Ok(brand) => *self.brand.lock().unwrap() = Some(brand),
+                Ok(brand) => *self.brand.lock() = Some(brand),
                 Err(e) => self.kick(&e.to_string()),
             }
         }
@@ -283,7 +282,7 @@ impl Client {
         _config_acknowledged: SAcknowledgeFinishConfig,
     ) {
         dbg!("config acknowledged");
-        *self.connection_state.lock().unwrap() = ConnectionState::Play;
+        self.connection_state.store(ConnectionState::Play);
         self.make_player
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }

--- a/pumpkin/src/client/container.rs
+++ b/pumpkin/src/client/container.rs
@@ -27,9 +27,7 @@ impl Player {
             .store(0, std::sync::atomic::Ordering::Relaxed);
         let total_opened_containers = inventory.total_opened_containers;
         let container = self.get_open_container(server);
-        let mut container = container
-            .as_ref()
-            .map(|container| container.lock());
+        let mut container = container.as_ref().map(|container| container.lock());
         let menu_protocol_id = (*pumpkin_world::global_registry::REGISTRY
             .get("minecraft:menu")
             .unwrap()
@@ -112,9 +110,7 @@ impl Player {
         packet: SClickContainer,
     ) -> Result<(), InventoryError> {
         let opened_container = self.get_open_container(server);
-        let mut opened_container = opened_container
-            .as_ref()
-            .map(|container| container.lock());
+        let mut opened_container = opened_container.as_ref().map(|container| container.lock());
         let drag_handler = &server.drag_handler;
 
         let state_id = self
@@ -217,14 +213,10 @@ impl Player {
         match slot {
             container_click::Slot::Normal(slot) => {
                 let mut carried_item = self.carried_item.load();
-                let res = container.handle_item_change(
-                    &mut carried_item,
-                    slot,
-                    mouse_click,
-                );
+                let res = container.handle_item_change(&mut carried_item, slot, mouse_click);
                 self.carried_item.store(carried_item);
                 res
-            },
+            }
             container_click::Slot::OutsideInventory => Ok(()),
         }
     }
@@ -362,8 +354,7 @@ impl Player {
             .unwrap_or(player_id as u64);
         match mouse_drag_state {
             MouseDragState::Start(drag_type) => {
-                if drag_type == MouseDragType::Middle
-                    && self.gamemode.load() != GameMode::Creative
+                if drag_type == MouseDragType::Middle && self.gamemode.load() != GameMode::Creative
                 {
                     Err(InventoryError::PermissionError)?
                 }
@@ -389,9 +380,7 @@ impl Player {
 
     async fn get_current_players_in_container(&self, server: &Server) -> Vec<Arc<Player>> {
         let player_ids = {
-            let open_containers = server
-                .open_containers
-                .read();
+            let open_containers = server.open_containers.read();
             open_containers
                 .get(&self.open_container.load().unwrap())
                 .unwrap()

--- a/pumpkin/src/client/container.rs
+++ b/pumpkin/src/client/container.rs
@@ -1,6 +1,7 @@
 use crate::entity::player::Player;
 use crate::server::Server;
 use itertools::Itertools;
+use parking_lot::Mutex;
 use pumpkin_core::text::TextComponent;
 use pumpkin_core::GameMode;
 use pumpkin_inventory::container_click::{
@@ -16,11 +17,11 @@ use pumpkin_protocol::client::play::{
 use pumpkin_protocol::server::play::SClickContainer;
 use pumpkin_protocol::slot::Slot;
 use pumpkin_world::item::ItemStack;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 impl Player {
     pub fn open_container(&self, server: &Arc<Server>, minecraft_menu_id: &str) {
-        let inventory = self.inventory.lock().unwrap();
+        let inventory = self.inventory.lock();
         inventory
             .state_id
             .store(0, std::sync::atomic::Ordering::Relaxed);
@@ -28,7 +29,7 @@ impl Player {
         let container = self.get_open_container(server);
         let mut container = container
             .as_ref()
-            .map(|container| container.lock().unwrap());
+            .map(|container| container.lock());
         let menu_protocol_id = (*pumpkin_world::global_registry::REGISTRY
             .get("minecraft:menu")
             .unwrap()
@@ -54,7 +55,7 @@ impl Player {
     }
 
     pub fn set_container_content(&self, container: Option<&mut Box<dyn Container>>) {
-        let mut inventory = self.inventory.lock().unwrap();
+        let mut inventory = self.inventory.lock();
 
         let total_opened_containers = inventory.total_opened_containers;
         let container = OptionallyCombinedContainer::new(&mut inventory, container);
@@ -66,7 +67,7 @@ impl Player {
             .collect_vec();
 
         let carried_item = {
-            if let Some(item) = self.carried_item.lock().unwrap().as_ref() {
+            if let Some(item) = self.carried_item.load().as_ref() {
                 item.into()
             } else {
                 Slot::empty()
@@ -87,7 +88,7 @@ impl Player {
 
     /// The official Minecraft client is weird, and will always just close *any* window that is opened when this gets sent
     pub fn close_container(&self) {
-        let mut inventory = self.inventory.lock().unwrap();
+        let mut inventory = self.inventory.lock();
         inventory.total_opened_containers += 1;
         self.client
             .send_packet(&CCloseContainer::new(inventory.total_opened_containers))
@@ -99,7 +100,7 @@ impl Player {
     ) {
         let (id, value) = window_property.into_tuple();
         self.client.send_packet(&CSetContainerProperty::new(
-            self.inventory.lock().unwrap().total_opened_containers,
+            self.inventory.lock().total_opened_containers,
             id,
             value,
         ));
@@ -113,13 +114,12 @@ impl Player {
         let opened_container = self.get_open_container(server);
         let mut opened_container = opened_container
             .as_ref()
-            .map(|container| container.lock().unwrap());
+            .map(|container| container.lock());
         let drag_handler = &server.drag_handler;
 
         let state_id = self
             .inventory
             .lock()
-            .unwrap()
             .state_id
             .load(std::sync::atomic::Ordering::Relaxed);
         // This is just checking for regular desync, client hasn't done anything malicious
@@ -129,7 +129,7 @@ impl Player {
         }
 
         if opened_container.is_some() {
-            if packet.window_id != self.inventory.lock().unwrap().total_opened_containers {
+            if packet.window_id != self.inventory.lock().total_opened_containers {
                 return Err(InventoryError::ClosedContainerInteract(self.entity_id()));
             }
         } else if packet.window_id != 0 {
@@ -191,7 +191,7 @@ impl Player {
                 drop(opened_container);
                 self.send_whole_container_change(server).await?;
             } else if let container_click::Slot::Normal(slot_index) = click.slot {
-                let mut inventory = self.inventory.lock().unwrap();
+                let mut inventory = self.inventory.lock();
                 let combined_container =
                     OptionallyCombinedContainer::new(&mut inventory, Some(&mut opened_container));
                 if let Some(slot) = combined_container.get_slot_excluding_inventory(slot_index) {
@@ -211,15 +211,20 @@ impl Player {
         mouse_click: MouseClick,
         slot: container_click::Slot,
     ) -> Result<(), InventoryError> {
-        let mut inventory = self.inventory.lock().unwrap();
+        let mut inventory = self.inventory.lock();
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
 
         match slot {
-            container_click::Slot::Normal(slot) => container.handle_item_change(
-                &mut self.carried_item.lock().unwrap(),
-                slot,
-                mouse_click,
-            ),
+            container_click::Slot::Normal(slot) => {
+                let mut carried_item = self.carried_item.load();
+                let res = container.handle_item_change(
+                    &mut carried_item,
+                    slot,
+                    mouse_click,
+                );
+                self.carried_item.store(carried_item);
+                res
+            },
             container_click::Slot::OutsideInventory => Ok(()),
         }
     }
@@ -229,7 +234,7 @@ impl Player {
         opened_container: Option<&mut Box<dyn Container>>,
         slot: container_click::Slot,
     ) -> Result<(), InventoryError> {
-        let mut inventory = self.inventory.lock().unwrap();
+        let mut inventory = self.inventory.lock();
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
 
         match slot {
@@ -281,7 +286,7 @@ impl Player {
             KeyClick::Slot(slot) => slot,
             KeyClick::Offhand => 45,
         };
-        let mut inventory = self.inventory.lock().unwrap();
+        let mut inventory = self.inventory.lock();
         let mut changing_item_slot = inventory.get_slot(changing_slot as usize)?.to_owned();
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
 
@@ -295,13 +300,13 @@ impl Player {
         opened_container: Option<&mut Box<dyn Container>>,
         slot: usize,
     ) -> Result<(), InventoryError> {
-        if *self.gamemode.lock().unwrap() != GameMode::Creative {
+        if self.gamemode.load() != GameMode::Creative {
             return Err(InventoryError::PermissionError);
         }
-        let mut inventory = self.inventory.lock().unwrap();
+        let mut inventory = self.inventory.lock();
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
         if let Some(Some(item)) = container.all_slots().get_mut(slot) {
-            *self.carried_item.lock().unwrap() = Some(item.to_owned())
+            self.carried_item.store(Some(item.to_owned()));
         }
         Ok(())
     }
@@ -311,7 +316,7 @@ impl Player {
         opened_container: Option<&mut Box<dyn Container>>,
         slot: usize,
     ) -> Result<(), InventoryError> {
-        let mut inventory = self.inventory.lock().unwrap();
+        let mut inventory = self.inventory.lock();
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
         let mut slots = container.all_slots();
 
@@ -340,7 +345,7 @@ impl Player {
                 }
             }
         }
-        *self.carried_item.lock().unwrap() = Some(carried_item);
+        self.carried_item.store(Some(carried_item));
         Ok(())
     }
 
@@ -358,7 +363,7 @@ impl Player {
         match mouse_drag_state {
             MouseDragState::Start(drag_type) => {
                 if drag_type == MouseDragType::Middle
-                    && *self.gamemode.lock().unwrap() != GameMode::Creative
+                    && self.gamemode.load() != GameMode::Creative
                 {
                     Err(InventoryError::PermissionError)?
                 }
@@ -366,15 +371,18 @@ impl Player {
             }
             MouseDragState::AddSlot(slot) => drag_handler.add_slot(container_id, player_id, slot),
             MouseDragState::End => {
-                let mut inventory = self.inventory.lock().unwrap();
+                let mut inventory = self.inventory.lock();
                 let mut container =
                     OptionallyCombinedContainer::new(&mut inventory, opened_container);
-                drag_handler.apply_drag(
-                    &mut self.carried_item.lock().unwrap(),
+                let mut carried_item = self.carried_item.load();
+                let res = drag_handler.apply_drag(
+                    &mut carried_item,
                     &mut container,
                     &container_id,
                     player_id,
-                )
+                );
+                self.carried_item.store(carried_item);
+                res
             }
         }
     }
@@ -383,10 +391,9 @@ impl Player {
         let player_ids = {
             let open_containers = server
                 .open_containers
-                .read()
-                .expect("open_containers is poisoned");
+                .read();
             open_containers
-                .get(&self.open_container.lock().unwrap().unwrap())
+                .get(&self.open_container.load().unwrap())
                 .unwrap()
                 .all_player_ids()
                 .into_iter()
@@ -403,7 +410,6 @@ impl Player {
             .world
             .current_players
             .lock()
-            .unwrap()
             .iter()
             .filter_map(|(token, player)| {
                 if *token != player_token {
@@ -428,7 +434,7 @@ impl Player {
         slot: Slot,
     ) -> Result<(), InventoryError> {
         for player in self.get_current_players_in_container(server).await {
-            let inventory = player.inventory.lock().unwrap();
+            let inventory = player.inventory.lock();
             let total_opened_containers = inventory.total_opened_containers;
 
             // Returns previous value
@@ -451,14 +457,14 @@ impl Player {
 
         for player in players {
             let container = player.get_open_container(server);
-            let mut container = container.as_ref().map(|v| v.lock().unwrap());
+            let mut container = container.as_ref().map(|v| v.lock());
             player.set_container_content(container.as_deref_mut());
         }
         Ok(())
     }
 
     pub fn get_open_container(&self, server: &Server) -> Option<Arc<Mutex<Box<dyn Container>>>> {
-        if let Some(id) = *self.open_container.lock().unwrap() {
+        if let Some(id) = self.open_container.load() {
             server.try_get_container(self.entity_id(), id)
         } else {
             None

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -179,10 +179,7 @@ impl Client {
     ) -> Result<(), DeserializerError> {
         // TODO: handle each packet's Error instead of calling .unwrap()
         let bytebuf = &mut packet.bytebuf;
-        let locked_state = self.connection_state.load();
-        let state = locked_state.clone();
-        drop(locked_state);
-        match state {
+        match self.connection_state.load() {
             pumpkin_protocol::ConnectionState::HandShake => match packet.id.0 {
                 SHandShake::PACKET_ID => {
                     self.handle_handshake(server, SHandShake::read(bytebuf)?);

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -2,7 +2,8 @@ use std::{
     io::{self, Write},
     net::SocketAddr,
     sync::{
-        atomic::{AtomicBool, AtomicI32}, Arc,
+        atomic::{AtomicBool, AtomicI32},
+        Arc,
     },
 };
 
@@ -128,9 +129,7 @@ impl Client {
 
     // Compression threshold, Compression level
     pub fn set_compression(&self, compression: Option<(u32, u32)>) {
-        self.dec
-            .lock()
-            .set_compression(compression.map(|v| v.0));
+        self.dec.lock().set_compression(compression.map(|v| v.0));
         self.enc.lock().set_compression(compression);
     }
 

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -155,7 +155,7 @@ impl Player {
         );
 
         let entity_id = entity.entity_id;
-        let Vector3 {x, y, z } = pos;
+        let Vector3 { x, y, z } = pos;
         let (lastx, lasty, lastz) = (last_position.x, last_position.y, last_position.z);
         let yaw = modulus(entity.yaw.load() * 256.0 / 360.0, 256.0);
         let pitch = modulus(entity.pitch.load() * 256.0 / 360.0, 256.0);
@@ -404,7 +404,9 @@ impl Player {
                                     victem_velocity.z as f32,
                                 );
                                 let velocity = entity.velocity.load();
-                                victem_entity.velocity.store(velocity.multiply(0.6, 1.0, 0.6));
+                                victem_entity
+                                    .velocity
+                                    .store(velocity.multiply(0.6, 1.0, 0.6));
 
                                 victem_entity.velocity.store(saved_velo);
                                 player.client.send_packet(packet);
@@ -556,11 +558,9 @@ impl Player {
         if self.gamemode.load() != GameMode::Creative {
             return Err(InventoryError::PermissionError);
         }
-        self.inventory.lock().set_slot(
-            packet.slot as usize,
-            packet.clicked_item.to_item(),
-            false,
-        )
+        self.inventory
+            .lock()
+            .set_slot(packet.slot as usize, packet.clicked_item.to_item(), false)
     }
 
     // TODO:
@@ -574,9 +574,7 @@ impl Player {
             .store(0, std::sync::atomic::Ordering::Relaxed);
         let open_container = self.open_container.load();
         if let Some(id) = open_container {
-            let mut open_containers = server
-                .open_containers
-                .write();
+            let mut open_containers = server.open_containers.write();
             if let Some(container) = open_containers.get_mut(&id) {
                 container.remove_player(self.entity_id())
             }

--- a/pumpkin/src/commands/cmd_echest.rs
+++ b/pumpkin/src/commands/cmd_echest.rs
@@ -13,9 +13,7 @@ pub(crate) fn init_command_tree<'a>() -> CommandTree<'a> {
             let entity_id = player.entity_id();
             player.open_container.store(Some(0));
             {
-                let mut open_containers = server
-                    .open_containers
-                    .write();
+                let mut open_containers = server.open_containers.write();
                 match open_containers.get_mut(&0) {
                     Some(ender_chest) => {
                         ender_chest.add_player(entity_id);

--- a/pumpkin/src/commands/cmd_echest.rs
+++ b/pumpkin/src/commands/cmd_echest.rs
@@ -11,12 +11,11 @@ pub(crate) fn init_command_tree<'a>() -> CommandTree<'a> {
     CommandTree::new(NAMES, DESCRIPTION).execute(&|sender, server, _| {
         if let Some(player) = sender.as_mut_player() {
             let entity_id = player.entity_id();
-            *player.open_container.lock().unwrap() = Some(0);
+            player.open_container.store(Some(0));
             {
                 let mut open_containers = server
                     .open_containers
-                    .write()
-                    .expect("open_containers got poisoned");
+                    .write();
                 match open_containers.get_mut(&0) {
                     Some(ender_chest) => {
                         ender_chest.add_player(entity_id);

--- a/pumpkin/src/commands/cmd_gamemode.rs
+++ b/pumpkin/src/commands/cmd_gamemode.rs
@@ -65,7 +65,7 @@ pub(crate) fn init_command_tree<'a>() -> CommandTree<'a> {
                         let gamemode = parse_arg_gamemode(args)?;
 
                         return if let Player(target) = sender {
-                            if *target.gamemode.lock().unwrap() == gamemode {
+                            if target.gamemode.load() == gamemode {
                                 target.send_system_message(TextComponent::text(&format!(
                                     "You already in {:?} gamemode",
                                     gamemode
@@ -89,7 +89,7 @@ pub(crate) fn init_command_tree<'a>() -> CommandTree<'a> {
                         let gamemode = parse_arg_gamemode(args)?;
                         let target = parse_arg_player(sender, ARG_TARGET, args)?;
 
-                        if *target.gamemode.lock().unwrap() == gamemode {
+                        if target.gamemode.load() == gamemode {
                             target.send_system_message(TextComponent::text(&format!(
                                 "You already in {:?} gamemode",
                                 gamemode

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -172,7 +172,7 @@ fn main() -> io::Result<()> {
                                     dbg!("a");
                                     player.remove().await;
                                     dbg!("b");
-                                    let connection = &mut player.client.connection.lock().unwrap();
+                                    let connection = &mut player.client.connection.lock();
                                     dbg!("c");
 
                                     poll.registry().deregister(connection.by_ref())?;
@@ -201,7 +201,7 @@ fn main() -> io::Result<()> {
                         if done || make_player {
                             if let Some(client) = clients.remove(&token) {
                                 if done {
-                                    let connection = &mut client.connection.lock().unwrap();
+                                    let connection = &mut client.connection.lock();
                                     poll.registry().deregister(connection.by_ref())?;
                                 } else if make_player {
                                     let token = client.token;

--- a/pumpkin/src/proxy/velocity.rs
+++ b/pumpkin/src/proxy/velocity.rs
@@ -62,7 +62,7 @@ pub fn receive_plugin_response(
         }
         // TODO: no unwrap
         let addr: SocketAddr = buf.get_string().unwrap().parse().unwrap();
-        *client.address.lock().unwrap() = addr;
+        *client.address.lock() = addr;
         todo!()
     } else {
         client.kick("This server requires you to connect with Velocity.")

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -1,6 +1,7 @@
 use base64::{engine::general_purpose, Engine};
 use image::GenericImageView;
 use mio::Token;
+use parking_lot::{Mutex, RwLock};
 use pumpkin_config::{BasicConfiguration, BASIC_CONFIG};
 use pumpkin_core::GameMode;
 use pumpkin_entity::EntityId;
@@ -11,13 +12,11 @@ use pumpkin_protocol::{
 };
 use pumpkin_world::dimension::Dimension;
 use std::collections::HashMap;
-use std::sync::RwLock;
 use std::{
     io::Cursor,
     path::Path,
     sync::{
-        atomic::{AtomicI32, Ordering},
-        Arc, Mutex,
+        atomic::{AtomicI32, Ordering}, Arc,
     },
     time::Duration,
 };
@@ -143,8 +142,7 @@ impl Server {
     ) -> Option<Arc<Mutex<Box<dyn Container>>>> {
         let open_containers = self
             .open_containers
-            .read()
-            .expect("open_containers is poisoned");
+            .read();
         open_containers
             .get(&container_id)?
             .try_open(player_id)

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -16,7 +16,8 @@ use std::{
     io::Cursor,
     path::Path,
     sync::{
-        atomic::{AtomicI32, Ordering}, Arc,
+        atomic::{AtomicI32, Ordering},
+        Arc,
     },
     time::Duration,
 };
@@ -140,9 +141,7 @@ impl Server {
         player_id: EntityId,
         container_id: u64,
     ) -> Option<Arc<Mutex<Box<dyn Container>>>> {
-        let open_containers = self
-            .open_containers
-            .read();
+        let open_containers = self.open_containers.read();
         open_containers
             .get(&container_id)?
             .try_open(player_id)

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 pub mod player_chunker;
 
@@ -170,12 +167,7 @@ impl World {
         );
         // spawn players for our client
         let token = player.client.token;
-        for (_, existing_player) in self
-            .current_players
-            .lock()
-            .iter()
-            .filter(|c| c.0 != &token)
-        {
+        for (_, existing_player) in self.current_players.lock().iter().filter(|c| c.0 != &token) {
             let entity = &existing_player.entity;
             let pos = entity.pos.load();
             let gameprofile = &existing_player.gameprofile;
@@ -219,9 +211,7 @@ impl World {
         let level = self.level.clone();
         let closed = client.closed.load(std::sync::atomic::Ordering::Relaxed);
         let chunks = Arc::new(chunks);
-        tokio::task::spawn_blocking(move || {
-            level.lock().fetch_chunks(&chunks, sender, closed)
-        });
+        tokio::task::spawn_blocking(move || level.lock().fetch_chunks(&chunks, sender, closed));
 
         while let Some(chunk_data) = chunk_receiver.recv().await {
             // dbg!(chunk_pos);


### PR DESCRIPTION
> [!WARNING]
> This pull request requires review as it has a high likelihood of introducing a bug and should be thoroughly examined before approval.

This PR includes the following changes:

- Added `parking_lot` and `crossbeam` dependencies.
- Replaced all `std::sync::Mutex` by `parking_lot::Mutex` and refactored implementation accordingly.
- Replaced all `Mutex<T> where T: Copy` by `crossbeam::AtomicCell<T>` and refactored implementation accordingly.

Significant portions of the code involve setting Mutex on frequently updated fields and certain types that implement Copy. This optimization is expected to reduce locking overhead and improve overall performance.

## Method

- Types that do not implement `Copy` are now wrapper into `parking_lot::Mutex` and the overall `.unwrap()` or `expect()` around poisoning has been removed.
- Types that implements `Copy` trait has been wrapped into `AtomicCell` and the following conversions have been made: `*self.field.lock().unwrap() = value` -> `self.field.store(value)`, `*self.field.lock.unwrap()` -> `self.field.lock()` (There are exceptions to this rule as some methods required to update the data in middle of their routine)

## Bug

I've done my best to understand the code, but the number of changes makes it likely I've introduced an issue. Please review and test thoroughly. However, I am highly confident that the changes will result in performance improvements and are worth the time spent on reviewing.