### PR TITLE
Handle chunks in an intermediary state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ num-derive = "0.4"
 
 # Concurrency/Parallelism and Synchronization
 rayon = "1.10.0"
-parking_lot = "0.12.3"
+parking_lot = { version = "0.12.3", features = ["send_guard"] }
 crossbeam = "0.8.4"
 
 uuid = { version = "1.11.0", features = ["serde", "v3", "v4"] }

--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -153,6 +153,20 @@ pub enum PacketError {
     MalformedLength,
 }
 
+impl PacketError {
+    pub fn kickable(&self) -> bool {
+        // We no longer have a connection, so dont try to kick the player, just close
+        !matches!(
+            self,
+            Self::EncodeData
+                | Self::EncodeFailedWrite
+                | Self::FailedWrite(_)
+                | Self::FailedFinish
+                | Self::ConnectionWrite
+        )
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ConnectionState {
     HandShake,

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -1,9 +1,13 @@
 use std::{path::PathBuf, sync::Arc};
 
 use dashmap::{DashMap, Entry};
+use num_traits::Zero;
 use pumpkin_core::math::vector2::Vector2;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use tokio::sync::{mpsc, RwLock};
+use tokio::{
+    sync::{mpsc, RwLock},
+    task::JoinHandle,
+};
 
 use crate::{
     chunk::{
@@ -11,6 +15,8 @@ use crate::{
     },
     world_gen::{get_world_gen, Seed, WorldGenerator},
 };
+
+pub type ConcurrentChunkResult = Vec<(Vector2<i32>, JoinHandle<()>)>;
 
 /// The `Level` module provides functionality for working with chunks within or outside a Minecraft world.
 ///
@@ -77,58 +83,108 @@ impl Level {
         self.loaded_chunks.len()
     }
 
+    pub fn list_cached(&self) {
+        for entry in self.loaded_chunks.iter() {
+            log::debug!("In map: {:?}", entry.key());
+        }
+    }
+
     /// Marks chunks as "watched" by a unique player. When no players are watching a chunk,
     /// it is removed from memory. Should only be called on chunks the player was not watching
     /// before
     pub fn mark_chunks_as_newly_watched(&self, chunks: &[Vector2<i32>]) {
-        chunks
-            .par_iter()
-            .for_each(|chunk| match self.chunk_watchers.entry(*chunk) {
-                Entry::Occupied(mut occupied) => {
-                    let value = occupied.get_mut();
-                    if let Some(new_value) = value.checked_add(1) {
-                        *value = new_value;
-                        //log::debug!("Watch value for {:?}: {}", chunk, value);
-                    } else {
-                        log::error!("Watching overflow on chunk {:?}", chunk);
-                    }
+        chunks.par_iter().for_each(|chunk| {
+            self.mark_chunk_as_newly_watched(*chunk);
+        });
+    }
+
+    pub fn mark_chunk_as_newly_watched(&self, chunk: Vector2<i32>) {
+        match self.chunk_watchers.entry(chunk) {
+            Entry::Occupied(mut occupied) => {
+                let value = occupied.get_mut();
+                if let Some(new_value) = value.checked_add(1) {
+                    *value = new_value;
+                    //log::debug!("Watch value for {:?}: {}", chunk, value);
+                } else {
+                    log::error!("Watching overflow on chunk {:?}", chunk);
                 }
-                Entry::Vacant(vacant) => {
-                    vacant.insert(1);
-                }
-            });
+            }
+            Entry::Vacant(vacant) => {
+                vacant.insert(1);
+            }
+        }
     }
 
     /// Marks chunks no longer "watched" by a unique player. When no players are watching a chunk,
     /// it is removed from memory. Should only be called on chunks the player was watching before
-    pub async fn mark_chunk_as_not_watched_and_clean(&self, chunks: &[Vector2<i32>]) {
+    pub fn mark_chunks_as_not_watched(&self, chunks: &[Vector2<i32>]) -> Vec<Vector2<i32>> {
         chunks
             .par_iter()
-            .filter(|chunk| match self.chunk_watchers.entry(**chunk) {
-                Entry::Occupied(mut occupied) => {
-                    let value = occupied.get_mut();
-                    *value = value.saturating_sub(1);
-                    if *value == 0 {
-                        occupied.remove_entry();
-                        true
-                    } else {
-                        false
-                    }
-                }
-                Entry::Vacant(_) => {
-                    log::error!(
-                        "Marking a chunk as not watched, but was vacant! ({:?})",
-                        chunk
-                    );
+            .filter(|chunk| self.mark_chunk_as_not_watched(**chunk))
+            .map(|chunk| *chunk)
+            .collect()
+    }
+
+    /// Returns whether the chunk should be removed from memory
+    pub fn mark_chunk_as_not_watched(&self, chunk: Vector2<i32>) -> bool {
+        match self.chunk_watchers.entry(chunk) {
+            Entry::Occupied(mut occupied) => {
+                let value = occupied.get_mut();
+                *value = value.saturating_sub(1);
+                if *value == 0 {
+                    occupied.remove_entry();
+                    true
+                } else {
                     false
                 }
-            })
-            .for_each(|chunk_pos| {
-                //log::debug!("Unloading {:?}", chunk_pos);
-                if let Some(data) = self.loaded_chunks.remove(chunk_pos) {
-                    self.write_chunk(data);
-                };
-            });
+            }
+            Entry::Vacant(_) => {
+                // This can be:
+                // - Player disconnecting before all packets have been sent
+                // - Player moving so fast that the chunk leaves the render distance before it
+                // is loaded into memory
+                log::error!(
+                    "Marking a chunk as not watched, but was vacant! ({:?})",
+                    chunk
+                );
+                false
+            }
+        }
+    }
+
+    pub fn should_pop_chunk(&self, chunk: &Vector2<i32>) -> bool {
+        if let Some(entry) = self.chunk_watchers.get(chunk) {
+            if entry.value().is_zero() {
+                self.chunk_watchers.remove(chunk);
+            }
+        }
+
+        self.chunk_watchers.get(chunk).is_none()
+    }
+
+    pub fn clean_chunks(&self, chunks: &[Vector2<i32>]) {
+        chunks.par_iter().for_each(|chunk_pos| {
+            //log::debug!("Unloading {:?}", chunk_pos);
+            if let Some(data) = self.loaded_chunks.remove(chunk_pos) {
+                self.write_chunk(data);
+            };
+        });
+    }
+
+    pub fn clean_memory(&self, chunks_to_check: &[Vector2<i32>]) {
+        chunks_to_check.par_iter().for_each(|chunk| {
+            if let Some(entry) = self.chunk_watchers.get(chunk) {
+                if entry.value().is_zero() {
+                    self.chunk_watchers.remove(chunk);
+                }
+            }
+
+            if self.chunk_watchers.get(chunk).is_none() {
+                self.loaded_chunks.remove(chunk);
+            }
+        });
+        self.loaded_chunks.shrink_to_fit();
+        self.chunk_watchers.shrink_to_fit();
     }
 
     pub fn write_chunk(&self, _chunk_to_write: (Vector2<i32>, Arc<RwLock<ChunkData>>)) {
@@ -157,59 +213,67 @@ impl Level {
     /// MUST be called from a tokio runtime thread
     ///
     /// Note: The order of the output chunks will almost never be in the same order as the order of input chunks
-    pub async fn fetch_chunks(
+    pub fn fetch_chunks(
         &self,
         chunks: &[Vector2<i32>],
         channel: mpsc::Sender<Arc<RwLock<ChunkData>>>,
-    ) {
-        chunks.iter().for_each(|at| {
-            let channel = channel.clone();
-            let loaded_chunks = self.loaded_chunks.clone();
-            let chunk_reader = self.chunk_reader.clone();
-            let save_file = self.save_file.clone();
-            let world_gen = self.world_gen.clone();
-            let chunk_pos = *at;
+    ) -> ConcurrentChunkResult {
+        chunks
+            .iter()
+            .map(|at| {
+                let channel = channel.clone();
+                let loaded_chunks = self.loaded_chunks.clone();
+                let chunk_reader = self.chunk_reader.clone();
+                let save_file = self.save_file.clone();
+                let world_gen = self.world_gen.clone();
+                let chunk_pos = *at;
 
-            tokio::spawn(async move {
-                let chunk = loaded_chunks
-                    .get(&chunk_pos)
-                    .map(|entry| entry.value().clone())
-                    .unwrap_or_else(|| {
-                        let loaded_chunk = save_file
-                            .and_then(|save_file| {
-                                match Self::load_chunk_from_save(chunk_reader, save_file, chunk_pos)
-                                {
-                                    Ok(chunk) => chunk,
-                                    Err(err) => {
-                                        log::error!(
-                                            "Failed to read chunk (regenerating) {:?}: {:?}",
-                                            chunk_pos,
-                                            err
-                                        );
-                                        None
+                let join_handle = tokio::spawn(async move {
+                    let chunk = loaded_chunks
+                        .get(&chunk_pos)
+                        .map(|entry| entry.value().clone())
+                        .unwrap_or_else(|| {
+                            let loaded_chunk = save_file
+                                .and_then(|save_file| {
+                                    match Self::load_chunk_from_save(
+                                        chunk_reader,
+                                        save_file,
+                                        chunk_pos,
+                                    ) {
+                                        Ok(chunk) => chunk,
+                                        Err(err) => {
+                                            log::error!(
+                                                "Failed to read chunk (regenerating) {:?}: {:?}",
+                                                chunk_pos,
+                                                err
+                                            );
+                                            None
+                                        }
                                     }
-                                }
-                            })
-                            .unwrap_or_else(|| {
-                                Arc::new(RwLock::new(world_gen.generate_chunk(chunk_pos)))
-                            });
+                                })
+                                .unwrap_or_else(|| {
+                                    Arc::new(RwLock::new(world_gen.generate_chunk(chunk_pos)))
+                                });
 
-                        if let Some(data) = loaded_chunks.get(&chunk_pos) {
-                            // Another thread populated in between the previous check and now
-                            // We did work, but this is basically like a cache miss, not much we
-                            // can do about it
-                            data.value().clone()
-                        } else {
-                            loaded_chunks.insert(chunk_pos, loaded_chunk.clone());
-                            loaded_chunk
-                        }
-                    });
+                            if let Some(data) = loaded_chunks.get(&chunk_pos) {
+                                // Another thread populated in between the previous check and now
+                                // We did work, but this is basically like a cache miss, not much we
+                                // can do about it
+                                data.value().clone()
+                            } else {
+                                loaded_chunks.insert(chunk_pos, loaded_chunk.clone());
+                                loaded_chunk
+                            }
+                        });
 
-                let _ = channel
-                    .send(chunk)
-                    .await
-                    .inspect_err(|err| log::error!("unable to send chunk to channel: {}", err));
-            });
-        })
+                    let _ = channel
+                        .send(chunk)
+                        .await
+                        .inspect_err(|err| log::error!("unable to send chunk to channel: {}", err));
+                });
+
+                (*at, join_handle)
+            })
+            .collect()
     }
 }

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -25,6 +25,7 @@ thiserror.workspace = true
 
 num-traits.workspace = true
 num-derive.workspace = true
+parking_lot.workspace = true
 
 # config
 serde.workspace = true

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,9 +1,12 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap, VecDeque},
+    sync::Arc,
+};
 
 pub mod player_chunker;
 
 use crate::{
-    client::Client,
+    client::{ChunkHandleWrapper, Client},
     entity::{player::Player, Entity},
 };
 use num_traits::ToPrimitive;
@@ -28,10 +31,18 @@ use pumpkin_world::coordinates::ChunkRelativeBlockCoordinates;
 use pumpkin_world::level::Level;
 use rand::{thread_rng, Rng};
 use scoreboard::Scoreboard;
-use tokio::sync::{mpsc, RwLock};
 use tokio::sync::{mpsc::Receiver, Mutex};
+use tokio::{
+    sync::{mpsc, RwLock},
+    task::JoinHandle,
+};
 
 pub mod scoreboard;
+
+type ChunkReceiver = (
+    Vec<(Vector2<i32>, JoinHandle<()>)>,
+    Receiver<Arc<RwLock<ChunkData>>>,
+);
 
 /// Represents a Minecraft world, containing entities, players, and the underlying level data.
 ///
@@ -44,7 +55,7 @@ pub mod scoreboard;
 /// - Provides a central hub for interacting with the world's entities and environment.
 pub struct World {
     /// The underlying level, responsible for chunk management and terrain generation.
-    pub level: Arc<Mutex<Level>>,
+    pub level: Arc<Level>,
     /// A map of active players within the world, keyed by their unique token.
     pub current_players: Arc<Mutex<HashMap<uuid::Uuid, Arc<Player>>>>,
     pub scoreboard: Mutex<Scoreboard>,
@@ -55,7 +66,7 @@ impl World {
     #[must_use]
     pub fn load(level: Level) -> Self {
         Self {
-            level: Arc::new(Mutex::new(level)),
+            level: Arc::new(level),
             current_players: Arc::new(Mutex::new(HashMap::new())),
             scoreboard: Mutex::new(Scoreboard::new()),
         }
@@ -299,30 +310,67 @@ impl World {
         player_chunker::player_join(self, player.clone()).await;
     }
 
-    pub async fn mark_chunks_as_not_watched(&self, chunks: &[Vector2<i32>]) {
-        let level = self.level.lock().await;
-        level.mark_chunk_as_not_watched_and_clean(chunks).await;
+    pub fn mark_chunks_as_not_watched(&self, chunks: &[Vector2<i32>]) -> Vec<Vector2<i32>> {
+        self.level.mark_chunks_as_not_watched(chunks)
     }
 
-    pub async fn mark_chunks_as_watched(&self, chunks: &[Vector2<i32>]) {
-        let level = self.level.lock().await;
-        level.mark_chunks_as_newly_watched(chunks);
+    pub fn clean_chunks(&self, chunks: &[Vector2<i32>]) {
+        self.level.clean_chunks(chunks);
     }
 
-    pub async fn get_cached_chunk_len(&self) -> usize {
-        let level = self.level.lock().await;
-        level.loaded_chunk_count()
+    pub fn clean_memory(&self, chunks_to_check: &[Vector2<i32>]) {
+        self.level.clean_memory(chunks_to_check);
     }
 
-    fn spawn_world_chunks(&self, client: Arc<Client>, chunks: Vec<Vector2<i32>>) {
+    pub fn get_cached_chunk_len(&self) -> usize {
+        self.level.loaded_chunk_count()
+    }
+
+    fn spawn_world_chunks(&self, client: Arc<Client>, chunks: &[Vector2<i32>]) {
         if client.closed.load(std::sync::atomic::Ordering::Relaxed) {
             log::info!("The connection has closed before world chunks were spawned",);
             return;
         }
+        #[cfg(debug_assertions)]
         let inst = std::time::Instant::now();
-        let mut receiver = self.receive_chunks(chunks);
+        // Unique id of this chunk batch for later removal
+        let id = uuid::Uuid::new_v4();
 
-        tokio::spawn(async move {
+        let (pending, mut receiver) = self.receive_chunks(chunks);
+        {
+            let mut pending_chunks = client.pending_chunks.lock();
+
+            for chunk in chunks {
+                if pending_chunks.contains_key(chunk) {
+                    log::debug!(
+                        "Client id {} is requesting chunk {:?} but its already pending!",
+                        client.id,
+                        chunk
+                    );
+                }
+            }
+
+            for (chunk, handle) in pending {
+                let entry = pending_chunks.entry(chunk);
+                let wrapper = ChunkHandleWrapper::new(handle);
+                match entry {
+                    Entry::Occupied(mut entry) => {
+                        entry.get_mut().push_back(wrapper);
+                    }
+                    Entry::Vacant(entry) => {
+                        let mut queue = VecDeque::new();
+                        queue.push_back(wrapper);
+                        entry.insert(queue);
+                    }
+                };
+            }
+        }
+        let pending_chunks = client.pending_chunks.clone();
+        let level = self.level.clone();
+        let retained_client = client.clone();
+        let batch_id = id;
+
+        let handle = tokio::spawn(async move {
             while let Some(chunk_data) = receiver.recv().await {
                 let chunk_data = chunk_data.read().await;
                 let packet = CChunkData(&chunk_data);
@@ -340,15 +388,62 @@ impl World {
                     );
                 }
 
-                // TODO: Queue player packs in a queue so we don't need to check if its closed before
-                // sending
+                {
+                    let mut pending_chunks = pending_chunks.lock();
+                    let handlers = pending_chunks
+                        .get_mut(&chunk_data.position)
+                        .expect("All chunks should be pending");
+                    let handler = handlers
+                        .pop_front()
+                        .expect("All chunks should have a handler");
+
+                    if handlers.is_empty() {
+                        pending_chunks.remove(&chunk_data.position);
+                    }
+
+                    // Chunk loading task was canceled after it was completed
+                    if handler.aborted() {
+                        // We never increment the watch value
+                        if level.should_pop_chunk(&chunk_data.position) {
+                            level.clean_chunks(&[chunk_data.position]);
+                        }
+                        // If ignored, dont send the packet
+                        let loaded_chunks = level.loaded_chunk_count();
+                        log::debug!(
+                            "Aborted chunk {:?} (post-process) {} cached",
+                            chunk_data.position,
+                            loaded_chunks
+                        );
+
+                        // We dont want to mark this chunk as watched or send it to the client
+                        continue;
+                    }
+
+                    // This must be locked with pending
+                    level.mark_chunk_as_newly_watched(chunk_data.position);
+                };
+
                 if !client.closed.load(std::sync::atomic::Ordering::Relaxed) {
                     client.send_packet(&packet).await;
                 }
             }
 
-            log::debug!("chunks sent after {}ms", inst.elapsed().as_millis());
+            {
+                let mut batch = client.pending_chunk_batch.lock();
+                batch.remove(&batch_id);
+            }
+            #[cfg(debug_assertions)]
+            log::debug!(
+                "chunks sent after {}ms (batch {})",
+                inst.elapsed().as_millis(),
+                batch_id
+            );
         });
+
+        {
+            let mut batch_handles = retained_client.pending_chunk_batch.lock();
+            batch_handles.insert(id, handle);
+        }
     }
 
     /// Gets a Player by entity id
@@ -427,20 +522,14 @@ impl World {
     }
 
     // Stream the chunks (don't collect them and then do stuff with them)
-    pub fn receive_chunks(&self, chunks: Vec<Vector2<i32>>) -> Receiver<Arc<RwLock<ChunkData>>> {
+    pub fn receive_chunks(&self, chunks: &[Vector2<i32>]) -> ChunkReceiver {
         let (sender, receive) = mpsc::channel(chunks.len());
-        {
-            let level = self.level.clone();
-            tokio::spawn(async move {
-                let level = level.lock().await;
-                level.fetch_chunks(&chunks, sender).await;
-            });
-        }
-        receive
+        let pending_chunks = self.level.fetch_chunks(chunks, sender);
+        (pending_chunks, receive)
     }
 
     pub async fn receive_chunk(&self, chunk: Vector2<i32>) -> Arc<RwLock<ChunkData>> {
-        let mut receiver = self.receive_chunks(vec![chunk]);
+        let (_, mut receiver) = self.receive_chunks(&[chunk]);
         receiver
             .recv()
             .await

--- a/pumpkin/src/world/player_chunker.rs
+++ b/pumpkin/src/world/player_chunker.rs
@@ -47,8 +47,7 @@ pub async fn player_join(world: &World, player: Arc<Player>) {
     let new_cylindrical = Cylindrical::new(Vector2::new(chunk_pos.x, chunk_pos.z), view_distance);
     let loading_chunks = new_cylindrical.all_chunks_within();
 
-    world.mark_chunks_as_watched(&loading_chunks).await;
-    world.spawn_world_chunks(player.client.clone(), loading_chunks);
+    world.spawn_world_chunks(player.client.clone(), &loading_chunks);
 }
 
 pub async fn update_position(player: &Player) {
@@ -91,30 +90,69 @@ pub async fn update_position(player: &Player) {
             },
         );
         if !loading_chunks.is_empty() {
-            entity.world.mark_chunks_as_watched(&loading_chunks).await;
+            //let inst = std::time::Instant::now();
             entity
                 .world
-                .spawn_world_chunks(player.client.clone(), loading_chunks);
+                .spawn_world_chunks(player.client.clone(), &loading_chunks);
+            //log::debug!("Loading chunks took {:?}", inst.elapsed());
         }
 
         if !unloading_chunks.is_empty() {
-            entity
-                .world
-                .mark_chunks_as_not_watched(&unloading_chunks)
-                .await;
-            // we may don't need to iter twice
-            for chunk in unloading_chunks {
-                if !player
-                    .client
-                    .closed
-                    .load(std::sync::atomic::Ordering::Relaxed)
-                {
-                    player
-                        .client
+            // We want to check if this chunk is still pending
+            // if it is -> ignore
+
+            //let inst = std::time::Instant::now();
+
+            let watched_chunks: Vec<_> = {
+                let mut pending_chunks = player.client.pending_chunks.lock();
+                unloading_chunks
+                    .into_iter()
+                    .filter(|chunk| {
+                        if let Some(handles) = pending_chunks.get_mut(chunk) {
+                            if let Some((count, handle)) = handles
+                                .iter_mut()
+                                .rev()
+                                .enumerate()
+                                .find(|(_, handle)| !handle.aborted())
+                            {
+                                log::debug!("Aborting chunk {:?} ({}) (unload)", chunk, count);
+                                // We want to abort the last queued chunk, that we if a client still
+                                // has a pending request for this chunk, we dont need to do the work
+                                // twice
+                                handle.abort();
+                            } else {
+                                log::warn!(
+                                    "Aborting chunk {:?} but all were already aborted!",
+                                    chunk
+                                );
+                            }
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .collect()
+            };
+
+            //log::debug!("Unloading chunks took {:?} (1)", inst.elapsed());
+            let chunks_to_clean = entity.world.mark_chunks_as_not_watched(&watched_chunks);
+            entity.world.clean_chunks(&chunks_to_clean);
+
+            //log::debug!("Unloading chunks took {:?} (2)", inst.elapsed());
+            // This can take a little if we are sending a bunch of packets, queue it up :p
+            let client = player.client.clone();
+            tokio::spawn(async move {
+                for chunk in watched_chunks {
+                    if client.closed.load(std::sync::atomic::Ordering::Relaxed) {
+                        // We will never un-close a connection
+                        break;
+                    }
+                    client
                         .send_packet(&CUnloadChunk::new(chunk.x, chunk.z))
                         .await;
                 }
-            }
+            });
+            //log::debug!("Unloading chunks took {:?} (3)", inst.elapsed());
         }
     }
 }


### PR DESCRIPTION
This PR handles two edge cases that can leave chunks in memory:
1) A client disconnected before all chunks are sent
2) A client moving so fast that a chunk that was in render distance is no longer in render distance before the chunk packet is sent

~~A future implementation would somehow cancel the work being done to generate chunks if they are no longer needed.~~