### PR TITLE
List command + Better message on server stop

### DIFF
--- a/pumpkin/src/command/commands/cmd_list.rs
+++ b/pumpkin/src/command/commands/cmd_list.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use itertools::Itertools;
+use pumpkin_config::BASIC_CONFIG;
+use pumpkin_core::text::TextComponent;
+
+use crate::{
+    command::{
+        args::ConsumedArgs, tree::CommandTree, CommandExecutor, CommandSender, InvalidTreeError,
+    },
+    entity::player::Player,
+};
+
+const NAMES: [&str; 1] = ["list"];
+
+const DESCRIPTION: &str = "Print the list of online players.";
+
+struct ListExecutor;
+
+#[async_trait]
+impl CommandExecutor for ListExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        server: &crate::server::Server,
+        _args: &ConsumedArgs<'a>,
+    ) -> Result<(), InvalidTreeError> {
+        let players: Vec<Arc<Player>> = server.get_all_players().await;
+
+        let message = if players.is_empty() {
+            "There are no players online."
+        } else {
+            &format!(
+                "There are {} of a max of {} players online: {}",
+                players.len(),
+                BASIC_CONFIG.max_players,
+                players
+                    .iter()
+                    .map(|player| &player.gameprofile.name)
+                    .join(", ")
+            )
+        };
+
+        sender.send_message(TextComponent::text(message)).await;
+
+        Ok(())
+    }
+}
+
+pub fn init_command_tree<'a>() -> CommandTree<'a> {
+    CommandTree::new(NAMES, DESCRIPTION).execute(&ListExecutor)
+}

--- a/pumpkin/src/command/commands/cmd_stop.rs
+++ b/pumpkin/src/command/commands/cmd_stop.rs
@@ -18,7 +18,7 @@ impl CommandExecutor for StopExecutor {
     async fn execute<'a>(
         &self,
         sender: &mut CommandSender<'a>,
-        _server: &crate::server::Server,
+        server: &crate::server::Server,
         _args: &ConsumedArgs<'a>,
     ) -> Result<(), InvalidTreeError> {
         sender
@@ -26,6 +26,12 @@ impl CommandExecutor for StopExecutor {
             .await;
 
         // TODO: Gracefully stop
+
+        let kick_message = TextComponent::text("Server stopped");
+        for player in server.get_all_players().await {
+            player.kick(kick_message.clone()).await;
+        }
+
         std::process::exit(0)
     }
 }

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod cmd_gamemode;
 pub mod cmd_help;
 pub mod cmd_kick;
 pub mod cmd_kill;
+pub mod cmd_list;
 pub mod cmd_pumpkin;
 pub mod cmd_say;
 pub mod cmd_stop;

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
-    cmd_echest, cmd_gamemode, cmd_help, cmd_kick, cmd_kill, cmd_pumpkin, cmd_say, cmd_stop,
-    cmd_teleport, cmd_worldborder,
+    cmd_echest, cmd_gamemode, cmd_help, cmd_kick, cmd_kill, cmd_list, cmd_pumpkin, cmd_say,
+    cmd_stop, cmd_teleport, cmd_worldborder,
 };
 use dispatcher::InvalidTreeError;
 use pumpkin_core::math::vector3::Vector3;
@@ -82,6 +82,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_kick::init_command_tree());
     dispatcher.register(cmd_worldborder::init_command_tree());
     dispatcher.register(cmd_teleport::init_command_tree());
+    dispatcher.register(cmd_list::init_command_tree());
 
     Arc::new(dispatcher)
 }


### PR DESCRIPTION
## Description
- Added command /list that print the names of online players
- Kicking players with a proper message on /stop (Maybe should be added on signal interrupt)

## Testing
Use /list in game or in console with or without online players
Use /stop and see the message

## Checklist
N/A
- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`