### PR TITLE
Fix chunk loading deadlock and dangling chunk memory

### DIFF
--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -14,6 +14,7 @@ derive_more.workspace = true
 itertools.workspace = true
 thiserror = "1.0"
 futures = "0.3"
+dashmap = "6.1.0"
 
 # Compression
 flate2 = "1.0"

--- a/pumpkin-world/src/cylindrical_chunk_iterator.rs
+++ b/pumpkin-world/src/cylindrical_chunk_iterator.rs
@@ -14,31 +14,24 @@ impl Cylindrical {
         }
     }
 
-    #[allow(unused_variables)]
     pub fn for_each_changed_chunk(
         old_cylindrical: Cylindrical,
         new_cylindrical: Cylindrical,
         mut newly_included: impl FnMut(Vector2<i32>),
         mut just_removed: impl FnMut(Vector2<i32>),
-        ignore: bool,
     ) {
         let min_x = old_cylindrical.left().min(new_cylindrical.left());
         let max_x = old_cylindrical.right().max(new_cylindrical.right());
         let min_z = old_cylindrical.bottom().min(new_cylindrical.bottom());
         let max_z = old_cylindrical.top().max(new_cylindrical.top());
 
+        //log::debug!("{:?} {:?}", old_cylindrical, new_cylindrical);
         for x in min_x..=max_x {
             for z in min_z..=max_z {
-                let old_is_within = if ignore {
-                    false
-                } else {
-                    old_cylindrical.is_within_distance(x, z)
-                };
-                let new_is_within = if ignore {
-                    true
-                } else {
-                    new_cylindrical.is_within_distance(x, z)
-                };
+                let old_is_within = old_cylindrical.is_within_distance(x, z);
+                let new_is_within = new_cylindrical.is_within_distance(x, z);
+
+                //log::debug!("{}, {}: {} {}", x, z, old_is_within, new_is_within);
 
                 if old_is_within != new_is_within {
                     if new_is_within {
@@ -68,26 +61,53 @@ impl Cylindrical {
     }
 
     fn is_within_distance(&self, x: i32, z: i32) -> bool {
-        let max_dist_squared = self.view_distance * self.view_distance;
-        let max_dist = self.view_distance as i64;
-        let dist_x = (x - self.center.x).abs().max(0) - (1);
-        let dist_z = (z - self.center.z).abs().max(0) - (1);
-        let dist_squared = dist_x.pow(2) + (max_dist.min(dist_z as i64) as i32).pow(2);
-        dist_squared < max_dist_squared
+        let rel_x = ((x - self.center.x).abs() - 1).max(0);
+        let rel_z = ((z - self.center.z).abs() - 1).max(0);
+
+        let max_leg = (rel_x.max(rel_z) - 1).max(0) as i64;
+        let min_leg = rel_x.min(rel_z) as i64;
+
+        let hyp_sqr = max_leg * max_leg + min_leg * min_leg;
+        hyp_sqr < (self.view_distance * self.view_distance) as i64
     }
 
     /// Returns an iterator of all chunks within this cylinder
     pub fn all_chunks_within(&self) -> Vec<Vector2<i32>> {
         // This is a naive implementation: start with square and cut out ones that dont fit
         let mut all_chunks = Vec::new();
-        for x in -self.view_distance..=self.view_distance {
-            for z in -self.view_distance..=self.view_distance {
-                all_chunks.push(Vector2::new(self.center.x + x, self.center.z + z));
+        for x in self.left()..=self.right() {
+            for z in self.bottom()..=self.top() {
+                all_chunks.push(Vector2::new(x, z));
             }
         }
         all_chunks
             .into_iter()
             .filter(|chunk| self.is_within_distance(chunk.x, chunk.z))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::Cylindrical;
+    use pumpkin_core::math::vector2::Vector2;
+
+    #[test]
+    fn test_bounds() {
+        let cylinder = Cylindrical::new(Vector2::new(0, 0), 10);
+        for chunk in cylinder.all_chunks_within() {
+            assert!(chunk.x >= cylinder.left() && chunk.x <= cylinder.right());
+            assert!(chunk.z >= cylinder.bottom() && chunk.z <= cylinder.top());
+        }
+
+        for x in (cylinder.left() - 2)..=(cylinder.right() + 2) {
+            for z in (cylinder.bottom() - 2)..=(cylinder.top() + 2) {
+                if cylinder.is_within_distance(x, z) {
+                    assert!(x >= cylinder.left() && x <= cylinder.right());
+                    assert!(z >= cylinder.bottom() && z <= cylinder.top());
+                }
+            }
+        }
     }
 }

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
+
+use dashmap::{DashMap, Entry};
+use pumpkin_core::math::vector2::Vector2;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use tokio::sync::{mpsc, RwLock};
 
 use crate::{
     chunk::{
@@ -6,11 +11,6 @@ use crate::{
     },
     world_gen::{get_world_gen, Seed, WorldGenerator},
 };
-use pumpkin_core::math::vector2::Vector2;
-use tokio::sync::mpsc;
-use tokio::sync::{Mutex, RwLock};
-
-type RAMChunkStorage = Arc<RwLock<HashMap<Vector2<i32>, Arc<RwLock<ChunkData>>>>>;
 
 /// The `Level` module provides functionality for working with chunks within or outside a Minecraft world.
 ///
@@ -23,11 +23,12 @@ type RAMChunkStorage = Arc<RwLock<HashMap<Vector2<i32>, Arc<RwLock<ChunkData>>>>
 /// For more details on world generation, refer to the `WorldGenerator` module.
 pub struct Level {
     save_file: Option<SaveFile>,
-    loaded_chunks: RAMChunkStorage,
-    chunk_watchers: Arc<Mutex<HashMap<Vector2<i32>, usize>>>,
-    chunk_reader: Arc<Box<dyn ChunkReader>>,
-    world_gen: Arc<Box<dyn WorldGenerator>>,
+    loaded_chunks: Arc<DashMap<Vector2<i32>, Arc<RwLock<ChunkData>>>>,
+    chunk_watchers: Arc<DashMap<Vector2<i32>, usize>>,
+    chunk_reader: Arc<dyn ChunkReader>,
+    world_gen: Arc<dyn WorldGenerator>,
 }
+
 #[derive(Clone)]
 pub struct SaveFile {
     #[expect(dead_code)]
@@ -38,7 +39,6 @@ pub struct SaveFile {
 impl Level {
     pub fn from_root_folder(root_folder: PathBuf) -> Self {
         let world_gen = get_world_gen(Seed(0)).into(); // TODO Read Seed from config.
-
         if root_folder.exists() {
             let region_folder = root_folder.join("region");
             assert!(
@@ -52,9 +52,9 @@ impl Level {
                     root_folder,
                     region_folder,
                 }),
-                chunk_reader: Arc::new(Box::new(AnvilChunkReader::new())),
-                loaded_chunks: Arc::new(RwLock::new(HashMap::new())),
-                chunk_watchers: Arc::new(Mutex::new(HashMap::new())),
+                chunk_reader: Arc::new(AnvilChunkReader::new()),
+                loaded_chunks: Arc::new(DashMap::new()),
+                chunk_watchers: Arc::new(DashMap::new()),
             }
         } else {
             log::warn!(
@@ -64,42 +64,49 @@ impl Level {
             Self {
                 world_gen,
                 save_file: None,
-                chunk_reader: Arc::new(Box::new(AnvilChunkReader::new())),
-                loaded_chunks: Arc::new(RwLock::new(HashMap::new())),
-                chunk_watchers: Arc::new(Mutex::new(HashMap::new())),
+                chunk_reader: Arc::new(AnvilChunkReader::new()),
+                loaded_chunks: Arc::new(DashMap::new()),
+                chunk_watchers: Arc::new(DashMap::new()),
             }
         }
     }
 
     pub fn get_block() {}
 
+    pub fn loaded_chunk_count(&self) -> usize {
+        self.loaded_chunks.len()
+    }
+
     /// Marks chunks as "watched" by a unique player. When no players are watching a chunk,
     /// it is removed from memory. Should only be called on chunks the player was not watching
     /// before
-    pub async fn mark_chunk_as_newly_watched(&self, chunks: &[Vector2<i32>]) {
-        let mut watchers = self.chunk_watchers.lock().await;
-        for chunk in chunks {
-            match watchers.entry(*chunk) {
-                std::collections::hash_map::Entry::Occupied(mut occupied) => {
+    pub fn mark_chunks_as_newly_watched(&self, chunks: &[Vector2<i32>]) {
+        chunks.par_iter().for_each(|chunk| {
+            match self.chunk_watchers.entry(*chunk) {
+                Entry::Occupied(mut occupied) => {
                     let value = occupied.get_mut();
-                    *value = value.saturating_add(1);
+                    if let Some(new_value) = value.checked_add(1) {
+                        *value = new_value;
+                        //log::debug!("Watch value for {:?}: {}", chunk, value);
+                    } else {
+                        log::error!("Watching overflow on chunk {:?}", chunk);
+                    }
                 }
-                std::collections::hash_map::Entry::Vacant(vacant) => {
+                Entry::Vacant(vacant) => {
                     vacant.insert(1);
                 }
             }
-        }
+        });
     }
 
     /// Marks chunks no longer "watched" by a unique player. When no players are watching a chunk,
     /// it is removed from memory. Should only be called on chunks the player was watching before
     pub async fn mark_chunk_as_not_watched_and_clean(&self, chunks: &[Vector2<i32>]) {
         let dropped_chunks = {
-            let mut watchers = self.chunk_watchers.lock().await;
             chunks
-                .iter()
-                .filter(|chunk| match watchers.entry(**chunk) {
-                    std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                .par_iter()
+                .filter(|chunk| match self.chunk_watchers.entry(**chunk) {
+                    Entry::Occupied(mut occupied) => {
                         let value = occupied.get_mut();
                         *value = value.saturating_sub(1);
                         if *value == 0 {
@@ -109,7 +116,7 @@ impl Level {
                             false
                         }
                     }
-                    std::collections::hash_map::Entry::Vacant(_) => {
+                    Entry::Vacant(_) => {
                         log::error!(
                             "Marking a chunk as not watched, but was vacant! ({:?})",
                             chunk
@@ -119,14 +126,17 @@ impl Level {
                 })
                 .collect::<Vec<_>>()
         };
-        let mut loaded_chunks = self.loaded_chunks.write().await;
+
         let dropped_chunk_data = dropped_chunks
-            .iter()
+            .par_iter()
             .filter_map(|chunk| {
                 //log::debug!("Unloading chunk {:?}", chunk);
-                loaded_chunks.remove_entry(*chunk)
+
+                // This makes sense to parallelize because loadad_chunks is sharded
+                self.loaded_chunks.remove(chunk)
             })
             .collect();
+
         self.write_chunks(dropped_chunk_data);
     }
 
@@ -134,80 +144,81 @@ impl Level {
         //TODO
     }
 
+    fn load_chunk_from_save(
+        chunk_reader: Arc<dyn ChunkReader>,
+        save_file: SaveFile,
+        chunk_pos: Vector2<i32>,
+    ) -> Result<Option<Arc<RwLock<ChunkData>>>, ChunkReadingError> {
+        match chunk_reader.read_chunk(&save_file, &chunk_pos) {
+            Ok(data) => Ok(Some(Arc::new(RwLock::new(data)))),
+            Err(
+                ChunkReadingError::ChunkNotExist
+                | ChunkReadingError::ParsingError(ChunkParsingError::ChunkNotGenerated),
+            ) => {
+                // This chunk was not generated yet.
+                Ok(None)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
     /// Reads/Generates many chunks in a world
     /// MUST be called from a tokio runtime thread
     ///
     /// Note: The order of the output chunks will almost never be in the same order as the order of input chunks
-    pub fn fetch_chunks(
+    pub async fn fetch_chunks(
         &self,
         chunks: &[Vector2<i32>],
         channel: mpsc::Sender<Arc<RwLock<ChunkData>>>,
     ) {
-        for chunk in chunks {
-            {
-                let chunk_location = *chunk;
-                let channel = channel.clone();
-                let loaded_chunks = self.loaded_chunks.clone();
-                let chunk_reader = self.chunk_reader.clone();
-                let save_file = self.save_file.clone();
-                let world_gen = self.world_gen.clone();
-                tokio::spawn(async move {
-                    let loaded_chunks_read = loaded_chunks.read().await;
-                    let possibly_loaded_chunk = loaded_chunks_read.get(&chunk_location).cloned();
-                    drop(loaded_chunks_read);
-                    match possibly_loaded_chunk {
-                        Some(chunk) => {
-                            let chunk = chunk.clone();
-                            channel.send(chunk).await.unwrap();
-                        }
-                        None => {
-                            let chunk_data = match save_file {
-                                Some(save_file) => {
-                                    match chunk_reader.read_chunk(&save_file, &chunk_location) {
-                                        Ok(data) => Ok(Arc::new(RwLock::new(data))),
-                                        Err(
-                                            ChunkReadingError::ChunkNotExist
-                                            | ChunkReadingError::ParsingError(
-                                                ChunkParsingError::ChunkNotGenerated,
-                                            ),
-                                        ) => {
-                                            // This chunk was not generated yet.
-                                            let chunk = Arc::new(RwLock::new(
-                                                world_gen.generate_chunk(chunk_location),
-                                            ));
-                                            let mut loaded_chunks = loaded_chunks.write().await;
-                                            loaded_chunks.insert(chunk_location, chunk.clone());
-                                            drop(loaded_chunks);
-                                            Ok(chunk)
-                                        }
-                                        Err(err) => Err(err),
+        chunks.iter().for_each(|at| {
+            let channel = channel.clone();
+            let loaded_chunks = self.loaded_chunks.clone();
+            let chunk_reader = self.chunk_reader.clone();
+            let save_file = self.save_file.clone();
+            let world_gen = self.world_gen.clone();
+            let chunk_pos = *at;
+
+            tokio::spawn(async move {
+                let chunk = loaded_chunks
+                    .get(&chunk_pos)
+                    .map(|entry| entry.value().clone())
+                    .unwrap_or_else(|| {
+                        let loaded_chunk = save_file
+                            .and_then(|save_file| {
+                                match Self::load_chunk_from_save(chunk_reader, save_file, chunk_pos)
+                                {
+                                    Ok(chunk) => chunk,
+                                    Err(err) => {
+                                        log::error!(
+                                            "Failed to read chunk (regenerating) {:?}: {:?}",
+                                            chunk_pos,
+                                            err
+                                        );
+                                        None
                                     }
                                 }
-                                None => {
-                                    // There is no savefile yet -> generate the chunks
-                                    let chunk = Arc::new(RwLock::new(
-                                        world_gen.generate_chunk(chunk_location),
-                                    ));
+                            })
+                            .unwrap_or_else(|| {
+                                Arc::new(RwLock::new(world_gen.generate_chunk(chunk_pos)))
+                            });
 
-                                    let mut loaded_chunks = loaded_chunks.write().await;
-                                    loaded_chunks.insert(chunk_location, chunk.clone());
-                                    Ok(chunk)
-                                }
-                            };
-                            match chunk_data {
-                                Ok(data) => channel.send(data).await.unwrap(),
-                                Err(err) => {
-                                    log::warn!(
-                                        "Failed to read chunk {:?}: {:?}",
-                                        chunk_location,
-                                        err
-                                    );
-                                }
-                            }
+                        if let Some(data) = loaded_chunks.get(&chunk_pos) {
+                            // Another thread populated in between the previous check and now
+                            // We did work, but this is basically like a cache miss, not much we
+                            // can do about it
+                            data.value().clone()
+                        } else {
+                            loaded_chunks.insert(chunk_pos, loaded_chunk.clone());
+                            loaded_chunk
                         }
-                    }
-                });
-            }
-        }
+                    });
+
+                let _ = channel
+                    .send(chunk)
+                    .await
+                    .inspect_err(|err| log::error!("unable to send chunk to channel: {}", err));
+            });
+        })
     }
 }

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -175,7 +175,7 @@ impl Client {
 
     /// Send a Clientbound Packet to the Client
     pub async fn send_packet<P: ClientPacket>(&self, packet: &P) {
-        log::debug!("Sending packet with id {} to {}", P::PACKET_ID, self.id);
+        //log::debug!("Sending packet with id {} to {}", P::PACKET_ID, self.id);
         // assert!(!self.closed);
         let mut enc = self.enc.lock().await;
         if let Err(error) = enc.append_packet(packet) {
@@ -201,11 +201,13 @@ impl Client {
 
     pub async fn try_send_packet<P: ClientPacket>(&self, packet: &P) -> Result<(), PacketError> {
         // assert!(!self.closed);
+        /*
         log::debug!(
             "Trying to send packet with id {} to {}",
             P::PACKET_ID,
             self.id
         );
+        */
 
         let mut enc = self.enc.lock().await;
         enc.append_packet(packet)?;
@@ -392,7 +394,7 @@ impl Client {
                     self.add_packet(packet).await;
                     return true;
                 }
-                Ok(None) => log::debug!("Waiting for more data to complete packet..."),
+                Ok(None) => (), //log::debug!("Waiting for more data to complete packet..."),
                 Err(err) => log::warn!(
                     "Failed to decode packet for id {}: {}",
                     self.id,
@@ -406,7 +408,7 @@ impl Client {
             let bytes_read = self.connection_reader.lock().await.read_buf(&mut buf).await;
             match bytes_read {
                 Ok(cnt) => {
-                    log::debug!("Read {} bytes", cnt);
+                    //log::debug!("Read {} bytes", cnt);
                     if cnt == 0 {
                         self.close();
                         return false;

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -429,7 +429,7 @@ impl Client {
 
     /// Kicks the Client with a reason depending on the connection state
     pub async fn kick(&self, reason: &str) {
-        log::info!("Kicking for id {} for {}", self.id, reason);
+        log::info!("Kicking id {} for {}", self.id, reason);
         match self.connection_state.load() {
             ConnectionState::Login => {
                 self.try_send_packet(&CLoginDisconnect::new(

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -39,7 +39,7 @@ use super::Entity;
 use crate::{
     client::{authentication::GameProfile, Client, PlayerConfig},
     server::Server,
-    world::{player_chunker::chunk_section_from_pos, World},
+    world::World,
 };
 use crate::{error::PumpkinError, world::player_chunker::get_view_distance};
 
@@ -151,7 +151,7 @@ impl Player {
     pub async fn remove(&self) {
         self.living_entity.entity.world.remove_player(self).await;
 
-        let watched = chunk_section_from_pos(&self.living_entity.entity.block_pos.load());
+        let watched = self.watched_section.load();
         let view_distance = i32::from(get_view_distance(self).await);
         let cylindrical = Cylindrical::new(Vector2::new(watched.x, watched.z), view_distance);
         let all_chunks = cylindrical.all_chunks_within();

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -154,11 +154,24 @@ impl Player {
         let watched = chunk_section_from_pos(&self.living_entity.entity.block_pos.load());
         let view_distance = i32::from(get_view_distance(self).await);
         let cylindrical = Cylindrical::new(Vector2::new(watched.x, watched.z), view_distance);
+        let all_chunks = cylindrical.all_chunks_within();
+
+        log::debug!(
+            "Removing player id {}, unwatching {} chunks",
+            self.client.id,
+            all_chunks.len()
+        );
         self.living_entity
             .entity
             .world
-            .mark_chunks_as_not_watched(&cylindrical.all_chunks_within())
+            .mark_chunks_as_not_watched(&all_chunks)
             .await;
+
+        log::debug!(
+            "Removed player id {} ({} chunks remain cached)",
+            self.client.id,
+            self.living_entity.entity.world.get_cached_chunk_len().await
+        );
     }
 
     pub async fn tick(&self) {

--- a/pumpkin/src/world/player_chunker.rs
+++ b/pumpkin/src/world/player_chunker.rs
@@ -74,12 +74,11 @@ pub async fn player_join(world: &World, player: Arc<Player>) {
 
     if !loading_chunks.is_empty() {
         world.mark_chunks_as_watched(&loading_chunks).await;
-        world
-            .spawn_world_chunks(player.client.clone(), loading_chunks)
-            .await;
+        world.spawn_world_chunks(player.client.clone(), loading_chunks);
     }
 
     if !unloading_chunks.is_empty() {
+        log::warn!("Unloading chunks on join");
         world.mark_chunks_as_not_watched(&unloading_chunks).await;
         for chunk in unloading_chunks {
             if !player
@@ -101,6 +100,7 @@ pub async fn update_position(player: &Player) {
     let current_watched = player.watched_section.load();
     let new_watched = chunk_section_from_pos(&entity.block_pos.load());
     if current_watched != new_watched {
+        //log::debug!("changing chunks");
         let chunk_pos = entity.chunk_pos.load();
         player
             .client
@@ -136,8 +136,7 @@ pub async fn update_position(player: &Player) {
             entity.world.mark_chunks_as_watched(&loading_chunks).await;
             entity
                 .world
-                .spawn_world_chunks(player.client.clone(), loading_chunks)
-                .await;
+                .spawn_world_chunks(player.client.clone(), loading_chunks);
         }
 
         if !unloading_chunks.is_empty() {


### PR DESCRIPTION
If the chunk fetcher spawns and calls level.fetch_chunks and the chunk sender has not spawned yet, because the function is synchronous, the channel can be filled with no consumer