### PR TITLE
Format numbers and dates per region

### DIFF
--- a/docs/.vitepress/components/FmtDateTime.vue
+++ b/docs/.vitepress/components/FmtDateTime.vue
@@ -1,0 +1,19 @@
+<script setup>
+import { computed, getCurrentInstance } from 'vue';
+
+const props = defineProps({
+    d: {
+        type: Date,
+        required: true
+    }
+});
+
+const formattedDateTime = computed(() => {
+    return getCurrentInstance().appContext.config.globalProperties.$dateTimeFormatter.format(props.d);
+});
+</script>
+
+
+<template>
+{{ formattedDateTime }}
+</template>

--- a/docs/.vitepress/components/FmtNum.vue
+++ b/docs/.vitepress/components/FmtNum.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { computed, getCurrentInstance } from 'vue';
+
+const props = defineProps({
+    n: {
+        type: Number,
+        required: true
+    }
+});
+
+const formattedNumber = computed(() => {
+    return getCurrentInstance().appContext.config.globalProperties.$numberFormatter.format(props.n);
+});
+</script>
+
+<template>
+{{ formattedNumber }}
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,8 @@ import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import './style.css'
+import FmtNum from '../components/FmtNum.vue'
+import FmtDateTime from '../components/FmtDateTime.vue'
 
 export default {
   extends: DefaultTheme,
@@ -12,6 +14,16 @@ export default {
     })
   },
   enhanceApp({ app, router, siteData }) {
-    // ...
+    app.config.globalProperties.$numberFormatter = new Intl.NumberFormat(navigator.languages);
+    app.config.globalProperties.$dateTimeFormatter = new Intl.DateTimeFormat(navigator.languages, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      timeZoneName: "short"
+    });
+    app.component('FmtNum', FmtNum);
+    app.component('FmtDateTime', FmtDateTime);
   }
 } satisfies Theme

--- a/docs/about/benchmarks.md
+++ b/docs/about/benchmarks.md
@@ -2,14 +2,6 @@
 
 Here, common Minecraft servers are compared against Pumpkin.
 
-> [!NOTE]
-> All tests have been ran multiple times to guarantee consistent results.
-> All players did not move when spawning, only the initial 8 chunks were loaded.
-> All servers used their own terrain generation, no world was pre-loaded.
-
-> [!IMPORTANT]
-> `CPU Max` is usually higher with one player is as the initial chunks are being loaded.
-
 > [!CAUTION]
 > **This comparison is unfair.** Pumpkin currently has far fewer features than other servers, which might suggest it uses fewer resources.
 > It's also important to consider that other servers have had years for optimization.
@@ -55,6 +47,14 @@ Here, common Minecraft servers are compared against Pumpkin.
 - Rcon: false
 
 <sub><sup>online mode was disabled for easier testing with non-premium accounts</sup></sub>
+
+> [!NOTE]
+> All tests have been ran multiple times to guarantee consistent results.
+> All players did not move when spawning, only the initial 8 chunks were loaded.
+> All servers used their own terrain generation, no world was pre-loaded.
+
+> [!IMPORTANT]
+> `CPU Max` is usually higher with one player as the initial chunks are being loaded.
 
 ## Pumpkin
 

--- a/docs/about/benchmarks.md
+++ b/docs/about/benchmarks.md
@@ -105,13 +105,13 @@ Run args: `nogui`
 
 **Shutdown time:** <FmtNum :n=4 />sec
 
-| Players | RAM                | CPU idle                             | CPU Max |
-| ------- | ------------------ | ------------------------------------ | ------- |
-| 0       | 860MB              | <FmtNum n=0.1 /> - <FmtNum n=0.3 />% | 51%     |
-| 1       | <FmtNum n=1.5 />GB | <FmtNum n=0.9 /> - 1%                | 41%     |
-| 2       | <FmtNum n=1.6 />GB | 1 - <FmtNum n=1.1 />%                | 10%     |
-| 5       | <FmtNum n=1.8 />GB | 2%                                   | 20%     |
-| 10      | <FmtNum n=2.2 />GB | 4%                                   | 24%     |
+| Players | RAM                   | CPU idle                                 | CPU Max            |
+| ------- | --------------------- | ---------------------------------------- | ------------------ |
+| 0       | <FmtNum n="860" />MB  | <FmtNum n="0.1" /> - <FmtNum n="0.3" />% | <FmtNum n="51" />% |
+| 1       | <FmtNum n="1.5" />GB  | <FmtNum n="0.9" /> - <FmtNum n="1" />%   | <FmtNum n="41" />% |
+| 2       | <FmtNum n="1.6" />GB  | <FmtNum n="1" /> - <FmtNum n="1.1" />%   | <FmtNum n="10" />% |
+| 5       | <FmtNum n="1.8" />GB  | <FmtNum n="2" />%                        | <FmtNum n="20" />% |
+| 10      | <FmtNum n="2.2" />GB  | <FmtNum n="4" />%                        | <FmtNum n="24" />% |
 
 ## Paper
 

--- a/docs/about/benchmarks.md
+++ b/docs/about/benchmarks.md
@@ -1,13 +1,19 @@
-## Benchmarks
+# Benchmarks
 
-Here, I compare common Minecraft servers against Pumpkin.
+Here, common Minecraft servers are compared against Pumpkin.
 
-Is this comparison fair? Not really. While Pumpkin currently has far fewer features than other servers, which might suggest it uses fewer resources, it's important to consider that other servers have had years for optimization. Especially vanilla forks, which don’t need to rewrite the entire vanilla logic, can focus exclusively on optimizations.
+> [!NOTE]
+> All tests have been ran multiple times to guarantee consistent results.
+> All players did not move when spawning, only the initial 8 chunks were loaded.
+> All servers used their own terrain generation, no world was pre-loaded.
 
-ALL TESTS HAVE BEEN RAN MULTIPLE TIMES TO GUARANTEE CONSISTENT RESULTS
+> [!IMPORTANT]
+> `CPU Max` is usually higher with one player is as the initial chunks are being loaded.
 
-ALL PLAYERS DID NOT MOVE WHEN SPAWNING, ONLY THE INITIAL 8 CHUNKS WERE LOADED, THAT'S ALSO THE REASON CPU MAX IS USUALLY HIGH ON THE FIRST PLAYER
-ALL SERVERS USED THEIR OWN TERRAIN GENERATION, NO WORLD WAS PRE-LOADED
+> [!CAUTION]
+> **This comparison is unfair.** Pumpkin currently has far fewer features than other servers, which might suggest it uses fewer resources.
+> It's also important to consider that other servers have had years for optimization.
+> Vanilla forks, which don’t need to rewrite the entire vanilla logic, can focus exclusively on optimizations.
 
 ![Screenshot From 2024-10-15 16-42-53](https://github.com/user-attachments/assets/e08fbb00-42fe-4479-a03b-11bb6886c91a)
 
@@ -54,36 +60,36 @@ ALL SERVERS USED THEIR OWN TERRAIN GENERATION, NO WORLD WAS PRE-LOADED
 
 Build: [8febc50](https://github.com/Snowiiii/Pumpkin/commit/8febc5035d5611558c13505b7724e6ca284e0ada)
 
-Compile args:`--release`
+Compile args: `--release`
 
 Run args:
 
-**File Size:** 12,3MB
+**File Size:** <FmtNum :n=12.3 />MB
 
-**Startup time:** 8ms
+**Startup time:** <FmtNum :n=8 />ms
 
-**Shutdown time:** 0ms
+**Shutdown time:** <FmtNum :n=0 />ms
 
-| Players | RAM     | CPU idle | CPU Max |
-| ------- | ------- | -------- | ------- |
-| 0       | 392,2KB | 0,0%     | 0,0%    |
-| 1       | 24,9MB  | 0,0%     | 4,0%    |
-| 2       | 25,1MB  | 0,0%     | 0,6%    |
-| 5       | 26,0MB  | 0,0%     | 1,0%    |
-| 10      | 27,1MB  | 0,0%     | 1,5%    |
+| Players | RAM                   | CPU Idle         | CPU Max            |
+| ------- | --------------------- | ---------------- | ------------------ |
+| 0       | <FmtNum :n=392.2 />KB | <FmtNum :n=0 />% | <FmtNum :n=0 />%   |
+| 1       | <FmtNum :n=24.9 />MB  | <FmtNum :n=0 />% | <FmtNum :n=4 />%   |
+| 2       | <FmtNum :n=25.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=0.6 />% |
+| 5       | <FmtNum :n=26 />MB    | <FmtNum :n=0 />% | <FmtNum :n=1 />%   |
+| 10      | <FmtNum :n=27.1 />MB  | <FmtNum :n=0 />% | <FmtNum :n=1.5 />% |
 
-<sub><sup>pumpkin does cache already loaded chunks, resulting in no extra RAM usage besides player data and minimal CPU usage</sup></sub>
+<sub><sup>Pumpkin does cache already loaded chunks, resulting in no extra RAM usage besides player data and minimal CPU usage.</sup></sub>
 
 #### Compile time
-Compiling from Nothing
+Compiling from Nothing:
 
-**Debug:** 10.35sec
-**Release:** 38.40sec
+**Debug:** <FmtNum :n=10.35 />sec
+**Release:** <FmtNum :n=38.40 />sec
 
-Recompilation (pumpkin crate)
+Recompilation (pumpkin crate):
 
-**Debug:** 1.82sec
-**Release:** 28.68sec
+**Debug:** <FmtNum :n=1.82 />sec
+**Release:** <FmtNum :n=28.68 />sec
 
 ## Vanilla
 
@@ -93,19 +99,19 @@ Compile args:
 
 Run args: `nogui`
 
-**File Size:** 51,6MB
+**File Size:** <FmtNum :n=51.6 />MB
 
-**Startup time:** 7sec
+**Startup time:** <FmtNum :n=7 />sec
 
-**Shutdown time:** 4sec
+**Shutdown time:** <FmtNum :n=4 />sec
 
-| Players | RAM   | CPU idle | CPU Max |
-| ------- | ----- | -------- | ------- |
-| 0       | 860MB | 0,1-0,3% | 51,0%   |
-| 1       | 1.5GB | 0,9-1%   | 41,0%   |
-| 2       | 1.6GB | 1,0-1,1% | 10,0%   |
-| 5       | 1.8GB | 2,0%     | 20,0%   |
-| 10      | 2,2GB | 4,0%     | 24,0%   |
+| Players | RAM                | CPU idle                             | CPU Max |
+| ------- | ------------------ | ------------------------------------ | ------- |
+| 0       | 860MB              | <FmtNum n=0.1 /> - <FmtNum n=0.3 />% | 51%     |
+| 1       | <FmtNum n=1.5 />GB | <FmtNum n=0.9 /> - 1%                | 41%     |
+| 2       | <FmtNum n=1.6 />GB | 1 - <FmtNum n=1.1 />%                | 10%     |
+| 5       | <FmtNum n=1.8 />GB | 2%                                   | 20%     |
+| 10      | <FmtNum n=2.2 />GB | 4%                                   | 24%     |
 
 ## Paper
 
@@ -115,19 +121,20 @@ Compile args:
 
 Run args: `nogui`
 
-**File Size:** 49,4MB
+**File Size:** <FmtNum :n=49.4 />MB
 
-**Startup time:** 7sec
+**Startup time:** <FmtNum :n=7 />sec
 
-**Shutdown time:** 3sec
+**Shutdown time:** <FmtNum :n=3 />sec
 
-| Players | RAM   | CPU idle | CPU Max |
-| ------- | ----- | -------- | ------- |
-| 0       | 1.1GB | 0,2-0,3% | 36,0%   |
-| 1       | 1.7GB | 0,9-1,0% | 47,0%   |
-| 2       | 1.8GB | 1-1-1,0% | 10,0%   |
-| 5       | 1.9GB | 1.5%     | 15,0%   |
-| 10      | 2GB   | 3,0%     | 20,0%   |
+| Players | RAM                 | CPU idle                               | CPU Max           |
+| ------- | ------------------- | -------------------------------------- | ----------------- |
+| 0       | <FmtNum :n=1.1 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=36 />% |
+| 1       | <FmtNum :n=1.7 />GB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=47 />% |
+| 2       | <FmtNum :n=1.8 />GB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=10 />% |
+| 5       | <FmtNum :n=1.9 />GB | <FmtNum :n=1.5 />%                     | <FmtNum :n=15 />% |
+| 10      | <FmtNum :n=2 />GB   | <FmtNum :n=3 />%                       | <FmtNum :n=20 />% |
+
 
 ## Purpur
 
@@ -137,19 +144,19 @@ Compile args:
 
 Run args: `nogui`
 
-**File Size:** 53,1MB
+**File Size:** <FmtNum :n=53.1 />MB
 
-**Startup time:** 8sec
+**Startup time:** <FmtNum :n=8 />sec
 
-**Shutdown time:** 4sec
+**Shutdown time:** <FmtNum :n=4 />sec
 
-| Players | RAM   | CPU idle | CPU Max |
-| ------- | ----- | -------- | ------- |
-| 0       | 1.4GB | 0,2-0,3% | 25,0%   |
-| 1       | 1.6GB | 0,7-1,0% | 35,0%   |
-| 2       | 1.7GB | 1,1-1,3% | 9,0%    |
-| 5       | 1.9GB | 1.6%     | 20,0%   |
-| 10      | 2.2GB | 2-2,5,0% | 26,0%   |
+| Players | RAM                 | CPU idle                               | CPU Max           |
+| ------- | ------------------- | -------------------------------------- | ----------------- |
+| 0       | <FmtNum :n=1.4 />GB | <FmtNum :n=0.2 /> - <FmtNum :n=0.3 />% | <FmtNum :n=25 />% |
+| 1       | <FmtNum :n=1.6 />GB | <FmtNum :n=0.7 /> - <FmtNum :n=1.0 />% | <FmtNum :n=35 />% |
+| 2       | <FmtNum :n=1.7 />GB | <FmtNum :n=1.1 /> - <FmtNum :n=1.3 />% | <FmtNum :n=9 />%  |
+| 5       | <FmtNum :n=1.9 />GB | <FmtNum :n=1.6 />%                     | <FmtNum :n=20 />% |
+| 10      | <FmtNum :n=2.2 />GB | <FmtNum :n=2 /> - <FmtNum :n=2.5 />%   | <FmtNum :n=26 />% |
 
 ## Minestom
 
@@ -161,20 +168,21 @@ Run args:
 
 **Language:** Benchmarks ran with Kotlin 2.0.0 (Minestom itself is made with Java)
 
-**File Size:** 2,8MB (Library)
+**File Size:** <FmtNum :n=2.8 />MB (Library)
 
-**Startup time:** 310ms
+**Startup time:** <FmtNum :n=310 />ms
 
-**Shutdown time:** 0ms
+**Shutdown time:** <FmtNum :n=0 />ms
 
 <sub>[Used example code from](https://minestom.net/docs/setup/your-first-server)</sub>
 
-| Players | RAM   | CPU idle | CPU Max |
-| ------- | ----- | -------- | ------- |
-| 0       | 228MB | 0,1-0,3% | 1,0%    |
-| 1       | 365MB | 0,9-1,0% | 5,0%    |
-| 2       | 371MB | 1-1,1%   | 4,0%    |
-| 5       | 390MB | 1,0%     | 6,0%    |
-| 10      | 421MB | 3,0%     | 9,0%    |
+| Players | RAM                 | CPU idle                                | CPU Max          |
+| ------- | ------------------- | --------------------------------------- | ---------------- |
+| 0       | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />%  | <FmtNum :n=1 />% |
+| 1       | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNu:m :n=1.0 />% | <FmtNum :n=5 />% |
+| 2       | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%    | <FmtNum :n=4 />% |
+| 5       | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                      | <FmtNum :n=6 />% |
+| 10      | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                        | <FmtNum :n=9 />% |
 
-Benchmarked at 15.10.2024 18:34 (UTC+2)
+
+Benchmarked at <FmtDateTime :d="new Date('2024-10-15T16:34Z')" />

--- a/docs/about/benchmarks.md
+++ b/docs/about/benchmarks.md
@@ -179,7 +179,7 @@ Run args:
 | Players | RAM                 | CPU idle                                | CPU Max          |
 | ------- | ------------------- | --------------------------------------- | ---------------- |
 | 0       | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />%  | <FmtNum :n=1 />% |
-| 1       | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNu:m :n=1.0 />% | <FmtNum :n=5 />% |
+| 1       | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=5 />% |
 | 2       | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%    | <FmtNum :n=4 />% |
 | 5       | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                      | <FmtNum :n=6 />% |
 | 10      | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                        | <FmtNum :n=9 />% |

--- a/docs/about/benchmarks.md
+++ b/docs/about/benchmarks.md
@@ -176,13 +176,13 @@ Run args:
 
 <sub>[Used example code from](https://minestom.net/docs/setup/your-first-server)</sub>
 
-| Players | RAM                 | CPU idle                                | CPU Max          |
-| ------- | ------------------- | --------------------------------------- | ---------------- |
-| 0       | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />%  | <FmtNum :n=1 />% |
+| Players | RAM                 | CPU idle                               | CPU Max          |
+| ------- | ------------------- | -------------------------------------- | ---------------- |
+| 0       | <FmtNum :n=228 />MB | <FmtNum :n=0.1 /> - <FmtNum :n=0.3 />% | <FmtNum :n=1 />% |
 | 1       | <FmtNum :n=365 />MB | <FmtNum :n=0.9 /> - <FmtNum :n=1.0 />% | <FmtNum :n=5 />% |
-| 2       | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%    | <FmtNum :n=4 />% |
-| 5       | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                      | <FmtNum :n=6 />% |
-| 10      | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                        | <FmtNum :n=9 />% |
+| 2       | <FmtNum :n=371 />MB | <FmtNum :n=1 /> - <FmtNum :n=1.1 />%   | <FmtNum :n=4 />% |
+| 5       | <FmtNum :n=390 />MB | <FmtNum :n=1.0 />%                     | <FmtNum :n=6 />% |
+| 10      | <FmtNum :n=421 />MB | <FmtNum :n=3 />%                       | <FmtNum :n=9 />% |
 
 
 Benchmarked at <FmtDateTime :d="new Date('2024-10-15T16:34Z')" />


### PR DESCRIPTION
This PR formats dates and numbers to be formatted for each locale correctly. This also converts times to the user's respective time zone.

This introduces 2 new Vue components, FmtNum and FmtDateTime. These can be used as normal Vue components in the markdown files.

### For example, here is `en_US`:
![image](https://github.com/user-attachments/assets/8950910e-fe45-4c11-a83b-6007a4dca701)
### And here is `de-DE`
![image](https://github.com/user-attachments/assets/3d745985-b92e-4f9c-8aa1-c9d227543946)

### Here is a US formatted date, in the CDT time zone:
![image](https://github.com/user-attachments/assets/68fe14d4-880c-4bcd-8051-4b15943f5ef3)
### And here is a London formatted date
![image](https://github.com/user-attachments/assets/edd2d563-0713-4bcb-8534-881bd04c8d2c)

Everything is adjusted based on region, using the Intl JavaScript apis. ***To be clear, there is no actual translation. Only the numbers and dates are formatted as per the user region.***

Also, there are improvements to the benchmarking page so that it flows more smoothly.