### PR TITLE
Prevent duplicate profiles

### DIFF
--- a/pumpkin/src/client/authentication.rs
+++ b/pumpkin/src/client/authentication.rs
@@ -143,8 +143,6 @@ pub enum AuthError {
     FailedParse,
     #[error("Unknown Status Code")]
     UnknownStatusCode(StatusCode),
-    #[error("You are already connected to this server")]
-    DuplicateConnection,
 }
 
 #[derive(Error, Debug)]

--- a/pumpkin/src/client/authentication.rs
+++ b/pumpkin/src/client/authentication.rs
@@ -143,6 +143,8 @@ pub enum AuthError {
     FailedParse,
     #[error("Unknown Status Code")]
     UnknownStatusCode(StatusCode),
+    #[error("You are already connected to this server")]
+    DuplicateConnection,
 }
 
 #[derive(Error, Debug)]

--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -163,6 +163,13 @@ impl Client {
             }
         }
 
+        // don't allow a duplicate username
+        if let Some(online_player) = &server.get_player_by_name(&profile.name).await {
+            log::debug!("A player (IP '{}', attempted username '{}') tried to log in with the same username as an online player (UUID '{}', IP '{}', username '{}')", &self.address.lock().await.to_string(), &profile.name, &profile.id.to_string(), &online_player.client.address.lock().await.to_string(), &online_player.gameprofile.name);
+            self.kick("A player with this username is already connected").await;
+            return;
+        }
+
         if ADVANCED_CONFIG.packet_compression.enabled {
             self.enable_compression().await;
         }
@@ -192,6 +199,13 @@ impl Client {
             let ip = self.address.lock().await.ip();
 
             let profile = authentication::authenticate(username, &hash, &ip, auth_client).await?;
+            
+            // Don't allow duplicate UUIDs
+            if let Some(online_player) = &server.get_player_by_uuid(profile.id).await {
+                log::debug!("Player (IP '{}', username '{}') tried to log in with the same UUID ('{}') as an online player (IP '{}', username '{}')", &ip.to_string(), &profile.name, &profile.id.to_string(), &online_player.client.address.lock().await.to_string(), &online_player.gameprofile.name);
+                return Err(AuthError::DuplicateConnection);
+            }
+            
             // Check if player should join
             if let Some(actions) = &profile.profile_actions {
                 if ADVANCED_CONFIG

--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -166,7 +166,8 @@ impl Client {
         // don't allow a duplicate username
         if let Some(online_player) = &server.get_player_by_name(&profile.name).await {
             log::debug!("A player (IP '{}', attempted username '{}') tried to log in with the same username as an online player (UUID '{}', IP '{}', username '{}')", &self.address.lock().await.to_string(), &profile.name, &profile.id.to_string(), &online_player.client.address.lock().await.to_string(), &online_player.gameprofile.name);
-            self.kick("A player with this username is already connected").await;
+            self.kick("A player with this username is already connected")
+                .await;
             return;
         }
 
@@ -199,13 +200,13 @@ impl Client {
             let ip = self.address.lock().await.ip();
 
             let profile = authentication::authenticate(username, &hash, &ip, auth_client).await?;
-            
+
             // Don't allow duplicate UUIDs
             if let Some(online_player) = &server.get_player_by_uuid(profile.id).await {
                 log::debug!("Player (IP '{}', username '{}') tried to log in with the same UUID ('{}') as an online player (IP '{}', username '{}')", &ip.to_string(), &profile.name, &profile.id.to_string(), &online_player.client.address.lock().await.to_string(), &online_player.gameprofile.name);
                 return Err(AuthError::DuplicateConnection);
             }
-            
+
             // Check if player should join
             if let Some(actions) = &profile.profile_actions {
                 if ADVANCED_CONFIG

--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -151,13 +151,6 @@ impl Client {
         };
 
         if BASIC_CONFIG.online_mode {
-            // Don't allow duplicate UUIDs
-            if let Some(online_player) = &server.get_player_by_uuid(profile.id).await {
-                log::debug!("Player (IP '{}', username '{}') tried to log in with the same UUID ('{}') as an online player (IP '{}', username '{}')", &self.address.lock().await.to_string(), &profile.name, &profile.id.to_string(), &online_player.client.address.lock().await.to_string(), &online_player.gameprofile.name);
-                self.kick("You are already connected to this server").await;
-                return;
-            }
-
             // Online mode auth
             match self
                 .authenticate(server, &shared_secret, &profile.name)
@@ -171,7 +164,14 @@ impl Client {
             }
         }
 
-        // don't allow a duplicate username
+        // Don't allow duplicate UUIDs
+        if let Some(online_player) = &server.get_player_by_uuid(profile.id).await {
+            log::debug!("Player (IP '{}', username '{}') tried to log in with the same UUID ('{}') as an online player (IP '{}', username '{}')", &self.address.lock().await.to_string(), &profile.name, &profile.id.to_string(), &online_player.client.address.lock().await.to_string(), &online_player.gameprofile.name);
+            self.kick("You are already connected to this server").await;
+            return;
+        }
+
+        // Don't allow a duplicate username
         if let Some(online_player) = &server.get_player_by_name(&profile.name).await {
             log::debug!("A player (IP '{}', attempted username '{}') tried to log in with the same username as an online player (UUID '{}', IP '{}', username '{}')", &self.address.lock().await.to_string(), &profile.name, &profile.id.to_string(), &online_player.client.address.lock().await.to_string(), &online_player.gameprofile.name);
             self.kick("A player with this username is already connected")

--- a/pumpkin/src/commands/arg_player.rs
+++ b/pumpkin/src/commands/arg_player.rs
@@ -26,7 +26,7 @@ pub fn consume_arg_player(
             name => {
                 // todo: implement any other player than sender
                 for world in &server.worlds {
-                    if world.get_player_by_name(name).is_some() {
+                    if world.get_player_by_name_blocking(name).is_some() {
                         return Ok(name.into());
                     }
                 }
@@ -56,7 +56,7 @@ pub fn parse_arg_player(
         "@a" | "@e" => todo!(), // todo: implement all players target selector
         name => {
             for world in &server.worlds {
-                if let Some(player) = world.get_player_by_name(name) {
+                if let Some(player) = world.get_player_by_name_blocking(name) {
                     return Ok(player);
                 }
             }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -143,10 +143,10 @@ impl Server {
         }
     }
 
-    /// Searches every world for a player by name
-    pub fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
+    /// Searches every world for a player by username
+    pub async fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
         for world in &self.worlds {
-            if let Some(player) = world.get_player_by_name(name) {
+            if let Some(player) = world.get_player_by_name(name).await {
                 return Some(player);
             }
         }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -153,6 +153,16 @@ impl Server {
         None
     }
 
+    /// Searches every world for a player by UUID
+    pub async fn get_player_by_uuid(&self, id: uuid::Uuid) -> Option<Arc<Player>> {
+        for world in &self.worlds {
+            if let Some(player) = world.get_player_by_uuid(id).await {
+                return Some(player);
+            }
+        }
+        None
+    }
+
     /// Generates a new entity id
     /// This should be global
     pub fn new_entity_id(&self) -> EntityId {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -384,12 +384,7 @@ impl World {
 
     /// Gets a Player by UUID
     pub async fn get_player_by_uuid(&self, id: uuid::Uuid) -> Option<Arc<Player>> {
-        for player in self.current_players.lock().await.values() {
-            if player.gameprofile.id == id {
-                return Some(player.clone());
-            }
-        }
-        None
+        return self.current_players.lock().await.get(&id).cloned();
     }
 
     pub async fn add_player(&self, uuid: uuid::Uuid, player: Arc<Player>) {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -372,6 +372,16 @@ impl World {
         None
     }
 
+    /// Gets a Player by UUID
+    pub async fn get_player_by_uuid(&self, id: uuid::Uuid) -> Option<Arc<Player>> {
+        for player in self.current_players.lock().await.values() {
+            if player.gameprofile.id == id {
+                return Some(player.clone());
+            }
+        }
+        None
+    }
+
     pub async fn add_player(&self, uuid: uuid::Uuid, player: Arc<Player>) {
         self.current_players.lock().await.insert(uuid, player);
     }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -361,9 +361,19 @@ impl World {
         None
     }
 
-    /// Gets a Player by name
-    pub fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
-        // not sure of blocking lock
+    /// Gets a Player by username
+    pub async fn get_player_by_name(&self, name: &str) -> Option<Arc<Player>> {
+        for player in self.current_players.lock().await.values() {
+            if player.gameprofile.name == name {
+                return Some(player.clone());
+            }
+        }
+        None
+    }
+
+    /// Gets a Player by username (Blocking - Legacy use only)
+    pub fn get_player_by_name_blocking(&self, name: &str) -> Option<Arc<Player>> {
+        // TODO: Remove this blocking functions when commands are async.
         for player in self.current_players.blocking_lock().values() {
             if player.gameprofile.name == name {
                 return Some(player.clone());


### PR DESCRIPTION
This PR aims to resolve the to-do item [Check if player already joined][1].

This is implemented via two checks:
1. **Prevent duplicate UUIDs.**
  Stops a player from logging in to the server if they are already playing (or if their UUID is being used in some other narrow possibility).
3. **Prevent duplicate usernames.**
  Stops a player from taking the same username as an online player.
  Of course, this is primarily made for offline-mode servers. However, it *might* be possible that this serves as a protection for online-mode servers, in case someone does a name change whilst connected, someone takes their old name, and tries to connect.

## To-do

- [ ] Code reviewed with no further suggestions / requirements.
  Please note, I'm a Rust newbie, so please check my code thoroughly for any mistakes. 🙂 
- [x] Testing completed:
  - [x] Compiles, runs, allows normal players as expected.
  - [x] Prevents duplicate UUIDs (player already logged in).
  - [x] Prevents duplicate usernames (particularly for offline mode).
- [x] Ready to merge (convert PR from draft accordingly).

## Screenshots

### UUID duplication

<img width="591" alt="image" src="https://github.com/user-attachments/assets/bbffaf7d-147d-4a25-a8f3-6beaa7bae864">

### Username duplication

<img width="586" alt="image" src="https://github.com/user-attachments/assets/21c1be72-eb0c-4888-b6d5-b934aa55aee7">



[1]: https://github.com/users/Snowiiii/projects/12/views/3?pane=issue&itemId=84062083