### PR TITLE
docker: add compose file for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  pumpkin:
+    build: .
+    ports:
+      - 25565:25565
+    volumes:
+      - ./configuration.toml:/pumpkin/configuration.toml
+      - ./features.toml:/pumpkin/features.toml


### PR DESCRIPTION
This resolves #174.

I've chosen to make this compose file purely for development use (and thus sticks with `build: .`, rather than using an image).

Instead, for server owners, we should provide an example `docker-compose.yml` for them to use which references a public image instead.

This way, both use cases for the compose files are separated.

***

- [x] Ready for review.