### PR TITLE
Correct language used by minestom to Java

### DIFF
--- a/docs/about/benchmarks.md
+++ b/docs/about/benchmarks.md
@@ -159,7 +159,7 @@ Compile args:
 
 Run args:
 
-**Language:** Kotlin 2.0.0
+**Language:** Java
 
 **File Size:** 2,8MB (Library)
 

--- a/docs/about/benchmarks.md
+++ b/docs/about/benchmarks.md
@@ -159,7 +159,7 @@ Compile args:
 
 Run args:
 
-**Language:** Java
+**Language:** Benchmarks ran with Kotlin 2.0.0 (Minestom itself is made with Java)
 
 **File Size:** 2,8MB (Library)
 


### PR DESCRIPTION
This PR makes it clearer that minestom is built with Java, while the benchmarks are run with Kotlin