### PR TITLE
Prevent panic on client poll function

### DIFF
--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -381,17 +381,17 @@ impl Client {
             dec.reserve(4096);
             let mut buf = dec.take_capacity();
 
-            if self
-                .connection_reader
-                .lock()
-                .await
-                .read_buf(&mut buf)
-                .await
-                .unwrap()
-                == 0
-            {
-                self.close();
-                return false;
+            match self.connection_reader.lock().await.read_buf(&mut buf).await {
+                Ok(0) => {
+                    self.close();
+                    return false;
+                }
+                Err(error) => {
+                    log::error!("Error while reading incoming packet {}", error);
+                    self.close();
+                    return false;
+                }
+                _ => {}
             }
 
             // This should always be an O(1) unsplit because we reserved space earlier and


### PR DESCRIPTION
Hi!
In pumpkin\src\client\mod.rs if an error occur in the poll function the server crash:
![image](https://github.com/user-attachments/assets/b003df6c-5266-4e6d-8f30-4c74056f452b)

With the fix (match instead of using unwrap) the server don't panic.
![image](https://github.com/user-attachments/assets/0174d9a1-bab7-4bb2-8042-67057c13fc0b)
