### PR TITLE
MPSC channel buffer fix

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -356,6 +356,7 @@ impl World {
     }
 
     #[expect(clippy::too_many_lines)]
+    /// IMPORTANT: Chunks have to be non-empty
     fn spawn_world_chunks(&self, player: Arc<Player>, chunks: &[Vector2<i32>]) {
         if player
             .client

--- a/pumpkin/src/world/player_chunker.rs
+++ b/pumpkin/src/world/player_chunker.rs
@@ -47,8 +47,10 @@ pub async fn player_join(world: &World, player: Arc<Player>) {
 
     let new_cylindrical = Cylindrical::new(Vector2::new(chunk_pos.x, chunk_pos.z), view_distance);
     let loading_chunks = new_cylindrical.all_chunks_within();
-
-    world.spawn_world_chunks(player, &loading_chunks);
+    
+    if !loading_chunks.is_empty() {
+        world.spawn_world_chunks(player, &loading_chunks);
+    }
 }
 
 pub async fn update_position(player: &Arc<Player>) {

--- a/pumpkin/src/world/player_chunker.rs
+++ b/pumpkin/src/world/player_chunker.rs
@@ -47,7 +47,7 @@ pub async fn player_join(world: &World, player: Arc<Player>) {
 
     let new_cylindrical = Cylindrical::new(Vector2::new(chunk_pos.x, chunk_pos.z), view_distance);
     let loading_chunks = new_cylindrical.all_chunks_within();
-    
+
     if !loading_chunks.is_empty() {
         world.spawn_world_chunks(player, &loading_chunks);
     }


### PR DESCRIPTION
Fix: https://github.com/Snowiiii/Pumpkin/issues/229
Fix: Reported in Discord

```
mini-1   | thread 'tokio-runtime-worker' panicked at pumpkin/src/world/mod.rs:592:33:
mini-1   | mpsc bounded channel requires buffer > 0
mini-1   | stack backtrace:
mini-1   |    0:     0x55f9d5e191ac - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h304520fd6a30aa07
mini-1   |    1:     0x55f9d5b96c6b - core::fmt::write::hf5713710ce10ff22
mini-1   |    2:     0x55f9d5deca72 - std::io::Write::write_fmt::hda708db57927dacf
mini-1   |    3:     0x55f9d5e1e348 - std::panicking::default_hook::{{closure}}::he1ad87607d0c11c5
mini-1   |    4:     0x55f9d5e1dfd1 - std::panicking::default_hook::h81c8cd2e7c59ee33
mini-1   |    5:     0x55f9d5b7edae - pumpkin::main::{{closure}}::{{closure}}::hc9deebfb693d4711
mini-1   |    6:     0x55f9d5e1ef79 - std::panicking::rust_panic_with_hook::had2118629c312a4a
mini-1   |    7:     0x55f9d5e1ecb2 - std::panicking::begin_panic_handler::{{closure}}::h7fa5985d111bafa2
mini-1   |    8:     0x55f9d5e1ec49 - std::sys::backtrace::__rust_end_short_backtrace::h704d151dbefa09c5
mini-1   |    9:     0x55f9d5e1ec34 - rust_begin_unwind
mini-1   |   10:     0x55f9d5a74d02 - core::panicking::panic_fmt::h3eea515d05f7a35e
mini-1   |   11:     0x55f9d5b5f5e1 - pumpkin::world::World::receive_chunks::h5f94f135d2b3fadd
mini-1   |   12:     0x55f9d5b55b1f - pumpkin::world::World::spawn_world_chunks::hd0d451ce338daea6
mini-1   |   13:     0x55f9d5b532a5 - pumpkin::world::World::spawn_player::{{closure}}::hfccea441522181e1
mini-1   |   14:     0x55f9d5b8a200 - pumpkin::main::{{closure}}::{{closure}}::h1d2d6f9c87997936
mini-1   |   15:     0x55f9d5abfb91 - tokio::runtime::task::raw::poll::ha08181843b9e5a7d
mini-1   |   16:     0x55f9d5e36bd3 - tokio::runtime::scheduler::multi_thread::worker::Context::run_task::h863c34c3a52b62ae
mini-1   |   17:     0x55f9d5e3c9c0 - tokio::runtime::task::raw::poll::h60044f893c6725c2
mini-1   |   18:     0x55f9d5e2da06 - std::sys::backtrace::__rust_begin_short_backtrace::hfede57c8454d3b58
mini-1   |   19:     0x55f9d5e2d715 - core::ops::function::FnOnce::call_once{{vtable.shim}}::hede0001341afbe3a
mini-1   |   20:     0x55f9d5e1fadb - std::sys::pal::unix::thread::Thread::new::thread_start::hcdbd1049068002f4
mini-1   |   21:     0x7f098a415144 - <unknown>
mini-1   |   22:     0x7f098a494a40 - __clone
mini-1   |   23:                0x0 - <unknown>
``