### PR TITLE
Adds "Expensive Task" API and eager cancelling to client

### DIFF
--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -16,7 +16,7 @@ use crate::{
     world_gen::{get_world_gen, Seed, WorldGenerator},
 };
 
-pub type ConcurrentChunkResult = Vec<(Vector2<i32>, JoinHandle<()>)>;
+pub type ConcurrentChunkResult = (Vec<Vector2<i32>>, Vec<JoinHandle<()>>);
 
 /// The `Level` module provides functionality for working with chunks within or outside a Minecraft world.
 ///

--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -56,13 +56,13 @@ impl Client {
     }
 
     pub async fn handle_status_request(&self, server: &Server, _status_request: SStatusRequest) {
-        log::debug!("Handling status request for id");
+        log::debug!("Handling status request for {}", self.id);
         let status = server.get_status();
         self.send_packet(&status.lock().await.get_status()).await;
     }
 
     pub async fn handle_ping_request(&self, ping_request: SStatusPingRequest) {
-        log::debug!("Handling ping request for id");
+        log::debug!("Handling ping request for {}", self.id);
         self.send_packet(&CPingResponse::new(ping_request.payload))
             .await;
         self.close();
@@ -147,7 +147,7 @@ impl Client {
         server: &Server,
         encryption_response: SEncryptionResponse,
     ) {
-        log::debug!("Handling encryption for id");
+        log::debug!("Handling encryption for {}", self.id);
         let shared_secret = server.decrypt(&encryption_response.shared_secret).unwrap();
 
         if let Err(error) = self.set_encryption(Some(&shared_secret)).await {
@@ -254,7 +254,7 @@ impl Client {
     }
 
     pub async fn handle_plugin_response(&self, plugin_response: SLoginPluginResponse) {
-        log::debug!("Handling plugin for id");
+        log::debug!("Handling plugin for {}", self.id);
         let velocity_config = &ADVANCED_CONFIG.proxy.velocity;
         if velocity_config.enabled {
             let mut address = self.address.lock().await;
@@ -278,7 +278,7 @@ impl Client {
         server: &Server,
         _login_acknowledged: SLoginAcknowledged,
     ) {
-        log::debug!("Handling login acknowledged for id");
+        log::debug!("Handling login acknowledged for {}", self.id);
         self.connection_state.store(ConnectionState::Config);
         self.send_packet(&server.get_branding()).await;
 
@@ -315,7 +315,7 @@ impl Client {
         &self,
         client_information: SClientInformationConfig,
     ) {
-        log::debug!("Handling client settings for id");
+        log::debug!("Handling client settings for {}", self.id);
         if let (Some(main_hand), Some(chat_mode)) = (
             Hand::from_i32(client_information.main_hand.into()),
             ChatMode::from_i32(client_information.chat_mode.into()),
@@ -336,7 +336,7 @@ impl Client {
     }
 
     pub async fn handle_plugin_message(&self, plugin_message: SPluginMessage) {
-        log::debug!("Handling plugin message for id");
+        log::debug!("Handling plugin message for {}", self.id);
         if plugin_message.channel.starts_with("minecraft:brand")
             || plugin_message.channel.starts_with("MC|Brand")
         {
@@ -349,7 +349,7 @@ impl Client {
     }
 
     pub async fn handle_known_packs(&self, server: &Server, _config_acknowledged: SKnownPacks) {
-        log::debug!("Handling known packs for id");
+        log::debug!("Handling known packs for {}", self.id);
         for registry in &server.cached_registry {
             self.send_packet(&CRegistryData::new(
                 &registry.registry_id,
@@ -364,7 +364,7 @@ impl Client {
     }
 
     pub fn handle_config_acknowledged(&self, _config_acknowledged: &SAcknowledgeFinishConfig) {
-        log::debug!("Handling config acknowledge for id");
+        log::debug!("Handling config acknowledge for {}", self.id);
         self.connection_state.store(ConnectionState::Play);
         self.make_player
             .store(true, std::sync::atomic::Ordering::Relaxed);

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -540,7 +540,7 @@ impl Client {
         server: &Arc<Server>,
         packet: &mut RawPacket,
     ) -> Result<(), DeserializerError> {
-        log::debug!("Handling login group for id");
+        log::debug!("Handling login group for {}", self.id);
         let bytebuf = &mut packet.bytebuf;
         if let Some(packet) = ServerboundLoginPackets::from_i32(packet.id.0) {
             match packet {

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -183,7 +183,7 @@ async fn main() -> io::Result<()> {
                 .make_player
                 .load(std::sync::atomic::Ordering::Relaxed)
             {
-                let (player, world) = server.add_player(client).await;
+                let (player, world) = server.add_player(client.clone()).await;
                 world.spawn_player(&BASIC_CONFIG, player.clone()).await;
                 // poll Player
                 while !player
@@ -196,7 +196,12 @@ async fn main() -> io::Result<()> {
                         player.process_packets(&server).await;
                     };
                 }
-                log::debug!("Cleaning up player for id {}", id);
+                log::debug!(
+                    "Cleaning up player for id {} ({})",
+                    id,
+                    player.gameprofile.name
+                );
+                client.cancel_expensive_tasks("Closed connection");
                 player.remove().await;
                 server.remove_player().await;
             }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -138,8 +138,9 @@ impl World {
         let entity_id = player.entity_id();
         let gamemode = player.gamemode.load();
         log::debug!(
-            "spawning player {}, entity id {}",
+            "spawning player {} ({}), entity id {}",
             player.gameprofile.name,
+            player.client.id,
             entity_id
         );
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -460,8 +460,11 @@ impl World {
 
             // Remove all canceled chunks
             for task_id in ids {
-                player.client.stop_watching_expensive_task(&task_id);
-                log::debug!("Aborted task {} (pre-process)", task_id,);
+                if let Some(task) = player.client.stop_watching_expensive_task(&task_id) {
+                    if task.aborted() {
+                        log::debug!("Aborted task {} (pre-process)", task_id);
+                    }
+                }
             }
 
             {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->
## Description
A Detailed Description:
Adds an idea of "expensive tasks" to the client where the client can watch async tasks that take a lot of compute power so they can be cancelled if no longer needed.

## Testing
A description of the tests performed to verify the changes:
Built in debug mode for slow chunk spawning, then flew around.

## Checklist
Things need to be done before this Pull Request can be merged.
N/A

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
