### PR TITLE
Migrate to tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,6 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
- "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -1929,7 +1928,6 @@ dependencies = [
  "image",
  "itertools 0.13.0",
  "log",
- "mio",
  "num-bigint",
  "num-derive",
  "num-traits",
@@ -2028,11 +2026,13 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
+ "parking_lot",
  "pumpkin-core",
  "pumpkin-macros",
  "pumpkin-world",
  "serde",
  "thiserror",
+ "tokio",
  "uuid",
 ]
 

--- a/pumpkin-protocol/Cargo.toml
+++ b/pumpkin-protocol/Cargo.toml
@@ -14,6 +14,8 @@ uuid.workspace = true
 
 serde.workspace = true
 
+tokio.workspace = true
+
 flate2 = "1.0.33"
 
 thiserror = "1.0"
@@ -27,3 +29,4 @@ cfb8 = "0.8.1"
 
 itertools = "0.13.0"
 fastnbt = { git = "https://github.com/owengage/fastnbt.git" }
+parking_lot.workspace = true

--- a/pumpkin-protocol/src/packet_decoder.rs
+++ b/pumpkin-protocol/src/packet_decoder.rs
@@ -1,13 +1,12 @@
 use aes::cipher::{generic_array::GenericArray, BlockDecryptMut, BlockSizeUser, KeyIvInit};
-use bytes::{Buf, BytesMut};
+use parking_lot::Mutex;
 
-use std::io::Write;
+use std::{io::Write, sync::{atomic::{AtomicBool, Ordering}, OnceLock}};
 
-use bytes::BufMut;
 use flate2::write::ZlibDecoder;
 
 use crate::{
-    bytebuf::ByteBuffer, PacketError, RawPacket, VarInt, VarIntDecodeError, MAX_PACKET_SIZE,
+    bytebuf::ByteBuffer, PacketError, RawPacket, VarInt,
 };
 
 type Cipher = cfb8::Decryptor<aes::Aes128>;
@@ -17,136 +16,61 @@ type Cipher = cfb8::Decryptor<aes::Aes128>;
 // Supports Aes128 Encyption
 #[derive(Default)]
 pub struct PacketDecoder {
-    buf: BytesMut,
-    decompress_buf: BytesMut,
-    compression: Option<u32>,
-    cipher: Option<Cipher>,
+    compression: AtomicBool,
+    cipher: OnceLock<Mutex<Cipher>>,
 }
 
 impl PacketDecoder {
-    pub fn decode(&mut self) -> Result<Option<RawPacket>, PacketError> {
-        let mut r = &self.buf[..];
-
-        let packet_len = match VarInt::decode_partial(&mut r) {
-            Ok(len) => len,
-            Err(VarIntDecodeError::Incomplete) => return Ok(None),
-            Err(VarIntDecodeError::TooLarge) => Err(PacketError::MalformedLength)?,
-        };
-
-        if !(0..=MAX_PACKET_SIZE).contains(&packet_len) {
-            Err(PacketError::OutOfBounds)?
-        }
-
-        if r.len() < packet_len as usize {
-            // Not enough data arrived yet.
-            return Ok(None);
-        }
-
-        let packet_len_len = VarInt(packet_len).written_size();
-
-        let mut data;
-        if self.compression.is_some() {
-            r = &r[..packet_len as usize];
-
-            let data_len = VarInt::decode(&mut r).map_err(|_| PacketError::TooLong)?.0;
-
-            if !(0..=MAX_PACKET_SIZE).contains(&data_len) {
-                Err(PacketError::OutOfBounds)?
-            }
-
-            // Is this packet compressed?
-            if data_len > 0 {
-                debug_assert!(self.decompress_buf.is_empty());
-
-                self.decompress_buf.put_bytes(0, data_len as usize);
-
-                // TODO: use libdeflater or zune-inflate?
-                let mut z = ZlibDecoder::new(&mut self.decompress_buf[..]);
-
-                z.write_all(r).map_err(|_| PacketError::FailedWrite)?;
-                z.finish().map_err(|_| PacketError::FailedFinish)?;
-
-                let total_packet_len = VarInt(packet_len).written_size() + packet_len as usize;
-
-                self.buf.advance(total_packet_len);
-
-                data = self.decompress_buf.split();
-            } else {
-                debug_assert_eq!(data_len, 0);
-
-                let remaining_len = r.len();
-
-                self.buf.advance(packet_len_len + 1);
-
-                data = self.buf.split_to(remaining_len);
-            }
-        } else {
-            // no compression
-            self.buf.advance(packet_len_len);
-            data = self.buf.split_to(packet_len as usize);
-        }
-
-        r = &data[..];
-        let packet_id = VarInt::decode(&mut r).map_err(|_| PacketError::DecodeID)?;
-
-        data.advance(data.len() - r.len());
-        Ok(Some(RawPacket {
-            id: packet_id,
-            bytebuf: ByteBuffer::new(data),
-        }))
-    }
-
-    pub fn enable_encryption(&mut self, key: &[u8; 16]) {
-        assert!(self.cipher.is_none(), "encryption is already enabled");
-
-        let mut cipher = Cipher::new_from_slices(key, key).expect("invalid key");
-
-        // Don't forget to decrypt the data we already have.
-        Self::decrypt_bytes(&mut cipher, &mut self.buf);
-
-        self.cipher = Some(cipher);
+    /// Enable encryption with the provided key.
+    /// Does nothing if already enabled
+    pub fn enable_encryption(&self, key: &[u8; 16]) {
+        self.cipher.get_or_init(|| {
+            Mutex::new(Cipher::new_from_slices(key, key).expect("Invalid Key"))
+        });
     }
 
     /// Enables ZLib Deompression
-    pub fn set_compression(&mut self, compression: Option<u32>) {
-        self.compression = compression;
+    pub fn set_compression(&self, compression: bool) {
+        self.compression.store(compression, Ordering::Relaxed);
     }
 
-    fn decrypt_bytes(cipher: &mut Cipher, bytes: &mut [u8]) {
-        for chunk in bytes.chunks_mut(Cipher::block_size()) {
-            let gen_arr = GenericArray::from_mut_slice(chunk);
-            cipher.decrypt_block_mut(gen_arr);
+    /// Decrypt and decompress the given bytes (if enabled)
+    /// Returns a Raw Packet if succesfull
+    /// Caller is responsible for validating packet size
+    pub async fn decode(&self, bytes: &mut [u8]) -> Result<RawPacket, PacketError> {
+        // If cipher is not initialized, assume encryption is disabled
+        if let Some(cipher) = &mut self.cipher.get() {
+            let mut cipher = cipher.lock();
+            for chunk in bytes.chunks_mut(Cipher::block_size()) {
+                let gen_arr = GenericArray::from_mut_slice(chunk);
+                cipher.decrypt_block_mut(gen_arr);
+            }
         }
-    }
 
-    pub fn queue_bytes(&mut self, mut bytes: BytesMut) {
-        if let Some(cipher) = &mut self.cipher {
-            Self::decrypt_bytes(cipher, &mut bytes);
-        }
+        let decompressed_data = if self.compression.load(Ordering::Relaxed) {
+            let mut data = vec![];
+            let mut decompressor = ZlibDecoder::new(&mut data);
 
-        self.buf.unsplit(bytes);
-    }
+            decompressor
+                .write_all(bytes)
+                .map_err(|_| PacketError::FailedWrite)?;
+            decompressor
+                .finish()
+                .map_err(|_| PacketError::FailedFinish)?;
 
-    pub fn queue_slice(&mut self, bytes: &[u8]) {
-        let len = self.buf.len();
+            data
+        } else {
+            bytes.to_vec()
+        };
+        let mut data_slice = &decompressed_data[..];
 
-        self.buf.extend_from_slice(bytes);
+        let packet_id = VarInt::decode_with_reader(&mut data_slice)
+            .await
+            .map_err(|_| PacketError::DecodeID)?;
 
-        if let Some(cipher) = &mut self.cipher {
-            let slice = &mut self.buf[len..];
-            Self::decrypt_bytes(cipher, slice);
-        }
-    }
-
-    pub fn take_capacity(&mut self) -> BytesMut {
-        self.buf.split_off(self.buf.len())
-    }
-
-    pub fn clear(&mut self) {
-        self.buf.clear()
-    }
-
-    pub fn reserve(&mut self, additional: usize) {
-        self.buf.reserve(additional);
+        Ok(RawPacket {
+            id: packet_id,
+            bytebuf: ByteBuffer::new(data_slice.into()),
+        })
     }
 }

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -59,9 +59,6 @@ image = { version = "0.25", default-features = false, features = ["png"]}
 simple_logger = "5.0.0"
 log.workspace = true
 
-# networking
-mio = { version = "1.0.2", features = ["os-poll", "net"]}
-
 parking_lot.workspace = true
 crossbeam.workspace = true
 uuid.workspace = true

--- a/pumpkin/src/client/container.rs
+++ b/pumpkin/src/client/container.rs
@@ -389,7 +389,6 @@ impl Player {
                 .filter(|player_id| *player_id != self.entity_id())
                 .collect_vec()
         };
-        let player_token = self.client.token;
 
         // TODO: Figure out better way to get only the players from player_ids
         // Also refactor out a better method to get individual advanced state ids
@@ -401,7 +400,7 @@ impl Player {
             .lock()
             .iter()
             .filter_map(|(token, player)| {
-                if *token != player_token {
+                if *token != self.gameprofile.id {
                     let entity_id = player.entity_id();
                     if player_ids.contains(&entity_id) {
                         Some(player.clone())

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -107,7 +107,7 @@ impl Player {
         // }
         // send new position to all other players
         world.broadcast_packet_expect(
-            &[self.client.token],
+            &[self.gameprofile.id],
             &CUpdateEntityPos::new(
                 entity_id.into(),
                 (x * 4096.0 - lastx * 4096.0) as i16,
@@ -177,7 +177,7 @@ impl Player {
         // send new position to all other players
 
         world.broadcast_packet_expect(
-            &[self.client.token],
+            &[self.gameprofile.id],
             &CUpdateEntityPosRot::new(
                 entity_id.into(),
                 (x * 4096.0 - lastx * 4096.0) as i16,
@@ -189,7 +189,7 @@ impl Player {
             ),
         );
         world.broadcast_packet_expect(
-            &[self.client.token],
+            &[self.gameprofile.id],
             &CHeadRot::new(entity_id.into(), yaw as u8),
         );
         player_chunker::update_position(entity, self).await;
@@ -217,9 +217,9 @@ impl Player {
         let world = &entity.world;
         let packet =
             CUpdateEntityRot::new(entity_id.into(), yaw as u8, pitch as u8, rotation.ground);
-        world.broadcast_packet_expect(&[self.client.token], &packet);
+        world.broadcast_packet_expect(&[self.gameprofile.id], &packet);
         let packet = CHeadRot::new(entity_id.into(), yaw as u8);
-        world.broadcast_packet_expect(&[self.client.token], &packet);
+        world.broadcast_packet_expect(&[self.gameprofile.id], &packet);
     }
 
     pub fn handle_chat_command(&self, server: &Arc<Server>, command: SChatCommand) {
@@ -291,7 +291,7 @@ impl Player {
                 let id = self.entity_id();
                 let world = &self.entity.world;
                 world.broadcast_packet_expect(
-                    &[self.client.token],
+                    &[self.gameprofile.id],
                     &CEntityAnimation::new(id.into(), animation as u8),
                 )
             }

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -3,14 +3,19 @@
 #[cfg(target_os = "wasi")]
 compile_error!("Compiling for WASI targets is not supported!");
 
-use mio::net::TcpListener;
-use mio::{Events, Interest, Poll, Token};
+use std::io;
+use std::sync::Arc;
+use std::time::Instant;
 
-use std::collections::HashMap;
-use std::io::{self, Read};
-
-use client::{interrupted, Client};
+use client::Client;
+use pumpkin_config::{ADVANCED_CONFIG, BASIC_CONFIG};
+use pumpkin_core::text::color::NamedColor;
+use pumpkin_core::text::TextComponent;
+use pumpkin_protocol::VarInt;
 use server::Server;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
 
 // Setup some tokens to allow us to identify which event is for which socket.
 
@@ -24,13 +29,6 @@ pub mod util;
 pub mod world;
 
 fn main() -> io::Result<()> {
-    use std::sync::Arc;
-
-    use entity::player::Player;
-    use pumpkin_config::{ADVANCED_CONFIG, BASIC_CONFIG};
-    use pumpkin_core::text::{color::NamedColor, TextComponent};
-    use rcon::RCONServer;
-
     simple_logger::SimpleLogger::new()
         .with_level(log::LevelFilter::Info)
         .init()
@@ -54,168 +52,243 @@ fn main() -> io::Result<()> {
     // ensure rayon is built outside of tokio scope
     rayon::ThreadPoolBuilder::new().build_global().unwrap();
     rt.block_on(async {
-        const SERVER: Token = Token(0);
-        use std::time::Instant;
+        // const SERVER: Token = Token(0);
+        // use std::time::Instant;
 
-        let time = Instant::now();
+        // let time = Instant::now();
 
-        // Create a poll instance.
-        let mut poll = Poll::new()?;
-        // Create storage for events.
-        let mut events = Events::with_capacity(128);
+        // // Create a poll instance.
+        // let mut poll = Poll::new()?;
+        // // Create storage for events.
+        // let mut events = Events::with_capacity(128);
 
-        // Setup the TCP server socket.
+        // // Setup the TCP server socket.
+        // let addr = BASIC_CONFIG.server_address;
+        // let mut listener = TcpListener::bind(addr)?;
+
+        // // Register the server with poll we can receive events for it.
+        // poll.registry()
+        //     .register(&mut listener, SERVER, Interest::READABLE)?;
+
+        // // Unique token for each incoming connection.
+        // let mut unique_token = Token(SERVER.0 + 1);
+
+        // let use_console = ADVANCED_CONFIG.commands.use_console;
+        // let rcon = ADVANCED_CONFIG.rcon.clone();
+
+        // let mut clients: HashMap<Token, Client> = HashMap::new();
+        // let mut players: HashMap<Token, Arc<Player>> = HashMap::new();
+
+        // let server = Arc::new(Server::new());
+        // log::info!("Started Server took {}ms", time.elapsed().as_millis());
+        // log::info!("You now can connect to the server, Listening on {}", addr);
+
+        // if use_console {
+        //     let server = server.clone();
+        //     tokio::spawn(async move {
+        //         let stdin = std::io::stdin();
+        //         loop {
+        //             let mut out = String::new();
+        //             stdin
+        //                 .read_line(&mut out)
+        //                 .expect("Failed to read console line");
+
+        //             if !out.is_empty() {
+        //                 let dispatcher = server.command_dispatcher.clone();
+        //                 dispatcher.handle_command(
+        //                     &mut commands::CommandSender::Console,
+        //                     &server,
+        //                     &out,
+        //                 );
+        //             }
+        //         }
+        //     });
+        // }
+        // if rcon.enabled {
+        //     let server = server.clone();
+        //     tokio::spawn(async move {
+        //         RCONServer::new(&rcon, server).await.unwrap();
+        //     });
+        // }
+        // loop {
+        //     if let Err(err) = poll.poll(&mut events, None) {
+        //         if interrupted(&err) {
+        //             continue;
+        //         }
+        //         return Err(err);
+        //     }
+
+        //     for event in events.iter() {
+        //         match event.token() {
+        //             SERVER => loop {
+        //                 // Received an event for the TCP server socket, which
+        //                 // indicates we can accept an connection.
+        //                 let (mut connection, address) = match listener.accept() {
+        //                     Ok((connection, address)) => (connection, address),
+        //                     Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+        //                         // If we get a `WouldBlock` error we know our
+        //                         // listener has no more incoming connections queued,
+        //                         // so we can return to polling and wait for some
+        //                         // more.
+        //                         break;
+        //                     }
+        //                     Err(e) => {
+        //                         // If it was any other kind of error, something went
+        //                         // wrong and we terminate with an error.
+        //                         return Err(e);
+        //                     }
+        //                 };
+        //                 if let Err(e) = connection.set_nodelay(true) {
+        //                     log::warn!("failed to set TCP_NODELAY {e}");
+        //                 }
+
+        //                 log::info!("Accepted connection from: {}", address);
+
+        //                 let token = next(&mut unique_token);
+        //                 poll.registry().register(
+        //                     &mut connection,
+        //                     token,
+        //                     Interest::READABLE.add(Interest::WRITABLE),
+        //                 )?;
+        //                 let client = Client::new(token, connection, addr);
+        //                 clients.insert(token, client);
+        //             },
+
+        //             token => {
+        //                 // Poll Players
+        //                 if let Some(player) = players.get_mut(&token) {
+        //                     player.client.poll(event).await;
+        //                     let closed = player
+        //                         .client
+        //                         .closed
+        //                         .load(std::sync::atomic::Ordering::Relaxed);
+        //                     if !closed {
+        //                         player.process_packets(&server).await;
+        //                     }
+        //                     if closed {
+        //                         if let Some(player) = players.remove(&token) {
+        //                             player.remove().await;
+        //                             let connection = &mut player.client.connection.lock();
+        //                             poll.registry().deregister(connection.by_ref())?;
+        //                         }
+        //                     }
+        //                 };
+
+        //                 // Poll current Clients (non players)
+        //                 // Maybe received an event for a TCP connection.
+        //                 let (done, make_player) = if let Some(client) = clients.get_mut(&token) {
+        //                     client.poll(event).await;
+        //                     let closed = client.closed.load(std::sync::atomic::Ordering::Relaxed);
+        //                     if !closed {
+        //                         client.process_packets(&server).await;
+        //                     }
+        //                     (
+        //                         closed,
+        //                         client
+        //                             .make_player
+        //                             .load(std::sync::atomic::Ordering::Relaxed),
+        //                     )
+        //                 } else {
+        //                     // Sporadic events happen, we can safely ignore them.
+        //                     (false, false)
+        //                 };
+        //                 if done || make_player {
+        //                     if let Some(client) = clients.remove(&token) {
+        //                         if done {
+        //                             let connection = &mut client.connection.lock();
+        //                             poll.registry().deregister(connection.by_ref())?;
+        //                         } else if make_player {
+        //                             let token = client.token;
+        //                             let (player, world) = server.add_player(token, client).await;
+        //                             players.insert(token, player.clone());
+        //                             world.spawn_player(&BASIC_CONFIG, player).await;
+        //                         }
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+
+        let time = Instant::now(); // Maybe use tokio's instant instead
+
         let addr = BASIC_CONFIG.server_address;
-        let mut listener = TcpListener::bind(addr)?;
-
-        // Register the server with poll we can receive events for it.
-        poll.registry()
-            .register(&mut listener, SERVER, Interest::READABLE)?;
-
-        // Unique token for each incoming connection.
-        let mut unique_token = Token(SERVER.0 + 1);
+        let listener = TcpListener::bind(addr).await?;
 
         let use_console = ADVANCED_CONFIG.commands.use_console;
         let rcon = ADVANCED_CONFIG.rcon.clone();
 
-        let mut clients: HashMap<Token, Client> = HashMap::new();
-        let mut players: HashMap<Token, Arc<Player>> = HashMap::new();
-
         let server = Arc::new(Server::new());
-        log::info!("Started Server took {}ms", time.elapsed().as_millis());
-        log::info!("You now can connect to the server, Listening on {}", addr);
+
+        log::info!("Server started, took {}ms", time.elapsed().as_millis());
+        log::info!("Listening on {}", addr);
 
         if use_console {
             let server = server.clone();
+
             tokio::spawn(async move {
-                let stdin = std::io::stdin();
+                let mut reader = BufReader::new(tokio::io::stdin());
+
                 loop {
                     let mut out = String::new();
-                    stdin
-                        .read_line(&mut out)
-                        .expect("Failed to read console line");
+
+                    reader.read_line(&mut out).await.expect("Failed to read console line"); // todo: improve error handling
 
                     if !out.is_empty() {
-                        let dispatcher = server.command_dispatcher.clone();
-                        dispatcher.handle_command(
-                            &mut commands::CommandSender::Console,
-                            &server,
-                            &out,
-                        );
+                        // todo: handle console commands
+                        // handle_command();
                     }
                 }
             });
         }
+
         if rcon.enabled {
-            let server = server.clone();
-            tokio::spawn(async move {
-                RCONServer::new(&rcon, server).await.unwrap();
-            });
+            // handle rcon
         }
+
         loop {
-            if let Err(err) = poll.poll(&mut events, None) {
-                if interrupted(&err) {
-                    continue;
-                }
-                return Err(err);
+            let (connection, address) = listener.accept().await?;
+            let server = server.clone();
+
+            if let Err(e) = connection.set_nodelay(true) {
+                log::warn!("Failed to set TCP_NODELAY for {}: {}", address, e)
             }
 
-            for event in events.iter() {
-                match event.token() {
-                    SERVER => loop {
-                        // Received an event for the TCP server socket, which
-                        // indicates we can accept an connection.
-                        let (mut connection, address) = match listener.accept() {
-                            Ok((connection, address)) => (connection, address),
-                            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                                // If we get a `WouldBlock` error we know our
-                                // listener has no more incoming connections queued,
-                                // so we can return to polling and wait for some
-                                // more.
-                                break;
-                            }
-                            Err(e) => {
-                                // If it was any other kind of error, something went
-                                // wrong and we terminate with an error.
-                                return Err(e);
-                            }
-                        };
-                        if let Err(e) = connection.set_nodelay(true) {
-                            log::warn!("failed to set TCP_NODELAY {e}");
+            let (mut read_half, mut write_half) = connection.into_split();
+            let (send_packets_sender, mut send_packets_receiver) = mpsc::unbounded_channel::<Vec<u8>>();
+
+            // Handle packet writing
+            // Doesn't handle encryption/compression
+            tokio::spawn(async move {
+                while let Some(packet) = send_packets_receiver.recv().await {
+                    write_half.write_all(&packet).await.unwrap();
+                }
+            });
+
+            let client = Arc::new(Client::new(send_packets_sender, address));
+
+            // Handle packet reading
+            tokio::spawn(async move {
+                let client = client.clone();
+                let server = server.clone();
+
+                loop {
+                    let packet_size = VarInt::decode_with_reader(&mut read_half).await.unwrap().0; // Improve error handling
+                    
+                    match packet_size {
+                        0 => {
+                            // Reading 0 bytes means the other side has closed the
+                            // connection or is done writing, then so are we.
+                            break;
                         }
-
-                        log::info!("Accepted connection from: {}", address);
-
-                        let token = next(&mut unique_token);
-                        poll.registry().register(
-                            &mut connection,
-                            token,
-                            Interest::READABLE.add(Interest::WRITABLE),
-                        )?;
-                        let client = Client::new(token, connection, addr);
-                        clients.insert(token, client);
-                    },
-
-                    token => {
-                        // Poll Players
-                        if let Some(player) = players.get_mut(&token) {
-                            player.client.poll(event).await;
-                            let closed = player
-                                .client
-                                .closed
-                                .load(std::sync::atomic::Ordering::Relaxed);
-                            if !closed {
-                                player.process_packets(&server).await;
-                            }
-                            if closed {
-                                if let Some(player) = players.remove(&token) {
-                                    player.remove().await;
-                                    let connection = &mut player.client.connection.lock();
-                                    poll.registry().deregister(connection.by_ref())?;
-                                }
-                            }
-                        };
-
-                        // Poll current Clients (non players)
-                        // Maybe received an event for a TCP connection.
-                        let (done, make_player) = if let Some(client) = clients.get_mut(&token) {
-                            client.poll(event).await;
-                            let closed = client.closed.load(std::sync::atomic::Ordering::Relaxed);
-                            if !closed {
-                                client.process_packets(&server).await;
-                            }
-                            (
-                                closed,
-                                client
-                                    .make_player
-                                    .load(std::sync::atomic::Ordering::Relaxed),
-                            )
-                        } else {
-                            // Sporadic events happen, we can safely ignore them.
-                            (false, false)
-                        };
-                        if done || make_player {
-                            if let Some(client) = clients.remove(&token) {
-                                if done {
-                                    let connection = &mut client.connection.lock();
-                                    poll.registry().deregister(connection.by_ref())?;
-                                } else if make_player {
-                                    let token = client.token;
-                                    let (player, world) = server.add_player(token, client).await;
-                                    players.insert(token, player.clone());
-                                    world.spawn_player(&BASIC_CONFIG, player).await;
-                                }
-                            }
+                        _ => {
+                            let mut buffer = vec![0; packet_size as usize];
+                            read_half.read_exact(&mut buffer).await.unwrap(); // Improve error handling
+                            client.handle_packet(&server, &mut buffer).await;
                         }
                     }
                 }
-            }
+            });
         }
     })
-}
-
-fn next(current: &mut Token) -> Token {
-    let next = current.0;
-    current.0 += 1;
-    Token(next)
 }

--- a/pumpkin/src/rcon/packet.rs
+++ b/pumpkin/src/rcon/packet.rs
@@ -1,9 +1,8 @@
 use std::io::{self, BufRead, Cursor, Write};
 
 use bytes::{BufMut, BytesMut};
-use mio::net::TcpStream;
 use thiserror::Error;
-use tokio::io::AsyncReadExt;
+use tokio::{io::{AsyncReadExt, AsyncWriteExt}, net::TcpStream};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PacketType {
@@ -65,7 +64,7 @@ impl Packet {
         buf.put_slice(bytes);
         buf.put_u8(0);
         buf.put_u8(0);
-        let _ = connection.write(&buf).unwrap();
+        let _ = connection.write(&buf).await.unwrap();
         Ok(())
     }
 

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -1,6 +1,5 @@
 use connection_cache::{CachedBranding, CachedStatus};
 use key_store::KeyStore;
-use mio::Token;
 use parking_lot::{Mutex, RwLock};
 use pumpkin_config::BASIC_CONFIG;
 use pumpkin_core::GameMode;
@@ -10,6 +9,7 @@ use pumpkin_protocol::client::login::CEncryptionRequest;
 use pumpkin_protocol::client::status::CStatusResponse;
 use pumpkin_protocol::{client::config::CPluginMessage, ClientPacket};
 use pumpkin_world::dimension::Dimension;
+use uuid::Uuid;
 use std::collections::HashMap;
 use std::{
     sync::{
@@ -96,7 +96,7 @@ impl Server {
         }
     }
 
-    pub async fn add_player(&self, token: Token, client: Client) -> (Arc<Player>, Arc<World>) {
+    pub async fn add_player(&self, token: Uuid, client: Client) -> (Arc<Player>, Arc<World>) {
         let entity_id = self.new_entity_id();
         let gamemode = match BASIC_CONFIG.default_gamemode {
             GameMode::Undefined => GameMode::Survival,


### PR DESCRIPTION
- [ ] Migrate to tokio networking
- [x] Remove mio from dependancies
- [ ] Read packets from the client
- [x] Write packets to the client
- [ ] Read RCON packets from the client
- [ ] Write RCON packets to the client
- [ ] Make functions that send packets async (see changed files for more details)
- [ ] Make command Apis take async closures

Migrate everything to tokio. Currently mio is used for networking. This PR aims to remove mio and use tokio in its place. This PR also makes a ton of changes to the code base as many functions are converted to async functions. Everything has been migrated to tokio networking and all the need functions are made async but currently packets are not read from the client and rcon client. Reading is not implemented yet because I am not sure on how to properly implement it. I'm open to suggestions and feedback!
I made a new PR as I accidentally closed the orginal one (#75) because I reverted my orginal changes to add new ones.
<sub>I probably should have opened an issue first<sub>