### PR TITLE
Optimized Anvil parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ features.toml
 docs/.vitepress/dist
 docs/.vitepress/cache
 node_modules
+
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pumpkin",
+  "name": "Pumpkin",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -18,7 +18,9 @@ futures = "0.3"
 
 # Compression
 flate2 = "1.0"
-lz4 = "1.11.1"
+lz4 = "1.28.0"
+yazi = "0.2.0"
+zune-inflate = "0.2.54"
 
 serde.workspace = true
 serde_json = "1.0"
@@ -35,3 +37,15 @@ rand = "0.8.5"
 
 num-traits = "0.2"
 num-derive = "0.4"
+memmap2 = "0.9.5"
+tracing = "0.1.40"
+fastanvil = "0.31.0"
+byteorder = "1.5.0"
+
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "world"
+harness = false

--- a/pumpkin-world/benches/world.rs
+++ b/pumpkin-world/benches/world.rs
@@ -13,7 +13,7 @@ fn anvil_benchmark(c: &mut Criterion) {
         region_folder: PathBuf::from("../.etc/regions"),
     };
     let reader = pumpkin_world::chunk::anvil::AnvilChunkReader::new();
-    group.bench_function("Old", |b| b.iter(|| {
+    group.bench_function("Custom", |b| b.iter(|| {
         black_box(reader.read_chunk(&save_file, Vector2::new(0, 0)).unwrap());
     }));
     

--- a/pumpkin-world/benches/world.rs
+++ b/pumpkin-world/benches/world.rs
@@ -6,29 +6,40 @@ use std::path::PathBuf;
 
 fn anvil_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("AnvilChunkReader");
-    
+
     // Our method
     let save_file = SaveFile {
         root_folder: PathBuf::from(""),
         region_folder: PathBuf::from("../.etc/regions"),
     };
     let reader = pumpkin_world::chunk::anvil::AnvilChunkReader::new();
-    group.bench_function("Custom", |b| b.iter(|| {
-        black_box(reader.read_chunk(&save_file, Vector2::new(0, 0)).unwrap());
-    }));
-    
+    group.bench_function("Custom", |b| {
+        b.iter(|| {
+            black_box(reader.read_chunk(&save_file, Vector2::new(0, 0)).unwrap());
+        })
+    });
+
     // Memory-mapped
-    let loaded_mapped_file = pumpkin_world::chunk::unsafe_anvil::load_anvil_file(PathBuf::from("../.etc/regions/r.0.0.mca")).unwrap();
-    group.bench_function("MMap", |b| b.iter(|| {
-        black_box(loaded_mapped_file.get_chunk(0, 0).unwrap());
-    }));
-    
+    let loaded_mapped_file = pumpkin_world::chunk::unsafe_anvil::load_anvil_file(PathBuf::from(
+        "../.etc/regions/r.0.0.mca",
+    ))
+    .unwrap();
+    group.bench_function("MMap", |b| {
+        b.iter(|| {
+            black_box(loaded_mapped_file.get_chunk(0, 0).unwrap());
+        })
+    });
+
     // FastAnvil
-    let mut fast_region = fastanvil::Region::from_stream(std::fs::File::open("../.etc/regions/r.0.0.mca").unwrap()).unwrap();
-    group.bench_function("FastAnvil", |b| b.iter(|| {
-        black_box(fast_region.read_chunk(0, 0).unwrap());
-    }));
-    
+    let mut fast_region =
+        fastanvil::Region::from_stream(std::fs::File::open("../.etc/regions/r.0.0.mca").unwrap())
+            .unwrap();
+    group.bench_function("FastAnvil", |b| {
+        b.iter(|| {
+            black_box(fast_region.read_chunk(0, 0).unwrap());
+        })
+    });
+
     group.finish();
 }
 

--- a/pumpkin-world/benches/world.rs
+++ b/pumpkin-world/benches/world.rs
@@ -1,0 +1,36 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use pumpkin_core::math::vector2::Vector2;
+use pumpkin_world::chunk::ChunkReader;
+use pumpkin_world::level::SaveFile;
+use std::path::PathBuf;
+
+fn anvil_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("AnvilChunkReader");
+    
+    // Our method
+    let save_file = SaveFile {
+        root_folder: PathBuf::from(""),
+        region_folder: PathBuf::from("../.etc/regions"),
+    };
+    let reader = pumpkin_world::chunk::anvil::AnvilChunkReader::new();
+    group.bench_function("Old", |b| b.iter(|| {
+        black_box(reader.read_chunk(&save_file, Vector2::new(0, 0)).unwrap());
+    }));
+    
+    // Memory-mapped
+    let loaded_mapped_file = pumpkin_world::chunk::unsafe_anvil::load_anvil_file(PathBuf::from("../.etc/regions/r.0.0.mca")).unwrap();
+    group.bench_function("MMap", |b| b.iter(|| {
+        black_box(loaded_mapped_file.get_chunk(0, 0).unwrap());
+    }));
+    
+    // FastAnvil
+    let mut fast_region = fastanvil::Region::from_stream(std::fs::File::open("../.etc/regions/r.0.0.mca").unwrap()).unwrap();
+    group.bench_function("FastAnvil", |b| b.iter(|| {
+        black_box(fast_region.read_chunk(0, 0).unwrap());
+    }));
+    
+    group.finish();
+}
+
+criterion_group!(benches, anvil_benchmark);
+criterion_main!(benches);

--- a/pumpkin-world/src/chunk/anvil.rs
+++ b/pumpkin-world/src/chunk/anvil.rs
@@ -21,33 +21,39 @@ impl AnvilChunkReader {
 }
 
 impl ChunkReader for AnvilChunkReader {
-    fn read_chunk(&self, save_file: &SaveFile, at: Vector2<i32>) -> Result<ChunkData, ChunkReadingError> {
+    fn read_chunk(
+        &self,
+        save_file: &SaveFile,
+        at: Vector2<i32>,
+    ) -> Result<ChunkData, ChunkReadingError> {
         // Calculate the region file's name
         let region = (
             ((at.x as f32) / 32.0).floor() as i32,
             ((at.z as f32) / 32.0).floor() as i32,
         );
 
-        let mut region_file =
-            File::open(
-                save_file
-                    .region_folder
-                    .join(format!("r.{}.{}.mca", region.0, region.1)),
-            )
-                .map_err(|err| match err.kind() {
-                    std::io::ErrorKind::NotFound => ChunkReadingError::ChunkNotExist,
-                    kind => ChunkReadingError::IoError(kind),
-                })?;
-
+        let mut region_file = File::open(
+            save_file
+                .region_folder
+                .join(format!("r.{}.{}.mca", region.0, region.1)),
+        )
+        .map_err(|err| match err.kind() {
+            std::io::ErrorKind::NotFound => ChunkReadingError::ChunkNotExist,
+            kind => ChunkReadingError::IoError(kind),
+        })?;
 
         // Figure out the index of the location table where the chunk is stored
         let index = 4 * ((at.x as u64 % 32) + (at.z as u64 % 32) * 32);
-        region_file.seek(std::io::SeekFrom::Start(index * 4)).map_err(|_| ChunkReadingError::RegionIsInvalid)?;
-        let location = region_file.read_u32::<BigEndian>().map_err(|_| ChunkReadingError::RegionIsInvalid)?;
-        
+        region_file
+            .seek(std::io::SeekFrom::Start(index * 4))
+            .map_err(|_| ChunkReadingError::RegionIsInvalid)?;
+        let location = region_file
+            .read_u32::<BigEndian>()
+            .map_err(|_| ChunkReadingError::RegionIsInvalid)?;
+
         // If you want the timestamp for whatever reason, you can read it here
         // let timestamp = region_file.read_u32::<BigEndian>().map_err(|_| ChunkReadingError::RegionIsInvalid)?;
-        
+
         // Using the location data, read the chunk data. I have no idea how this works, I stole it off
         // wiki.vg/Region_Files
         let offset = ((location >> 8) & 0xFFFFFF) * 4096;
@@ -60,30 +66,39 @@ impl ChunkReader for AnvilChunkReader {
 
         // Read the chunk data
         let mut chunk_data = vec![0u8; size as usize];
-        region_file.seek(std::io::SeekFrom::Start(offset as u64)).map_err(|_| ChunkReadingError::RegionIsInvalid)?;
-        region_file.read_exact(&mut chunk_data).map_err(|_| ChunkReadingError::RegionIsInvalid)?;
+        region_file
+            .seek(std::io::SeekFrom::Start(offset as u64))
+            .map_err(|_| ChunkReadingError::RegionIsInvalid)?;
+        region_file
+            .read_exact(&mut chunk_data)
+            .map_err(|_| ChunkReadingError::RegionIsInvalid)?;
 
         // Parse the chunk data
         let chunk_header = chunk_data[0..4].to_vec();
         let chunk_compressed_data = chunk_data[5..].to_vec();
-        
+
         let uncompressed_size = u32::from(chunk_header[0]) << 24
             | u32::from(chunk_header[1]) << 16
             | u32::from(chunk_header[2]) << 8
             | u32::from(chunk_header[3]);
-        
+
         // Decompress the chunk data
         let compression_type = chunk_data[4];
         let res = match compression_type {
             1 => {
                 let mut decompressed_data = Vec::new();
                 let mut decoder = flate2::read::GzDecoder::new(&chunk_compressed_data[..]);
-                decoder.read_to_end(&mut decompressed_data).map_err(|e| ChunkReadingError::Compression(CompressionError::GZipError(e)))?;
+                decoder
+                    .read_to_end(&mut decompressed_data)
+                    .map_err(|e| ChunkReadingError::Compression(CompressionError::GZipError(e)))?;
                 Some(decompressed_data)
             }
             2 => {
-                let mut decompressor = zune_inflate::DeflateDecoder::new(&chunk_compressed_data[..]);
-                Some(decompressor.decode_zlib().map_err(|e| ChunkReadingError::Compression(CompressionError::ZuneZlibError(e)))?)
+                let mut decompressor =
+                    zune_inflate::DeflateDecoder::new(&chunk_compressed_data[..]);
+                Some(decompressor.decode_zlib().map_err(|e| {
+                    ChunkReadingError::Compression(CompressionError::ZuneZlibError(e))
+                })?)
             }
             3 => Some(chunk_compressed_data),
             4 => {
@@ -94,13 +109,17 @@ impl ChunkReader for AnvilChunkReader {
                 Some(decompressed_data)
             }
             _ => {
-                return Err(ChunkReadingError::Compression(CompressionError::UnknownCompression));
+                return Err(ChunkReadingError::Compression(
+                    CompressionError::UnknownCompression,
+                ));
             }
-        }.ok_or(ChunkReadingError::Compression(CompressionError::UnknownCompression))?;
+        }
+        .ok_or(ChunkReadingError::Compression(
+            CompressionError::UnknownCompression,
+        ))?;
         ChunkData::from_bytes(res, at).map_err(ChunkReadingError::ParsingError)
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -110,23 +129,29 @@ mod tests {
     #[test]
     fn test_bad_load_fails() {
         let file_path = PathBuf::from("../.etc/shouldnotexist/");
-        let result = AnvilChunkReader::new().read_chunk(&SaveFile {
-            root_folder: PathBuf::from(""),
-            region_folder: file_path.clone(),
-        }, Vector2::new(0, 0));
+        let result = AnvilChunkReader::new().read_chunk(
+            &SaveFile {
+                root_folder: PathBuf::from(""),
+                region_folder: file_path.clone(),
+            },
+            Vector2::new(0, 0),
+        );
         assert!(result.is_err());
     }
 
     #[test]
     fn test_get_chunk() {
         let file_path = PathBuf::from("../.etc/regions");
-        let loaded_file = AnvilChunkReader::new().read_chunk(&SaveFile {
-            root_folder: PathBuf::from(""),
-            region_folder: file_path.clone(),
-        }, Vector2::new(0, 0));
+        let loaded_file = AnvilChunkReader::new().read_chunk(
+            &SaveFile {
+                root_folder: PathBuf::from(""),
+                region_folder: file_path.clone(),
+            },
+            Vector2::new(0, 0),
+        );
         assert!(loaded_file.is_ok());
         assert_eq!(loaded_file.unwrap().position, Vector2::new(0, 0));
     }
-    
+
     // TODO: Write better tests, these are utter shit
 }

--- a/pumpkin-world/src/chunk/anvil.rs
+++ b/pumpkin-world/src/chunk/anvil.rs
@@ -1,6 +1,5 @@
 use crate::level::SaveFile;
 use byteorder::{BigEndian, ReadBytesExt};
-use flate2::bufread::{GzDecoder, ZlibDecoder};
 use pumpkin_core::math::vector2::Vector2;
 use std::fs::File;
 use std::io::{Read, Seek};
@@ -21,68 +20,9 @@ impl AnvilChunkReader {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Compression {
-    /// GZip Compression
-    GZip,
-    /// ZLib Compression
-    ZLib,
-    /// Uncompressed (since a version before 1.15.1)
-    None,
-    /// LZ4 Compression (since 24w04a)
-    LZ4,
-    /// Custom compression algorithm (since 24w05a)
-    Custom,
-}
-
-impl Compression {
-    pub fn from_byte(byte: u8) -> Option<Self> {
-        match byte {
-            1 => Some(Self::GZip),
-            2 => Some(Self::ZLib),
-            3 => Some(Self::None),
-            4 => Some(Self::LZ4),
-            // Creative i guess?
-            127 => Some(Self::Custom),
-            _ => None,
-        }
-    }
-
-    fn decompress_data(&self, compressed_data: Vec<u8>) -> Result<Vec<u8>, CompressionError> {
-        match self {
-            Compression::GZip => {
-                let mut decoder = GzDecoder::new(&compressed_data[..]);
-                let mut chunk_data = Vec::new();
-                decoder
-                    .read_to_end(&mut chunk_data)
-                    .map_err(CompressionError::GZipError)?;
-                Ok(chunk_data)
-            }
-            Compression::ZLib => {
-                let mut decoder = ZlibDecoder::new(&compressed_data[..]);
-                let mut chunk_data = Vec::new();
-                decoder
-                    .read_to_end(&mut chunk_data)
-                    .map_err(CompressionError::ZlibError)?;
-                Ok(chunk_data)
-            }
-            Compression::None => Ok(compressed_data),
-            Compression::LZ4 => {
-                let mut decoder = lz4::Decoder::new(compressed_data.as_slice())
-                    .map_err(CompressionError::LZ4Error)?;
-                let mut decompressed_data = Vec::new();
-                decoder
-                    .read_to_end(&mut decompressed_data)
-                    .map_err(CompressionError::LZ4Error)?;
-                Ok(decompressed_data)
-            }
-            Compression::Custom => todo!(),
-        }
-    }
-}
-
 impl ChunkReader for AnvilChunkReader {
     fn read_chunk(&self, save_file: &SaveFile, at: Vector2<i32>) -> Result<ChunkData, ChunkReadingError> {
+        // Calculate the region file's name
         let region = (
             ((at.x as f32) / 32.0).floor() as i32,
             ((at.z as f32) / 32.0).floor() as i32,
@@ -100,38 +40,50 @@ impl ChunkReader for AnvilChunkReader {
                 })?;
 
 
+        // Figure out the index of the location table where the chunk is stored
         let index = 4 * ((at.x as u64 % 32) + (at.z as u64 % 32) * 32);
         region_file.seek(std::io::SeekFrom::Start(index * 4)).map_err(|_| ChunkReadingError::RegionIsInvalid)?;
         let location = region_file.read_u32::<BigEndian>().map_err(|_| ChunkReadingError::RegionIsInvalid)?;
-
+        
+        // If you want the timestamp for whatever reason, you can read it here
+        // let timestamp = region_file.read_u32::<BigEndian>().map_err(|_| ChunkReadingError::RegionIsInvalid)?;
+        
+        // Using the location data, read the chunk data. I have no idea how this works, I stole it off
+        // wiki.vg/Region_Files
         let offset = ((location >> 8) & 0xFFFFFF) * 4096;
         let size = (location & 0xFF) * 4096;
 
+        // If the offset is 0, the chunk does not exist
         if offset == 0 && size == 0 {
             return Err(ChunkReadingError::ChunkNotExist);
         }
 
+        // Read the chunk data
         let mut chunk_data = vec![0u8; size as usize];
         region_file.seek(std::io::SeekFrom::Start(offset as u64)).map_err(|_| ChunkReadingError::RegionIsInvalid)?;
         region_file.read_exact(&mut chunk_data).map_err(|_| ChunkReadingError::RegionIsInvalid)?;
 
+        // Parse the chunk data
         let chunk_header = chunk_data[0..4].to_vec();
         let chunk_compressed_data = chunk_data[5..].to_vec();
+        
         let uncompressed_size = u32::from(chunk_header[0]) << 24
             | u32::from(chunk_header[1]) << 16
             | u32::from(chunk_header[2]) << 8
             | u32::from(chunk_header[3]);
+        
+        // Decompress the chunk data
         let compression_type = chunk_data[4];
         let res = match compression_type {
             1 => {
                 let mut decompressed_data = Vec::new();
                 let mut decoder = flate2::read::GzDecoder::new(&chunk_compressed_data[..]);
-                decoder.read_to_end(&mut decompressed_data).unwrap();
+                decoder.read_to_end(&mut decompressed_data).map_err(|e| ChunkReadingError::Compression(CompressionError::GZipError(e)))?;
                 Some(decompressed_data)
             }
             2 => {
                 let mut decompressor = zune_inflate::DeflateDecoder::new(&chunk_compressed_data[..]);
-                Some(decompressor.decode_zlib().unwrap())
+                Some(decompressor.decode_zlib().map_err(|e| ChunkReadingError::Compression(CompressionError::ZuneZlibError(e)))?)
             }
             3 => Some(chunk_compressed_data),
             4 => {
@@ -142,7 +94,7 @@ impl ChunkReader for AnvilChunkReader {
                 Some(decompressed_data)
             }
             _ => {
-                None
+                return Err(ChunkReadingError::Compression(CompressionError::UnknownCompression));
             }
         }.ok_or(ChunkReadingError::Compression(CompressionError::UnknownCompression))?;
         ChunkData::from_bytes(res, at).map_err(ChunkReadingError::ParsingError)
@@ -175,4 +127,6 @@ mod tests {
         assert!(loaded_file.is_ok());
         assert_eq!(loaded_file.unwrap().position, Vector2::new(0, 0));
     }
+    
+    // TODO: Write better tests, these are utter shit
 }

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 use std::collections::HashMap;
 use std::ops::Index;
-
+use std::path::PathBuf;
 use fastnbt::LongArray;
 use pumpkin_core::math::vector2::Vector2;
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,7 @@ use crate::{
 };
 
 pub mod anvil;
+pub mod unsafe_anvil;
 
 const CHUNK_AREA: usize = 16 * 16;
 const SUBCHUNK_VOLUME: usize = CHUNK_AREA * 16;
@@ -40,6 +41,8 @@ pub enum ChunkReadingError {
     ChunkNotExist,
     #[error("Failed to parse Chunk from bytes: {0}")]
     ParsingError(ChunkParsingError),
+    #[error("Failed to find region file: {0}")]
+    RegionNotFound(PathBuf),
 }
 
 #[derive(Error, Debug)]
@@ -320,4 +323,6 @@ pub enum ChunkParsingError {
     ChunkNotGenerated,
     #[error("Error deserializing chunk: {0}")]
     ErrorDeserializingChunk(String),
+    #[error("Invalid region data: {0}")]
+    InvalidRegionData(PathBuf),
 }

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -51,6 +51,8 @@ pub enum CompressionError {
     UnknownCompression,
     #[error("Error while working with zlib compression: {0}")]
     ZlibError(std::io::Error),
+    #[error("Error while working with zune's zlib decompression: {0}")]
+    ZuneZlibError(zune_inflate::errors::InflateDecodeErrors),
     #[error("Error while working with Gzip compression: {0}")]
     GZipError(std::io::Error),
     #[error("Error while working with LZ4 compression: {0}")]

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -1,10 +1,10 @@
+use fastnbt::LongArray;
+use pumpkin_core::math::vector2::Vector2;
+use serde::{Deserialize, Serialize};
 use std::cmp::max;
 use std::collections::HashMap;
 use std::ops::Index;
 use std::path::PathBuf;
-use fastnbt::LongArray;
-use pumpkin_core::math::vector2::Vector2;
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{

--- a/pumpkin-world/src/chunk/unsafe_anvil.rs
+++ b/pumpkin-world/src/chunk/unsafe_anvil.rs
@@ -1,0 +1,230 @@
+use std::io::Read;
+use std::path::PathBuf;
+use memmap2::Mmap;
+use tracing::error;
+use crate::chunk::{ChunkParsingError, ChunkReadingError};
+
+pub struct LoadedAnvilFile {
+    pub table: [u8; 4096],
+    data_map: Mmap,
+}
+
+pub fn get_chunk(x: u32, z: u32, file_path: PathBuf) -> Option<Vec<u8>> {
+    let loaded_file = load_anvil_file(file_path).ok()?;
+    loaded_file.get_chunk(x, z)
+}
+
+/// Memory map the file and return a `LoadedAnvilFile` struct
+///
+/// The `LoadedAnvilFile` struct contains the table and the data map and can be used to get chunk data
+///
+/// This is pretty fragile when it comes to things like other programs writing to the file while it's open
+/// so be careful when using this and make sure to handle errors gracefully
+///
+/// Arguments:
+///
+/// * `file_path` - The path to the file
+///
+/// Returns:
+///
+/// * `Result<LoadedAnvilFile, ChunkReadingError>` - The loaded anvil file
+///
+/// # Examples
+///
+/// ```no_run
+/// use fastanvil::Region;
+/// use std::path::PathBuf;
+/// use crate::pumpkin_world::chunk::unsafe_anvil::load_anvil_file;
+///
+/// let file_path = PathBuf::from("r.0.0.mca");
+///
+/// let mut fast_file = Region::from_stream(file_path.clone()).unwrap();
+/// let loaded_file = load_anvil_file(file_path).unwrap();
+///
+/// let chunk = loaded_file.get_chunk(0, 0);
+/// let fast_chunk = fast_file.read_chunk(0, 0).unwrap();
+///
+/// assert_eq!(chunk, fast_chunk);
+/// ```
+#[allow(unsafe_code)]
+pub fn load_anvil_file(file_path: PathBuf) -> Result<LoadedAnvilFile, ChunkReadingError> {
+
+    // Check if the file exists
+    if !file_path.exists() {
+        return Err(ChunkReadingError::RegionNotFound(file_path));
+    }
+
+    match file_path.metadata() {
+        Ok(meta) => {
+            // We should have at least 8KB of data; 4KB for locations and 4KB for timestamps
+            if meta.len() <= (4 * 1024) * 2 {
+                return Err(ChunkReadingError::ParsingError(ChunkParsingError::InvalidRegionData(file_path)));
+            }
+        }
+        Err(e) => {
+            return Err(ChunkReadingError::IoError(e.kind()));
+        }
+    }
+
+    let file = std::fs::File::open(&file_path).map_err(
+        |e| ChunkReadingError::IoError(e.kind())
+    )?;
+
+    let res = unsafe { Mmap::map(&file) }.map_err(
+        |e| ChunkReadingError::IoError(e.kind())
+    )?;
+
+    let table = {
+        let mut table = [0; 4096];
+        table.copy_from_slice(&res[0..4096]);
+        table
+    };
+
+    Ok(LoadedAnvilFile {
+        table,
+        data_map: res,
+    })
+}
+
+
+impl LoadedAnvilFile {
+    /// Get all the locations from the table
+    ///
+    /// The locations are 32-bit integers, where the first 24 bits are the offset in the file, and
+    /// the last 8 bits are the size of the chunk. Generally these aren't useful on their own, but
+    /// can be used to get the chunk data with `get_chunk_from_location`. They are probably in order
+    /// but not guaranteed to be
+    pub fn get_locations(&self) -> Vec<u32> {
+        (0..1024).map(|i| {
+            u32::from(self.table[i * 4]) << 24
+                | u32::from(self.table[i * 4 + 1]) << 16
+                | u32::from(self.table[i * 4 + 2]) << 8
+                | u32::from(self.table[i * 4 + 3])
+        })
+            .filter(|&x| x != 0)
+            .collect::<Vec<u32>>()
+    }
+
+    /// Get the data from the mmaped file, given an offset and size
+    #[allow(unsafe_code)]
+    fn get_data_from_file(&self, offset: u32, size: u32) -> Vec<u8> {
+        unsafe {
+            let start = self.data_map.as_ptr().add(offset as usize);
+            let slice = std::slice::from_raw_parts(start, size as usize);
+            slice.to_vec()
+        }
+    }
+
+    /// Get the chunk data from a location
+    ///
+    /// Given a location (usually gotten from `get_locations`), this function will return the
+    /// decompressed chunk data associated with that location.
+    pub fn get_chunk_from_location(&self, location: u32) -> Option<Vec<u8>> {
+        let offset = ((location >> 8) & 0xFFFFFF) * 4096;
+        let size = (location & 0xFF) * 4096;
+        let chunk_data = self.get_data_from_file(offset, size);
+        let chunk_header = chunk_data[0..4].to_vec();
+        let chunk_compressed_data = chunk_data[5..].to_vec();
+        let uncompressed_size = u32::from(chunk_header[0]) << 24
+            | u32::from(chunk_header[1]) << 16
+            | u32::from(chunk_header[2]) << 8
+            | u32::from(chunk_header[3]);
+        let compression_type = chunk_data[4];
+        match compression_type {
+            1 => {
+                let mut decompressed_data = Vec::new();
+                let mut decoder = flate2::read::GzDecoder::new(&chunk_compressed_data[..]);
+                decoder.read_to_end(&mut decompressed_data).unwrap();
+                Some(decompressed_data)
+            }
+            2 => {
+                let out = yazi::decompress(&chunk_compressed_data[..], yazi::Format::Zlib).ok();
+                match out {
+                    Some(data) => Some(data.0),
+                    None => {
+                        error!("Failed to decompress Zlib data");
+                        None
+                    }
+                }
+            }
+            3 => Some(chunk_compressed_data),
+            4 => {
+                let mut decompressed_data = vec![0; uncompressed_size as usize];
+                lz4::Decoder::new(&chunk_compressed_data[..])
+                    .and_then(|mut decoder| decoder.read_exact(&mut decompressed_data))
+                    .ok()?;
+                Some(decompressed_data)
+            }
+            _ => {
+                error!("Unknown compression type: {}", compression_type);
+                None
+            }
+        }
+    }
+
+    /// Get the chunk data from the table
+    ///
+    /// The x and z coordinates are the chunk coordinates
+    ///
+    /// This function will return the decompressed chunk data
+    pub fn get_chunk(&self, x: u32, z: u32) -> Option<Vec<u8>> {
+        let index = u64::from(4 * ((x % 32) + (z % 32) * 32));
+        let location = u32::from(self.table[index as usize * 4]) << 24
+            | u32::from(self.table[index as usize * 4 + 1]) << 16
+            | u32::from(self.table[index as usize * 4 + 2]) << 8
+            | u32::from(self.table[index as usize * 4 + 3]);
+        self.get_chunk_from_location(location)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Read;
+    use fastanvil::Region;
+    use super::*;
+    use rayon::prelude::*;
+
+    #[test]
+    fn test_load_anvil_file() {
+        let file_path = PathBuf::from("../.etc/regions/r.0.0.mca");
+        let result = load_anvil_file(file_path.clone());
+        assert!(result.is_ok());
+        let loaded_file = result.unwrap();
+        let mut file = File::open(file_path).unwrap();
+        let mut buf: [u8; 4096] = [0; 4096];
+        file.read_exact(&mut buf).unwrap();
+        assert_eq!(loaded_file.table, buf);
+    }
+
+    #[test]
+    fn test_bad_load_fails() {
+        let file_path = PathBuf::from("../.etc/regions/shouldnotexist.mca");
+        let result = load_anvil_file(file_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_chunk() {
+        let file_path = PathBuf::from("../.etc/regions/r.0.0.mca");
+        let loaded_file = load_anvil_file(file_path.clone()).unwrap();
+        let chunk = loaded_file.get_chunk(0, 0);
+        let fast_chunk = Region::from_stream(File::open(file_path).unwrap()).unwrap().read_chunk(0, 0).unwrap();
+        assert!(chunk.is_some());
+        assert!(fast_chunk.is_some());
+        assert_eq!(chunk.clone().unwrap(), fast_chunk.unwrap());
+    }
+
+    #[test]
+    fn test_get_chunk_from_location() {
+        let file_path = PathBuf::from("../.etc/regions/r.0.0.mca");
+        let loaded_file = load_anvil_file(file_path).unwrap();
+        let locations = loaded_file.get_locations();
+        locations.chunks(96).par_bridge().for_each(|chunk| {
+            chunk.iter().for_each(|location| {
+                let _ = loaded_file.get_chunk_from_location(*location);
+            });
+        });
+    }
+}

--- a/pumpkin-world/src/chunk/unsafe_anvil.rs
+++ b/pumpkin-world/src/chunk/unsafe_anvil.rs
@@ -32,13 +32,14 @@ pub fn get_chunk(x: u32, z: u32, file_path: PathBuf) -> Option<Vec<u8>> {
 /// # Examples
 ///
 /// ```no_run
+/// use std::fs::File;
 /// use fastanvil::Region;
 /// use std::path::PathBuf;
 /// use crate::pumpkin_world::chunk::unsafe_anvil::load_anvil_file;
 ///
 /// let file_path = PathBuf::from("r.0.0.mca");
 ///
-/// let mut fast_file = Region::from_stream(file_path.clone()).unwrap();
+/// let mut fast_file = Region::from_stream(File::open(file_path.clone()).unwrap()).unwrap();
 /// let loaded_file = load_anvil_file(file_path).unwrap();
 ///
 /// let chunk = loaded_file.get_chunk(0, 0);

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -27,8 +27,7 @@ pub struct Level {
 }
 
 pub struct SaveFile {
-    #[expect(dead_code)]
-    root_folder: PathBuf,
+    pub root_folder: PathBuf,
     pub region_folder: PathBuf,
 }
 
@@ -73,7 +72,7 @@ impl Level {
     ///
     /// Note: The order of the output chunks will almost never be in the same order as the order of input chunks
     pub fn fetch_chunks(
-        &self,
+        &mut self,
         chunks: &[Vector2<i32>],
         channel: mpsc::Sender<Arc<ChunkData>>,
         is_alive: bool,

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -83,7 +83,7 @@ const fn convert_logger_filter(level: pumpkin_config::logging::LevelFilter) -> L
 async fn main() -> io::Result<()> {
     use std::sync::Arc;
 
-    use entity::player::Player;
+    
     use pumpkin_config::{ADVANCED_CONFIG, BASIC_CONFIG};
     use pumpkin_core::text::{color::NamedColor, TextComponent};
     use rcon::RCONServer;

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -248,7 +248,7 @@ impl World {
         let closed = client.closed.load(std::sync::atomic::Ordering::Relaxed);
         let chunks = Arc::new(chunks);
         tokio::spawn(async move {
-            let level = level.lock().await;
+            let mut level = level.lock().await;
             level.fetch_chunks(&chunks, sender, closed)
         });
 


### PR DESCRIPTION
I have rewritten the anvil parsing system to read as little data as possible. It no longer stores a location table in memory since that is only useful if we are going to reuse it and since we have no caching system for it, we can't.
Instead of storing the table in memory, it now calculates and reads only the bytes it needs. I have also switched out the ZLib decompression library for Zune, which does perform slightly better. 
I have also attached my memory-mapped implementation as well for consideration, though it does use some unsafe code.
Overall, it now performs about 15% faster (~440 µs, down from ~515 µs), but still nowhere near FastAnvil or the memory map implementation (~85 µs and 75 µs respectively). Benchmarks and unit tests are included