### PR TITLE
use derive macro for Default trait on Scoreboard struct

### DIFF
--- a/pumpkin/src/world/scoreboard.rs
+++ b/pumpkin/src/world/scoreboard.rs
@@ -8,15 +8,10 @@ use pumpkin_protocol::{
 
 use super::World;
 
+#[derive(Default)]
 pub struct Scoreboard {
     objectives: HashMap<String, ScoreboardObjective<'static>>,
     //  teams: HashMap<String, Team>,
-}
-
-impl Default for Scoreboard {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl Scoreboard {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->
## Description
A Detailed Description:
when I was reading the code I accidentally came across this:
```rust
impl Default for Scoreboard {
    fn default() -> Self {
        Self::new()
    }
}
```
In my opinion, this is a useless piece of code, because we can use #[derive(Default)] instead of this, for speed up
code read time.

## Testing
`cargo run` and joining to server

## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
