### PR TITLE
Fix: Set air block state when breaking a block

### DIFF
--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -498,7 +498,6 @@ impl Player {
                         return;
                     }
                     // Block break & block break sound
-                    // TODO: currently this is always dirt replace it
                     let entity = &self.living_entity.entity;
                     let world = &entity.world;
                     world.break_block(location).await;

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -25,9 +25,9 @@ use pumpkin_protocol::{
     },
     ClientPacket, VarInt,
 };
-use pumpkin_world::chunk::ChunkData;
 use pumpkin_world::coordinates::ChunkRelativeBlockCoordinates;
 use pumpkin_world::level::Level;
+use pumpkin_world::{block::BlockState, chunk::ChunkData};
 use rand::{thread_rng, Rng};
 use scoreboard::Scoreboard;
 use tokio::sync::{mpsc::Receiver, Mutex};
@@ -622,8 +622,13 @@ impl World {
     pub async fn break_block(&self, position: WorldPosition) {
         self.set_block(position, 0).await;
 
-        self.broadcast_packet_all(&CWorldEvent::new(2001, &position, 11, false))
-            .await;
+        self.broadcast_packet_all(&CWorldEvent::new(
+            2001,
+            &position,
+            i32::from(BlockState::AIR.state_id),
+            false,
+        ))
+        .await;
     }
 
     pub async fn get_block(&self, position: WorldPosition) -> u16 {


### PR DESCRIPTION
* Fixes the dirt block particles when breaking a block

<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
The server broadcasted a block breaking event with the block state `11`. Which meant that it set the new block's (air block)
state to 11, which isn't a valid state for that block.
<!-- A description of the tests performed to verify the changes -->
## Testing
Place a block, which is not dirt or grass and then break it, no more dual particles
<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [ ] Maybe consider using a constant 0 instead of importing the static var
- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
