### PR TITLE
Add player join and quit messages.

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -12,7 +12,7 @@ use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, ToPrimitive};
 use pumpkin_core::{
     math::{boundingbox::BoundingBox, position::WorldPosition, vector2::Vector2, vector3::Vector3},
-    text::{color::NamedColor, TextComponent},
+    text::TextComponent,
     GameMode,
 };
 use pumpkin_entity::{entity_type::EntityType, EntityId};
@@ -272,22 +272,6 @@ impl Player {
         );
 
         //self.living_entity.entity.world.level.list_cached();
-
-        // Send disconnect message / quit message to other players in the same world
-        let msg_txt = format!("{} left the game.", self.gameprofile.name.as_str());
-        let msg_comp = TextComponent::text(msg_txt.as_str()).color_named(NamedColor::Yellow);
-        for entry in world.current_players.lock().await.iter() {
-            let uuid = entry.0;
-            let player = entry.1;
-
-            if uuid.eq(&self.gameprofile.id) {
-                // don't send disconnect message to yourself
-                continue;
-            }
-
-            player.send_system_message(&msg_comp).await;
-        }
-        log::info!("{}", msg_comp.to_pretty_console());
     }
 
     pub async fn tick(&self) {

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -12,10 +12,7 @@ use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, ToPrimitive};
 use pumpkin_core::{
     math::{boundingbox::BoundingBox, position::WorldPosition, vector2::Vector2, vector3::Vector3},
-    text::{
-        color::{Color::Named, NamedColor},
-        TextComponent,
-    },
+    text::{color::NamedColor, TextComponent},
     GameMode,
 };
 use pumpkin_entity::{entity_type::EntityType, EntityId};
@@ -276,9 +273,9 @@ impl Player {
 
         //self.living_entity.entity.world.level.list_cached();
 
-        // Send disconnect message to other players in the same world
+        // Send disconnect message / quit message to other players in the same world
         let msg_txt = format!("{} left the game.", self.gameprofile.name.as_str());
-        let msg_comp = TextComponent::text(msg_txt.as_str()).color(Named(NamedColor::Yellow));
+        let msg_comp = TextComponent::text(msg_txt.as_str()).color_named(NamedColor::Yellow);
         for entry in world.current_players.lock().await.iter() {
             let uuid = entry.0;
             let player = entry.1;
@@ -290,6 +287,7 @@ impl Player {
 
             player.send_system_message(&msg_comp).await;
         }
+        log::info!("{}", msg_comp.to_pretty_console());
     }
 
     pub async fn tick(&self) {

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -1,7 +1,13 @@
 use connection_cache::{CachedBranding, CachedStatus};
 use key_store::KeyStore;
 use pumpkin_config::BASIC_CONFIG;
-use pumpkin_core::GameMode;
+use pumpkin_core::{
+    text::{
+        color::{Color::Named, NamedColor},
+        TextComponent,
+    },
+    GameMode,
+};
 use pumpkin_entity::EntityId;
 use pumpkin_inventory::drag_handler::DragHandler;
 use pumpkin_inventory::{Container, OpenContainer};
@@ -113,6 +119,14 @@ impl Server {
                 self.server_listing.lock().await.add_player();
             }
         }
+
+        // Handle join message
+        let msg_txt = format!("{} joined the game.", player.gameprofile.name.as_str());
+        let msg_comp = TextComponent::text(msg_txt.as_str()).color(Named(NamedColor::Yellow));
+        for player in world.current_players.lock().await.values() {
+            player.send_system_message(&msg_comp).await;
+        }
+
         (player, world.clone())
     }
 

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -2,10 +2,7 @@ use connection_cache::{CachedBranding, CachedStatus};
 use key_store::KeyStore;
 use pumpkin_config::BASIC_CONFIG;
 use pumpkin_core::{
-    text::{
-        color::{Color::Named, NamedColor},
-        TextComponent,
-    },
+    text::{color::NamedColor, TextComponent},
     GameMode,
 };
 use pumpkin_entity::EntityId;
@@ -122,10 +119,11 @@ impl Server {
 
         // Handle join message
         let msg_txt = format!("{} joined the game.", player.gameprofile.name.as_str());
-        let msg_comp = TextComponent::text(msg_txt.as_str()).color(Named(NamedColor::Yellow));
+        let msg_comp = TextComponent::text(msg_txt.as_str()).color_named(NamedColor::Yellow);
         for player in world.current_players.lock().await.values() {
             player.send_system_message(&msg_comp).await;
         }
+        log::info!("{}", msg_comp.to_pretty_console());
 
         (player, world.clone())
     }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -1,10 +1,7 @@
 use connection_cache::{CachedBranding, CachedStatus};
 use key_store::KeyStore;
 use pumpkin_config::BASIC_CONFIG;
-use pumpkin_core::{
-    text::{color::NamedColor, TextComponent},
-    GameMode,
-};
+use pumpkin_core::GameMode;
 use pumpkin_entity::EntityId;
 use pumpkin_inventory::drag_handler::DragHandler;
 use pumpkin_inventory::{Container, OpenContainer};
@@ -116,14 +113,6 @@ impl Server {
                 self.server_listing.lock().await.add_player();
             }
         }
-
-        // Handle join message
-        let msg_txt = format!("{} joined the game.", player.gameprofile.name.as_str());
-        let msg_comp = TextComponent::text(msg_txt.as_str()).color_named(NamedColor::Yellow);
-        for player in world.current_players.lock().await.values() {
-            player.send_system_message(&msg_comp).await;
-        }
-        log::info!("{}", msg_comp.to_pretty_console());
 
         (player, world.clone())
     }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -473,7 +473,18 @@ impl World {
     }
 
     pub async fn add_player(&self, uuid: uuid::Uuid, player: Arc<Player>) {
-        self.current_players.lock().await.insert(uuid, player);
+        self.current_players
+            .lock()
+            .await
+            .insert(uuid, player.clone());
+
+        // Handle join message
+        let msg_txt = format!("{} joined the game.", player.gameprofile.name.as_str());
+        let msg_comp = TextComponent::text(msg_txt.as_str()).color_named(NamedColor::Yellow);
+        for player in self.current_players.lock().await.values() {
+            player.send_system_message(&msg_comp).await;
+        }
+        log::info!("{}", msg_comp.to_pretty_console());
     }
 
     pub async fn remove_player(&self, player: &Player) {

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -13,6 +13,7 @@ use num_traits::ToPrimitive;
 use pumpkin_config::BasicConfiguration;
 use pumpkin_core::math::vector2::Vector2;
 use pumpkin_core::math::{position::WorldPosition, vector3::Vector3};
+use pumpkin_core::text::{color::NamedColor, TextComponent};
 use pumpkin_entity::{entity_type::EntityType, EntityId};
 use pumpkin_protocol::{
     client::play::{CBlockUpdate, CSoundEffect, CWorldEvent},
@@ -488,6 +489,15 @@ impl World {
         )
         .await;
         self.remove_entity(&player.living_entity.entity).await;
+
+        // Send disconnect message / quit message to players in the same world
+        let disconn_msg_txt = format!("{} left the game.", player.gameprofile.name.as_str());
+        let disconn_msg_cmp =
+            TextComponent::text(disconn_msg_txt.as_str()).color_named(NamedColor::Yellow);
+        for player in self.current_players.lock().await.values() {
+            player.send_system_message(&disconn_msg_cmp).await;
+        }
+        log::info!("{}", disconn_msg_cmp.to_pretty_console());
     }
 
     pub async fn remove_entity(&self, entity: &Entity) {


### PR DESCRIPTION
This implementation will send a 'joined the game' and 'left the game' message akin to the vanilla server when a player joins or disconnects respectively.

One caveat with this implementation is that it only broadcasts the join/quit messages to players in the same world, unlike the vanilla server, which broadcasts it to all online players (regardless of their world).

I discussed this with Alex who suggested to keep it as per-world (seemingly for now?) - [Discord conversation](https://discord.com/channels/1268592337445978193/1268611318617866261/1299668206734147597).

Regardless, this implementation works perfectly on my end. (yes, it has been tested)

Resolves #188 

Screenshot:
![image](https://github.com/user-attachments/assets/4ffcaaf6-dbdb-480b-8f1a-917c701e0104)

- [x] Ready for review/merge