### PR TITLE
expose docker container port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ FROM alpine:3.20
 WORKDIR /pumpkin
 RUN apk add --no-cache libgcc
 COPY --from=builder /pumpkin/target/release/pumpkin /pumpkin/pumpkin
+EXPOSE 25565
 ENTRYPOINT ["/pumpkin/pumpkin"]

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ docker build . -t pumpkin
 To run it use the following command:
 
 ```shell
-docker run --rm -v "./world:/pumpkin/world" pumpkin
+docker run --rm -p 25565:25565 -v "./world:/pumpkin/world" pumpkin
 ```
 
 ## Contributions


### PR DESCRIPTION
The port of the Pumpkin server needs to be exposed to be accessable from the docker container