### PR TITLE
Implement cross platform signal handling with `tokio`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.41", features = [
     "rt-multi-thread",
     "sync",
     "io-std",
+    "signal",
 ] }
 
 thiserror = "1.0"

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -36,7 +36,7 @@ rand = "0.8.5"
 
 num-bigint = "0.4"
 
-ctrlc = "3.4"
+ctrlc = { version = "3.4", features = ["termination"] }
 
 # encryption
 rsa = "0.9.6"

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -36,8 +36,6 @@ rand = "0.8.5"
 
 num-bigint = "0.4"
 
-ctrlc = { version = "3.4", features = ["termination"] }
-
 # encryption
 rsa = "0.9.6"
 rsa-der = "0.3.0"

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -215,7 +215,7 @@ async fn setup_sighandler() -> io::Result<()> {
         handle_interrupt();
     }
 
-    Ok(());
+    Ok(())
 }
 
 // Unix signal handling

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -100,7 +100,9 @@ async fn main() -> io::Result<()> {
     //     .unwrap();
 
     tokio::spawn(async {
-        setup_sighandler().await.expect("Unable to setup signal handlers");
+        setup_sighandler()
+            .await
+            .expect("Unable to setup signal handlers");
     });
 
     // ensure rayon is built outside of tokio scope

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -25,7 +25,7 @@ use client::Client;
 use server::{ticker::Ticker, Server};
 use std::io::{self};
 use tokio::io::{AsyncBufReadExt, BufReader};
-#[cfg(windows)]
+#[cfg(not(unix))]
 use tokio::signal::ctrl_c;
 #[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
@@ -208,8 +208,8 @@ fn handle_interrupt() {
     std::process::exit(0);
 }
 
-// Windows Ctrl-C handling
-#[cfg(windows)]
+// Non-UNIX Ctrl-C handling
+#[cfg(not(unix))]
 async fn setup_sighandler() -> io::Result<()> {
     if ctrl_c().await.is_ok() {
         handle_interrupt();

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -23,10 +23,7 @@ use log::LevelFilter;
 
 use client::Client;
 use server::{ticker::Ticker, Server};
-use std::{
-    io::{self},
-    process,
-};
+use std::io::{self};
 use tokio::io::{AsyncBufReadExt, BufReader};
 // TODO: #[cfg(windows)]
 use tokio::signal::ctrl_c;
@@ -118,10 +115,8 @@ async fn main() -> io::Result<()> {
     }
 
     // Windows Ctrl-C handling
-    if cfg!(windows) {
-        if ctrl_c().await.is_ok() {
-            handle_interrupt();
-        }
+    if cfg!(windows) && ctrl_c().await.is_ok() {
+        handle_interrupt();
     }
 
     // ensure rayon is built outside of tokio scope

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -94,6 +94,8 @@ async fn main() -> io::Result<()> {
     //     .enable_all()
     //     .build()
     //     .unwrap();
+
+    // handle Ctrl-C here - signals e.g., sigint, sigterm, ...
     ctrlc::set_handler(|| {
         log::warn!(
             "{}",
@@ -103,7 +105,8 @@ async fn main() -> io::Result<()> {
         );
         std::process::exit(0);
     })
-    .unwrap();
+    .expect("Unable to set ctrlc handler");
+
     // ensure rayon is built outside of tokio scope
     rayon::ThreadPoolBuilder::new().build_global().unwrap();
     let default_panic = std::panic::take_hook();

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -210,10 +210,12 @@ fn handle_interrupt() {
 
 // Windows Ctrl-C handling
 #[cfg(windows)]
-async fn setup_sighandler() {
+async fn setup_sighandler() -> io::Result<()> {
     if ctrl_c().await.is_ok() {
         handle_interrupt();
     }
+
+    Ok(());
 }
 
 // Unix signal handling


### PR DESCRIPTION
This PR enables the `termination` feature in `ctrlc` so that `sigterm` and `sighup` are also handled on UNIX systems. This in turn improves Docker compatibility since containers now listen to the `SIGTERM` signal it sends to containers when trying to stop the container via `Ctrl-C` whilst attached.

Resolves #182; please check this issue for more information.

***

- [x] Fix compilation errors on Windows
- [x] Ready for merge
