### PR TITLE
feat : make dockerfile uses cargo cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,16 @@ ENV RUSTFLAGS="-C target-feature=-crt-static -C target-cpu=native"
 RUN apk add --no-cache musl-dev
 WORKDIR /pumpkin
 COPY . /pumpkin
-RUN cargo build --release
-RUN strip target/release/pumpkin
+RUN --mount=type=cache,sharing=private,target=/pumpkin/target \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    cargo build --release && cp target/release/pumpkin ./pumpkin.release
+RUN strip pumpkin.release
 
 FROM alpine:3.20
 WORKDIR /pumpkin
 RUN apk add --no-cache libgcc
-COPY --from=builder /pumpkin/target/release/pumpkin /pumpkin/pumpkin
+COPY --from=builder /pumpkin/pumpkin.release /pumpkin/pumpkin
+ENV RUST_BACKTRACE=full
 EXPOSE 25565
 ENTRYPOINT ["/pumpkin/pumpkin"]


### PR DESCRIPTION
 Make dockerfile uses cargo cache to go from 2m30s to 0s if nothing changes or 40 secondes if there is a change is the rust code to compile