### PR TITLE
small CChunkData write improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ edition = "2021"
 lto = true
 codegen-units = 1
 
+[profile.profiling]
+inherits = "release"
+debug = true
+
 [workspace.dependencies]
 log = "0.4"
 tokio = { version = "1.41", features = [

--- a/pumpkin-protocol/src/client/play/c_chunk_data.rs
+++ b/pumpkin-protocol/src/client/play/c_chunk_data.rs
@@ -54,9 +54,7 @@ impl<'a> ClientPacket for CChunkData<'a> {
                     // Palette length
                     data_buf.put_var_int(&VarInt(palette.len() as i32));
 
-                    let mut palette_ids = Vec::with_capacity(palette.len());
                     palette.iter().for_each(|id| {
-                        palette_ids.push(*id);
                         // Palette
                         data_buf.put_var_int(&VarInt(id.get_id_mojang_repr()));
                     });
@@ -68,7 +66,7 @@ impl<'a> ClientPacket for CChunkData<'a> {
                     for block_clump in chunk.chunks(64 / block_size as usize) {
                         let mut out_long: i64 = 0;
                         for block in block_clump.iter().rev() {
-                            let index = palette_ids
+                            let index = palette
                                 .iter()
                                 .position(|b| *b == block)
                                 .expect("Its just got added, ofc it should be there");

--- a/pumpkin-protocol/src/client/play/c_chunk_data.rs
+++ b/pumpkin-protocol/src/client/play/c_chunk_data.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use crate::{bytebuf::ByteBuffer, BitSet, ClientPacket, VarInt};
 use itertools::Itertools;
 
@@ -55,23 +53,26 @@ impl<'a> ClientPacket for CChunkData<'a> {
                     data_buf.put_u8(block_size as u8);
                     // Palette length
                     data_buf.put_var_int(&VarInt(palette.len() as i32));
-                    let mut palette_map = HashMap::new();
-                    palette.iter().enumerate().for_each(|(i, id)| {
-                        palette_map.insert(*id, i);
+
+                    let mut palette_ids = Vec::with_capacity(palette.len());
+                    palette.iter().for_each(|id| {
+                        palette_ids.push(*id);
                         // Palette
                         data_buf.put_var_int(&VarInt(id.get_id_mojang_repr()));
                     });
                     // Data array length
-                    data_buf.put_var_int(&VarInt(
-                        chunk.len().div_ceil(64 / block_size as usize) as i32
-                    ));
+                    let data_array_len = chunk.len().div_ceil(64 / block_size as usize);
+                    data_buf.put_var_int(&VarInt(data_array_len as i32));
+
+                    data_buf.reserve(data_array_len * 8);
                     for block_clump in chunk.chunks(64 / block_size as usize) {
                         let mut out_long: i64 = 0;
                         for block in block_clump.iter().rev() {
-                            let index = palette_map
-                                .get(block)
+                            let index = palette_ids
+                                .iter()
+                                .position(|b| *b == block)
                                 .expect("Its just got added, ofc it should be there");
-                            out_long = out_long << block_size | (*index as i64);
+                            out_long = out_long << block_size | (index as i64);
                         }
                         data_buf.put_i64(out_long);
                     }
@@ -80,9 +81,10 @@ impl<'a> ClientPacket for CChunkData<'a> {
                     // Bits per entry
                     data_buf.put_u8(DIRECT_PALETTE_BITS as u8);
                     // Data array length
-                    data_buf.put_var_int(&VarInt(
-                        chunk.len().div_ceil(64 / DIRECT_PALETTE_BITS as usize) as i32,
-                    ));
+                    let data_array_len = chunk.len().div_ceil(64 / DIRECT_PALETTE_BITS as usize);
+                    data_buf.put_var_int(&VarInt(data_array_len as i32));
+
+                    data_buf.reserve(data_array_len * 8);
                     for block_clump in chunk.chunks(64 / DIRECT_PALETTE_BITS as usize) {
                         let mut out_long: i64 = 0;
                         let mut shift = 0;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->
## Description
- Replaced the HashMap in CChunkData::write with a Vec
- Added profiling profile

Even though Vec has a worse time complexity for this, the HashMap overhead is worse for performance

## Testing
Performance profiling was done using cargo-flamegraph.
If this breaks something I'll be genuinely surprised.

## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
