### PR TITLE
Fix: Use correct packet for set_help_item

### DIFF
--- a/pumpkin-protocol/src/server/play/s_set_held_item.rs
+++ b/pumpkin-protocol/src/server/play/s_set_held_item.rs
@@ -2,7 +2,7 @@ use pumpkin_macros::server_packet;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-#[server_packet("play:pick_item")]
+#[server_packet("play:set_carried_item")]
 pub struct SSetHeldItem {
     pub slot: i16,
 }


### PR DESCRIPTION
*

<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->
## Description
A Detailed Description:  According to the wiki we need to use (~~0x2F~~) 0x31 for set held item, this fixes the bug where if you have something in your 1st slot you would be able to place it with any other slot selected. 
This issue is partly referenced in #230

## Testing
A description of the tests performed to verify the changes: Put a block in the first slot, select said slot, then change the selected slot to any other, then try placing the block

## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
