### PR TITLE
make `get_player_by_name` async, rename old fn to `get_player_by_name_blocking`

### DIFF
--- a/pumpkin/src/commands/arg_player.rs
+++ b/pumpkin/src/commands/arg_player.rs
@@ -26,7 +26,7 @@ pub fn consume_arg_player(
             name => {
                 // todo: implement any other player than sender
                 for world in &server.worlds {
-                    if world.get_player_by_name(name).is_some() {
+                    if world.get_player_by_name_blocking(name).is_some() {
                         return Ok(name.into());
                     }
                 }
@@ -56,7 +56,7 @@ pub fn parse_arg_player(
         "@a" | "@e" => todo!(), // todo: implement all players target selector
         name => {
             for world in &server.worlds {
-                if let Some(player) = world.get_player_by_name(name) {
+                if let Some(player) = world.get_player_by_name_blocking(name) {
                     return Ok(player);
                 }
             }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -145,9 +145,9 @@ impl Server {
     }
 
     /// Searches every world for a player by name
-    pub fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
+    pub async fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
         for world in &self.worlds {
-            if let Some(player) = world.get_player_by_name(name) {
+            if let Some(player) = world.get_player_by_name(name).await {
                 return Some(player);
             }
         }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -337,8 +337,18 @@ impl World {
     }
 
     /// Gets a Player by name
-    pub fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
-        // not sure of blocking lock
+    pub async fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
+        for player in self.current_players.lock().await.values() {
+            if player.gameprofile.name == name {
+                return Some(player.clone());
+            }
+        }
+        None
+    }
+
+    /// Gets a Player by name (blocking - legacy)
+    pub fn get_player_by_name_blocking(&self, name: &str) -> Option<Arc<Player>> {
+        //TODO: Remove this function after commands are async.
         for player in self.current_players.blocking_lock().values() {
             if player.gameprofile.name == name {
                 return Some(player.clone());


### PR DESCRIPTION
Currently, the existing commands system is all that requires the existing blocking version of `get_player_by_name` function. After discussing in the Discord, it seems renaming the old blocking method with a suffix of `_blocking` in addition to adding an async version under the original (unmodified) name of `get_player_by_name`.

This change was required to work on the 'Check if player already joined' project.

[Jump to Discord conversation](https://discord.com/channels/1268592337445978193/1268611318617866261/1299028500547637359)