### PR TITLE
Implement `get_player_by_uuid` for server & world

### DIFF
--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -144,6 +144,16 @@ impl Server {
         }
     }
 
+    /// Searches every world for a player by UUID
+    pub async fn get_player_by_uuid(&self, id: uuid::Uuid) -> Option<Arc<Player>> {
+        for world in &self.worlds {
+            if let Some(player) = world.get_player_by_uuid(id).await {
+                return Some(player);
+            }
+        }
+        None
+    }
+
     /// Searches every world for a player by name
     pub fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
         for world in &self.worlds {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -347,6 +347,16 @@ impl World {
         None
     }
 
+    /// Gets a Player by UUID
+    pub async fn get_player_by_uuid(&self, id: uuid::Uuid) -> Option<Arc<Player>> {
+        for player in self.current_players.lock().await.values() {
+            if player.gameprofile.id == id {
+                return Some(player.clone());
+            }
+        }
+        None
+    }
+
     pub async fn add_player(&self, uuid: uuid::Uuid, player: Arc<Player>) {
         self.current_players.lock().await.insert(uuid, player);
     }


### PR DESCRIPTION
Similar to the existing functions named `get_player_by_name`, these functions will search for a player with a matching `Uuid`.

This implementation is asynchronous and thus better suits being combined with #176, which makes `get_player_by_name` asynchronous too.

