### PR TITLE
World persistence and .MCA region files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +167,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -734,6 +746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1142,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heed"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4f449bab7320c56003d37732a917e18798e2f1709d80263face2b4f9436ddb"
+dependencies = [
+ "bitflags 2.6.0",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3f528b053a6d700b2734eabcd0fd49cb8230647aa72958467527b0b7917114"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1500,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
+name = "lmdb-master-sys"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472c3760e2a8d0f61f322fb36788021bb36d573c502b50fa3e2bcaac3ec326c9"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
  "rustix",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1713,6 +1792,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1844,48 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2047,6 +2178,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pumpkin-storage"
+version = "0.1.0"
+dependencies = [
+ "crossbeam",
+ "futures",
+ "heed",
+ "parking_lot",
+ "pumpkin-world",
+ "rayon",
+ "speedy",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "pumpkin-world"
 version = "0.1.0"
 dependencies = [
@@ -2065,6 +2210,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "speedy",
  "static_assertions",
  "thiserror",
  "tokio",
@@ -2618,6 +2764,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2801,27 @@ checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "speedy"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1992073f0e55aab599f4483c460598219b4f9ff0affa124b33580ab511e25a"
+dependencies = [
+ "memoffset",
+ "speedy-derive",
+]
+
+[[package]]
+name = "speedy-derive"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658f2ca5276b92c3dfd65fa88316b4e032ace68f88d7570b43967784c0bac5ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2709,6 +2882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
 ]
 
 [[package]]
@@ -3918,6 +4100,12 @@ dependencies = [
  "thiserror",
  "wast 35.0.2",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "pumpkin-plugin",
     "pumpkin-protocol/",
     "pumpkin-registry/",
+    "pumpkin-storage",
     "pumpkin-world",
     "pumpkin/",
 ]
@@ -38,6 +39,7 @@ rayon = "1.10.0"
 parking_lot = "0.12.3"
 crossbeam = "0.8.4"
 
+speedy = "0.8.7"
 uuid = { version = "1.10.0", features = ["serde", "v3", "v4"] }
 derive_more = { version = "1.0.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/pumpkin-storage/Cargo.toml
+++ b/pumpkin-storage/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pumpkin-storage"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+heed = "0.20.5"
+xxhash-rust = { version = "0.8.12", features = ["xxh3"] }
+futures = "*"
+speedy.workspace = true
+parking_lot.workspace = true
+rayon.workspace = true
+crossbeam.workspace = true
+
+pumpkin-world = { path = "../pumpkin-world"}

--- a/pumpkin-storage/src/lib.rs
+++ b/pumpkin-storage/src/lib.rs
@@ -12,9 +12,10 @@ pub mod mca;
 /// A trait implementing the API for fetching and inserting chunks to storage
 pub trait ChunkStorage: Sized + Send + Sync {
     
-    type Error: Debug;
+    /// Error returned by the database
+    type Error: Debug; // In the future: + Into<PumpkinError>
 
-    type OpenOptions;
+    type OpenOptions: Clone; 
     
     /// Open storage
     async fn start(options: Self::OpenOptions) -> Result<Self, Self::Error>;

--- a/pumpkin-storage/src/lib.rs
+++ b/pumpkin-storage/src/lib.rs
@@ -1,0 +1,30 @@
+use std::fmt::Debug;
+
+use pumpkin_world::chunk::ChunkData;
+
+/// Chunk storage over LMDB
+pub mod lmdb;
+
+/// Chunk storage over .MCA folder
+pub mod mca;
+
+#[allow(async_fn_in_trait)]
+/// A trait implementing the API for fetching and inserting chunks to storage
+pub trait ChunkStorage: Sized + Send + Sync {
+    
+    type Error: Debug;
+
+    type OpenOptions;
+    
+    /// Open storage
+    async fn start(options: Self::OpenOptions) -> Result<Self, Self::Error>;
+    
+    /// Close storage
+    async fn close(self);
+    
+    /// Get chunk from storage
+    async fn get_chunk(&self, x: i32, z: i32, dimension: &'static str) -> Result<Option<ChunkData>, Self::Error>;
+    
+    /// Insert chunk into storage
+    async fn insert_chunk(&self, x: i32, z: i32, dimension: &'static str, chunk: ChunkData) -> Result<(),Self::Error>;
+}

--- a/pumpkin-storage/src/lmdb/encoding.rs
+++ b/pumpkin-storage/src/lmdb/encoding.rs
@@ -1,0 +1,25 @@
+use std::{borrow::Cow, marker::PhantomData};
+
+use heed::{BytesDecode, BytesEncode};
+use speedy::{LittleEndian, Readable, Writable};
+
+pub struct Speedy<'t, T>(PhantomData<&'t T>);
+
+impl<'t, T: Writable<LittleEndian>> BytesEncode<'t> for Speedy<'t, T> {
+    type EItem = T;
+
+    fn bytes_encode(item: &'t Self::EItem) -> Result<Cow<'t, [u8]>, heed::BoxedError> {
+        
+        let bytes = item.write_to_vec()?;
+        Ok(Cow::Owned(bytes))
+    }
+}
+
+impl<'t, T: Readable<'t, LittleEndian>> BytesDecode<'t> for Speedy<'t, T> {
+    type DItem = T;
+
+    fn bytes_decode(bytes: &'t [u8]) -> Result<Self::DItem, heed::BoxedError> {
+        
+        Ok(T::read_from_buffer(bytes)?)
+    }
+}

--- a/pumpkin-storage/src/lmdb/mod.rs
+++ b/pumpkin-storage/src/lmdb/mod.rs
@@ -28,6 +28,7 @@ pub struct LMDBStorage {
     env: Env,
 }
 
+#[derive(Clone)]
 /// Configurable options for LMDB.
 pub struct LMDBOpenOptions {
     /// Path towards world folder

--- a/pumpkin-storage/src/lmdb/mod.rs
+++ b/pumpkin-storage/src/lmdb/mod.rs
@@ -1,0 +1,178 @@
+use std::{num::NonZeroUsize, ops::Deref, path::PathBuf, sync::{atomic::{AtomicUsize, Ordering}, Arc}};
+
+use crossbeam::sync::ShardedLock;
+use encoding::Speedy;
+use heed::{byteorder::LE, types::U64, Env, EnvFlags, EnvOpenOptions};
+use pumpkin_world::chunk::ChunkData;
+use rayon::ThreadPoolBuilder;
+use threadpool::{LMDB_INCREMENT_RUNTIME, LMDB_MAP_RUNTIME_SIZE, LMDB_READER_THREADPOOL, LMDB_RESIZE_HANDLE, LMDB_WRITER_THREAD};
+use xxhash_rust::xxh3::Xxh3;
+
+use crate::ChunkStorage;
+
+mod encoding;
+mod threadpool;
+
+// LMDB parameters constants
+const LMDB_MAX_DATABASE: u32 = 1;
+const LMDB_MIN_PAGE_SIZE: usize = 300usize.pow(3); // 300MiB
+const LMDB_PAGE_SIZE_INCREMENT: usize = 300*1024usize.pow(2); // 300 MiB
+
+// Tables names
+const LMDB_TABLE_CHUNK_STORAGE: &str = "chunks";
+
+#[derive(Clone)]
+/// A chunk storage over LMDB
+pub struct LMDBStorage {
+    /// Shared handle of LMDB
+    env: Env,
+}
+
+/// Configurable options for LMDB.
+pub struct LMDBOpenOptions {
+    /// Path towards world folder
+    path: PathBuf,
+    /// Minimal page size
+    page_size: Option<NonZeroUsize>,
+    /// Page increment
+    page_increment: Option<NonZeroUsize>,
+}
+
+impl Deref for LMDBStorage {
+    type Target = Env;
+
+    fn deref(&self) -> &Self::Target {
+        &self.env
+    }
+}
+
+/// LMDB will show a constant growth over time.
+pub fn page_calculation(old_size: usize) -> usize {
+    old_size + *LMDB_INCREMENT_RUNTIME.get().unwrap()
+}
+
+impl ChunkStorage for LMDBStorage {
+    type Error = heed::Error;
+
+    type OpenOptions = LMDBOpenOptions;
+    
+    /// Start LMDB and initialize all runtime OnceLock for runtime operations.
+    async fn start(options: LMDBOpenOptions) -> Result<Self, Self::Error> {
+        
+        // TODO: dynamic thread count (num_cpu equation)
+        let mut env_options = EnvOpenOptions::new();
+        let env = unsafe {
+            env_options
+                .max_dbs(LMDB_MAX_DATABASE)
+                .map_size(options.page_size.map(Into::<usize>::into).unwrap_or(LMDB_MIN_PAGE_SIZE))
+                .max_readers(8);
+            
+            #[cfg(not(target_os = "windows"))]
+            env_options
+                .flags(EnvFlags::WRITE_MAP);
+            
+            env_options.open(options.path)
+        }?;
+        
+        // Initialize page increment size
+        let _ = LMDB_INCREMENT_RUNTIME.get_or_init(|| {
+            options.page_increment.map(Into::<usize>::into).unwrap_or(LMDB_PAGE_SIZE_INCREMENT)
+        });
+        
+        // Initialize runtime map size
+        let _ = LMDB_MAP_RUNTIME_SIZE.get_or_init(|| {
+            let real_size = env.real_disk_size().expect("Unable to read disk file size") as usize;
+            let increment = *LMDB_INCREMENT_RUNTIME.get().unwrap();
+            Arc::new(
+                AtomicUsize::new(
+                    (real_size / increment) * (increment+1)
+                )
+            )
+        });
+        
+        // Resize environment to runtime page
+        unsafe { env.resize(LMDB_MAP_RUNTIME_SIZE.get().unwrap().load(Ordering::Relaxed)) }?;
+        
+        // Initialize resize handle
+        let _ = LMDB_RESIZE_HANDLE.get_or_init(|| {
+            ShardedLock::new(())
+        });
+        
+        // Initialize writer thread
+        let _ = LMDB_WRITER_THREAD.get_or_init(|| {
+            ThreadPoolBuilder::new().num_threads(1).build().expect("Unable to build LMDB rayon writer thread")
+        });
+        
+        // Initialize readers threadpool
+        let _ = LMDB_READER_THREADPOOL.get_or_init(|| {
+           ThreadPoolBuilder::new().num_threads(8).build().expect("Unable to build LMDB rayon readers threadpool.")
+        });
+        
+        // Check if world exist
+        {
+            let mut rw_tx = env.write_txn()?;
+            let database = env.open_database::<U64<LE>, Speedy<ChunkData>>(&rw_tx, Some(LMDB_TABLE_CHUNK_STORAGE))?;
+            if database.is_none() {
+                // LOG: warn!("No chunks table found. Recreating one")
+                env.create_database::<U64<LE>, Speedy<ChunkData>>(&mut rw_tx, Some(LMDB_TABLE_CHUNK_STORAGE))?;
+            }
+        }
+        
+        Ok(LMDBStorage { env })
+    }
+
+    /// Close LMDB database
+    /// 
+    /// # Blocking
+    /// 
+    /// This method will block until all copies of the env have disappeared. It is 
+    /// caller responsibility to ensure that this function is call when any shared state
+    /// has been dismissed.
+    async fn close(self) {
+        let event = self.env.prepare_for_closing();
+        event.wait();
+    }
+
+    /// Get a chunk with its coordinate and dimension from storage (if it exists).
+    async fn get_chunk(&self, x: i32, z: i32, dimension: &'static str) -> Result<Option<ChunkData>, Self::Error> {
+        let db = self.env.clone();
+        
+        Self::spawn_read(move || {
+            let key = calculate_chunk_key(x,z,dimension);
+            let ro_tx = db.read_txn()?;
+            let chunks = db.open_database::<U64<LE>, Speedy<ChunkData>>(&ro_tx, Some(LMDB_TABLE_CHUNK_STORAGE))?.unwrap();
+            
+            let res = chunks.get(&ro_tx, &key)?;
+            ro_tx.commit()?;
+            Ok(res)
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Insert a chunk into storage.
+    async fn insert_chunk(&self, x: i32, z: i32, dimension: &'static str, chunk: ChunkData) -> Result<(),Self::Error> {
+        let db = self.env.clone();
+        
+        Self::spawn_write(db.clone(), move || {
+            let key = calculate_chunk_key(x,z,dimension);
+            let mut rw_tx = db.write_txn()?;
+            let chunks = db.open_database::<U64<LE>, Speedy<ChunkData>>(&rw_tx, Some(LMDB_TABLE_CHUNK_STORAGE))?.unwrap();
+            
+            chunks.put(&mut rw_tx, &key, &chunk)?;
+            rw_tx.commit()?;
+            Ok(())
+        })
+        .await
+        .unwrap()
+    }
+}
+
+/// Calculate key of the chunk based on its location and dimension
+fn calculate_chunk_key(x: i32, z: i32, dimension: &str) -> u64 {
+    let mut hasher = Xxh3::default();
+    hasher.update(&x.to_le_bytes());
+    hasher.update(&z.to_le_bytes());
+    hasher.update(dimension.as_bytes());
+    hasher.digest()
+}

--- a/pumpkin-storage/src/lmdb/threadpool.rs
+++ b/pumpkin-storage/src/lmdb/threadpool.rs
@@ -1,0 +1,99 @@
+use std::{future::Future, sync::{atomic::{AtomicUsize, Ordering}, Arc, OnceLock}};
+
+use crossbeam::sync::ShardedLock;
+use futures::channel::oneshot::{self, Canceled};
+use heed::{Env, Error};
+use rayon::ThreadPool;
+
+use super::{page_calculation, LMDBStorage};
+
+pub static LMDB_READER_THREADPOOL: OnceLock<ThreadPool> = OnceLock::new();
+pub static LMDB_WRITER_THREAD: OnceLock<ThreadPool> = OnceLock::new();
+pub static LMDB_RESIZE_HANDLE: OnceLock<ShardedLock<()>> = OnceLock::new();
+pub static LMDB_MAP_RUNTIME_SIZE: OnceLock<Arc<AtomicUsize>> = OnceLock::new();
+pub static LMDB_INCREMENT_RUNTIME: OnceLock<usize> = OnceLock::new();
+
+impl LMDBStorage {
+    
+    /// Spawn a database reading operations into the reading threadpool.
+    pub fn spawn_read<R,F>(f: F) -> impl Future<Output = Result<R,Canceled>> 
+    where 
+        F: Fn() -> R + Send + 'static,
+        R: Send + 'static
+    {        
+        let (tx,rx) = oneshot::channel::<R>();
+        LMDB_READER_THREADPOOL.get().unwrap()
+            .spawn(move || {
+                
+                // Obtain resize read lock
+                let rz_lock = LMDB_RESIZE_HANDLE.get().unwrap().read().unwrap();
+                
+                // Execute operation
+                let res = f();
+                
+                // Drop lock
+                drop(rz_lock);
+                
+                // Send back result
+                if tx.send(res).is_err() {
+                    // LOG: warn!("Receiver closed on the other side! A database operation has been wasted.")
+                }
+            });
+        rx
+    }
+    
+    /// Spawn a database reading operations into the reading threadpool.
+    pub fn spawn_write<R,F>(db: Env, f: F) -> impl Future<Output = Result<Result<R,heed::Error>,Canceled>> 
+    where 
+        F: Fn() -> Result<R,heed::Error> + Send + 'static,
+        R: Send + 'static
+    {        
+        let (tx,rx) = oneshot::channel::<Result<R,heed::Error>>();
+        LMDB_WRITER_THREAD.get().unwrap()
+            .spawn(move || {
+                
+                
+                let res = || {
+                    // Obtain resize read lock
+                    let rz_lock = LMDB_RESIZE_HANDLE.get().unwrap().read().unwrap();
+                    
+                    // Execute operation
+                    let mut res = f();
+                    
+                    // Drop lock
+                    drop(rz_lock);
+                    
+                    // Resizing map if full
+                    while let Err(Error::Mdb(heed::MdbError::MapFull)) = res {
+                        
+                        // LOG: warn!("LMDB Map is full. Resizing...")
+                        
+                        // When the map is full we get the write lock of the resize handle. Ensuring we have exclusive access
+                        // to the database. This let use the resize functionality since no transaction is ongoing.
+                        let rz_lock = LMDB_RESIZE_HANDLE.get().unwrap().write().unwrap();
+                        
+                        let pt = LMDB_MAP_RUNTIME_SIZE.get().unwrap();
+                        let old_size = pt.load(Ordering::Relaxed);
+                        let new_size = page_calculation(old_size);
+                        unsafe { db.resize(new_size) }?;
+                        pt.store(new_size, Ordering::Relaxed);
+                        
+                        // LOG: info!("LMDB Map successfully resized from {} MiB to {} MiB", (old_size / 1024usize.pow(2)), (new_size / 1024usize.pow(2)))
+                        
+                        res = f();
+                        
+                        drop(rz_lock);
+                    }
+                    
+                    res
+                };
+                
+                
+                // Send back result
+                if tx.send(res()).is_err() {
+                    // LOG: warn!("Receiver closed on the other side! A database operation has been wasted.")
+                }
+            });
+        rx
+    }
+}

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -9,6 +9,7 @@ pumpkin-core = { path = "../pumpkin-core"}
 fastnbt = { git = "https://github.com/owengage/fastnbt.git" }
 tokio.workspace = true
 rayon.workspace = true
+speedy.workspace = true
 derive_more.workspace = true
 itertools = "0.13.0"
 thiserror = "1.0"


### PR DESCRIPTION
Related to: https://github.com/Snowiiii/Pumpkin/issues/92

This pull request is intended to introduce a ChunkStorage actor, which will be responsible for retrieving and storing chunks to and from disk. The implementation of this feature is a crucial step towards achieving world persistence, a key requirement for Pumpkin to function as a vanilla server in the future.

Current state:
- [ ] Implement serialization of ChunkData (temporary at the moment)
- [x] Implement skeleton ChunkStorage trait 
- [x] Implement LMDB
- [ ] Implement .MCA storage
    - [ ] Implement Anvil format parsing