### PR TITLE
Clear command and details

### DIFF
--- a/pumpkin/src/command/commands/cmd_clear.rs
+++ b/pumpkin/src/command/commands/cmd_clear.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use pumpkin_core::text::color::NamedColor;
+use pumpkin_core::text::TextComponent;
+
+use crate::command::args::arg_entities::EntitiesArgumentConsumer;
+use crate::command::args::{Arg, ConsumedArgs};
+use crate::command::tree::CommandTree;
+use crate::command::tree_builder::{argument, require};
+use crate::command::{CommandExecutor, CommandSender, InvalidTreeError};
+use crate::entity::player::Player;
+use InvalidTreeError::InvalidConsumptionError;
+
+const NAMES: [&str; 1] = ["clear"];
+const DESCRIPTION: &str = "Clear yours or targets inventory.";
+
+const ARG_TARGET: &str = "target";
+
+async fn clear_player(target: &Arc<Player>) -> usize {
+    let mut inventory = target.inventory.lock().await;
+
+    // There may be a better way to do this with something like all_slots() or .clear on Player.inventory
+    let mut items_count: usize = 0;
+    for slot in 0..=45 {
+        if let Some(item) = inventory.get_slot(slot).unwrap() {
+            items_count += item.item_count as usize;
+            inventory.set_slot(slot as u16, None, true).unwrap();
+            target
+                .send_inventory_slot_update(&mut inventory, slot)
+                .await
+                .unwrap();
+        }
+    }
+    items_count
+}
+
+struct ClearExecutor;
+
+#[async_trait]
+impl CommandExecutor for ClearExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        _server: &crate::server::Server,
+        args: &ConsumedArgs<'a>,
+    ) -> Result<(), InvalidTreeError> {
+        let Some(Arg::Entities(targets)) = args.get(&ARG_TARGET) else {
+            return Err(InvalidConsumptionError(Some(ARG_TARGET.into())));
+        };
+
+        let target_count = targets.len();
+
+        let mut items_count = 0;
+        for target in targets {
+            let item_count = clear_player(target).await;
+            items_count += item_count;
+        }
+
+        let msg = if target_count == 1 {
+            let target = targets.first().unwrap();
+            if items_count == 0 {
+                TextComponent::text_string(format!(
+                    "No items were found on player {}",
+                    target.gameprofile.name
+                ))
+                .color_named(NamedColor::Red)
+            } else {
+                TextComponent::text_string(format!(
+                    "Removed {} item(s) on player {}",
+                    items_count, target.gameprofile.name
+                ))
+            }
+        } else if items_count == 0 {
+            TextComponent::text_string(format!("No items were found on {target_count} players"))
+                .color_named(NamedColor::Red)
+        } else {
+            TextComponent::text_string(format!(
+                "Removed {items_count} item(s) from {target_count} players"
+            ))
+        };
+
+        sender.send_message(msg).await;
+
+        Ok(())
+    }
+}
+
+struct ClearSelfExecutor;
+
+#[async_trait]
+impl CommandExecutor for ClearSelfExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        _server: &crate::server::Server,
+        _args: &ConsumedArgs<'a>,
+    ) -> Result<(), InvalidTreeError> {
+        let target = sender
+            .as_player()
+            .ok_or(InvalidTreeError::InvalidRequirementError)?;
+
+        let items_count = clear_player(&target).await;
+
+        let msg = if items_count == 0 {
+            TextComponent::text_string(format!(
+                "No items were found on player {}",
+                target.gameprofile.name
+            ))
+            .color_named(NamedColor::Red)
+        } else {
+            TextComponent::text_string(format!(
+                "Removed {} item(s) on player {}",
+                items_count, target.gameprofile.name
+            ))
+        };
+
+        sender.send_message(msg).await;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::redundant_closure_for_method_calls)] // causes lifetime issues
+pub fn init_command_tree<'a>() -> CommandTree<'a> {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(argument(ARG_TARGET, &EntitiesArgumentConsumer).execute(&ClearExecutor))
+        .with_child(require(&|sender| sender.is_player()).execute(&ClearSelfExecutor))
+}

--- a/pumpkin/src/command/commands/cmd_kill.rs
+++ b/pumpkin/src/command/commands/cmd_kill.rs
@@ -35,7 +35,7 @@ impl CommandExecutor for KillExecutor {
         }
 
         let msg = if target_count == 1 {
-            TextComponent::text("Enitity has been killed.")
+            TextComponent::text("Entity has been killed.")
         } else {
             TextComponent::text_string(format!("{target_count} entities have been killed."))
         };

--- a/pumpkin/src/command/commands/cmd_pumpkin.rs
+++ b/pumpkin/src/command/commands/cmd_pumpkin.rs
@@ -9,7 +9,7 @@ use crate::{
     server::CURRENT_MC_VERSION,
 };
 
-const NAMES: [&str; 1] = ["pumpkin"];
+const NAMES: [&str; 2] = ["pumpkin", "version"];
 
 const DESCRIPTION: &str = "Display information about Pumpkin.";
 

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod cmd_clear;
 pub mod cmd_echest;
 pub mod cmd_gamemode;
 pub mod cmd_give;

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
-    cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill, cmd_list, cmd_pumpkin,
-    cmd_say, cmd_stop, cmd_teleport, cmd_worldborder,
+    cmd_clear, cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill, cmd_list,
+    cmd_pumpkin, cmd_say, cmd_stop, cmd_teleport, cmd_worldborder,
 };
 use dispatcher::InvalidTreeError;
 use pumpkin_core::math::vector3::Vector3;
@@ -84,6 +84,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_teleport::init_command_tree());
     dispatcher.register(cmd_give::init_command_tree());
     dispatcher.register(cmd_list::init_command_tree());
+    dispatcher.register(cmd_clear::init_command_tree());
 
     Arc::new(dispatcher)
 }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -838,7 +838,7 @@ impl Player {
             }
             SUseItem::PACKET_ID => self.handle_use_item(&SUseItem::read(bytebuf)?),
             _ => {
-                log::warn!("Failed to handle player packet id {}", packet.id.0);
+                log::warn!("Failed to handle player packet id {:#04x}", packet.id.0);
                 // TODO: We give an error if all play packets are implemented
                 //  return Err(Box::new(DeserializerError::UnknownPacket));
             }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -836,7 +836,7 @@ impl Player {
             }
             SUseItem::PACKET_ID => self.handle_use_item(&SUseItem::read(bytebuf)?),
             _ => {
-                log::warn!("Failed to handle player packet id {:#04x}", packet.id.0);
+                log::warn!("Failed to handle player packet id {:#04X}", packet.id.0);
                 // TODO: We give an error if all play packets are implemented
                 //  return Err(Box::new(DeserializerError::UnknownPacket));
             }


### PR DESCRIPTION
## Description

- Added a /clear command like the vanilla one
- Fixed a typo in KillCommand
- Added /version alias for /pumpkin
- Changed message format for unimplemented packet id to match the protocol documentation from [wiki.vg](https://wiki.vg/Main_Page)

## Testing
- [x] Clear command on self, player, players with and without stuff in inventories from client and console
- [x] Version command from client and console

## Checklist
- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
