### PR TITLE
fix: autenticate -> authenticate

### DIFF
--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -152,7 +152,7 @@ impl Client {
 
         if BASIC_CONFIG.online_mode {
             match self
-                .autenticate(server, &shared_secret, &profile.name)
+                .authenticate(server, &shared_secret, &profile.name)
                 .await
             {
                 Ok(new_profile) => *profile = new_profile,
@@ -181,7 +181,7 @@ impl Client {
         self.send_packet(&packet).await;
     }
 
-    async fn autenticate(
+    async fn authenticate(
         &self,
         server: &Server,
         shared_secret: &[u8],


### PR DESCRIPTION
Fixed a typo in client_packets.rs.

I believe all references to the function (1 of them - on line 155) have been renamed to reflect the corrected spelling.

I ran and joined the server with no problems after making this change.

Thought I'd start out with a super basic pull request just to make sure I'm on the right track with contributing to the project. Cheers 🙂 