### PR TITLE
Check collision before block place

### DIFF
--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -1,5 +1,7 @@
 use super::{position::WorldPosition, vector3::Vector3};
 
+
+#[derive(Clone, Copy)]
 pub struct BoundingBox {
     pub min_x: f64,
     pub min_y: f64,

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -8,30 +8,26 @@ pub struct BoundingBox {
     pub max_x: f64,
     pub max_y: f64,
     pub max_z: f64,
-    pub width: f64,
-    pub height: f64,
 }
 
 impl BoundingBox {
-    pub fn new_default(width: f64, height: f64) -> Self {
-        Self::new_from_pos(0., 0., 0., width, height)
+    pub fn new_default(size: &BoundingBoxSize) -> Self {
+        Self::new_from_pos(0., 0., 0., size)
     }
 
-    pub fn new_from_pos(x: f64, y: f64, z: f64, width: f64, height: f64) -> Self {
-        let f = width / 2.;
+    pub fn new_from_pos(x: f64, y: f64, z: f64, size: &BoundingBoxSize) -> Self {
+        let f = size.width / 2.;
         Self {
             min_x: x - f,
             min_y: y,
             min_z: z - f,
             max_x: x + f,
-            max_y: y + height,
+            max_y: y + size.height,
             max_z: z + f,
-            width,
-            height,
         }
     }
 
-    pub fn new(min: Vector3<f64>, max: Vector3<f64>, width: f64, height: f64) -> Self {
+    pub fn new(min: Vector3<f64>, max: Vector3<f64>) -> Self {
         Self {
             min_x: min.x,
             min_y: min.y,
@@ -39,8 +35,6 @@ impl BoundingBox {
             max_x: max.x,
             max_y: max.y,
             max_z: max.z,
-            width,
-            height,
         }
     }
 
@@ -53,8 +47,6 @@ impl BoundingBox {
             max_x: (position.x as f64) + 1.0,
             max_y: (position.y as f64) + 1.0,
             max_z: (position.z as f64) + 1.0,
-            width: 1., //Block is 1.0 * 1.0
-            height: 1.,
         }
     }
 
@@ -73,4 +65,10 @@ impl BoundingBox {
         let f = f64::max(f64::max(self.min_z - pos.z, pos.z - self.max_z), 0.0);
         super::squared_magnitude(d, e, f)
     }
+}
+
+#[derive(Clone, Copy)]
+pub struct BoundingBoxSize {
+    pub width: f64,
+    pub height: f64,
 }

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -7,6 +7,8 @@ pub struct BoundingBox {
     pub max_x: f64,
     pub max_y: f64,
     pub max_z: f64,
+    pub width: f64,
+    pub height: f64,
 }
 
 impl BoundingBox {
@@ -23,10 +25,12 @@ impl BoundingBox {
             max_x: x + f,
             max_y: y + height,
             max_z: z + f,
+            width,
+            height,
         }
     }
 
-    pub fn new(min_x: f64, min_y: f64, min_z: f64, max_x: f64, max_y: f64, max_z: f64) -> Self {
+    pub fn new(min_x: f64, min_y: f64, min_z: f64, max_x: f64, max_y: f64, max_z: f64, width: f64, height: f64) -> Self {
         Self {
             min_x,
             min_y,
@@ -34,6 +38,8 @@ impl BoundingBox {
             max_x,
             max_y,
             max_z,
+            width,
+            height,
         }
     }
 
@@ -46,6 +52,8 @@ impl BoundingBox {
             max_x: (position.x as f64) + 1.0,
             max_y: (position.y as f64) + 1.0,
             max_z: (position.z as f64) + 1.0,
+            width: 1., //Block is 1.0 * 1.0
+            height: 1.,
         }
     }
 

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -1,6 +1,5 @@
 use super::{position::WorldPosition, vector3::Vector3};
 
-
 #[derive(Clone, Copy)]
 pub struct BoundingBox {
     pub min_x: f64,
@@ -59,10 +58,13 @@ impl BoundingBox {
         }
     }
 
-    pub fn bounding_boxes_intersect(b1: &BoundingBox, b2: &BoundingBox) -> bool {
-        b1.min_x < b2.max_x && b1.max_x > b2.min_x &&
-        b1.min_y < b2.max_y && b1.max_y > b2.min_y &&
-        b1.min_z < b2.max_z && b1.max_z > b2.min_z
+    pub fn bounding_boxes_intersect(&self, other: &BoundingBox) -> bool {
+        self.min_x < other.max_x
+            && self.max_x > other.min_x
+            && self.min_y < other.max_y
+            && self.max_y > other.min_y
+            && self.min_z < other.max_z
+            && self.max_z > other.min_z
     }
 
     pub fn squared_magnitude(&self, pos: Vector3<f64>) -> f64 {

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -32,14 +32,14 @@ impl BoundingBox {
         }
     }
 
-    pub fn new(min_x: f64, min_y: f64, min_z: f64, max_x: f64, max_y: f64, max_z: f64, width: f64, height: f64) -> Self {
+    pub fn new(min: Vector3<f64>, max: Vector3<f64>, width: f64, height: f64) -> Self {
         Self {
-            min_x,
-            min_y,
-            min_z,
-            max_x,
-            max_y,
-            max_z,
+            min_x: min.x,
+            min_y: min.y,
+            min_z: min.z,
+            max_x: max.x,
+            max_y: max.y,
+            max_z: max.z,
             width,
             height,
         }

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -50,7 +50,7 @@ impl BoundingBox {
         }
     }
 
-    pub fn bounding_boxes_intersect(&self, other: &BoundingBox) -> bool {
+    pub fn intersects(&self, other: &BoundingBox) -> bool {
         self.min_x < other.max_x
             && self.max_x > other.min_x
             && self.min_y < other.max_y

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -59,6 +59,12 @@ impl BoundingBox {
         }
     }
 
+    pub fn bounding_boxes_intersect(b1: &BoundingBox, b2: &BoundingBox) -> bool {
+        b1.min_x < b2.max_x && b1.max_x > b2.min_x &&
+        b1.min_y < b2.max_y && b1.max_y > b2.min_y &&
+        b1.min_z < b2.max_z && b1.max_z > b2.min_z
+    }
+
     pub fn squared_magnitude(&self, pos: Vector3<f64>) -> f64 {
         let d = f64::max(f64::max(self.min_x - pos.x, pos.x - self.max_x), 0.0);
         let e = f64::max(f64::max(self.min_y - pos.y, pos.y - self.max_y), 0.0);

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -10,6 +10,22 @@ pub struct BoundingBox {
 }
 
 impl BoundingBox {
+    pub fn new_default(width: f64, height: f64) -> Self {
+        Self::new_from_pos(0., 0., 0., width, height)
+    }
+
+    pub fn new_from_pos(x: f64, y: f64, z: f64, width: f64, height: f64) -> Self {
+        let f = width / 2.;
+        Self {
+            min_x: x - f,
+            min_y: y,
+            min_z: z - f,
+            max_x: x + f,
+            max_y: y + height,
+            max_z: z + f,
+        }
+    }
+
     pub fn new(min_x: f64, min_y: f64, min_z: f64, max_x: f64, max_y: f64, max_z: f64) -> Self {
         Self {
             min_x,

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -583,12 +583,7 @@ impl Player {
 
                     //TODO: Make this check for every entity in that posistion
                     if !BoundingBox::bounding_boxes_intersect(&block_bounding_box, &bounding_box) {
-                        world
-                        .set_block(
-                            world_pos,
-                            block.default_state_id,
-                        )
-                        .await;
+                        world.set_block(world_pos, block.default_state_id).await;
                     }
                 }
                 self.client

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -582,7 +582,7 @@ impl Player {
                     let bounding_box = self.living_entity.entity.bounding_box.load();
 
                     //TODO: Make this check for every entity in that posistion
-                    if !BoundingBox::bounding_boxes_intersect(&block_bounding_box, &bounding_box) {
+                    if !BoundingBox::intersects(&block_bounding_box, &bounding_box) {
                         world.set_block(world_pos, block.default_state_id).await;
                     }
                 }

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use num_traits::FromPrimitive;
 use pumpkin_config::ADVANCED_CONFIG;
-use pumpkin_core::math::position::WorldPosition;
+use pumpkin_core::math::{boundingbox::BoundingBox, position::WorldPosition};
 use pumpkin_core::{
     math::{vector3::Vector3, wrap_degrees},
     text::TextComponent,
@@ -577,12 +577,18 @@ impl Player {
                         }
                     }
 
-                    world
+                    let world_pos = WorldPosition(location.0 + face.to_offset());
+                    let block_bounding_box = BoundingBox::from_block(&world_pos);
+                    let bounding_box = self.living_entity.entity.bounding_box.load();
+
+                    if !BoundingBox::bounding_boxes_intersect(&block_bounding_box, &bounding_box) {
+                        world
                         .set_block(
-                            WorldPosition(location.0 + face.to_offset()),
+                            world_pos,
                             block.default_state_id,
                         )
                         .await;
+                    }
                 }
                 self.client
                     .send_packet(&CAcknowledgeBlockChange::new(use_item_on.sequence))

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -579,10 +579,10 @@ impl Player {
 
                     let world_pos = WorldPosition(location.0 + face.to_offset());
                     let block_bounding_box = BoundingBox::from_block(&world_pos);
-                    let bounding_box = self.living_entity.entity.bounding_box.load();
-
+                    let bounding_box = entity.bounding_box.load();
+                    
                     //TODO: Make this check for every entity in that posistion
-                    if !BoundingBox::intersects(&block_bounding_box, &bounding_box) {
+                    if !bounding_box.intersects(&block_bounding_box) {
                         world.set_block(world_pos, block.default_state_id).await;
                     }
                 }

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -581,6 +581,7 @@ impl Player {
                     let block_bounding_box = BoundingBox::from_block(&world_pos);
                     let bounding_box = self.living_entity.entity.bounding_box.load();
 
+                    //TODO: Make this check for every entity in that posistion
                     if !BoundingBox::bounding_boxes_intersect(&block_bounding_box, &bounding_box) {
                         world
                         .set_block(

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -580,7 +580,6 @@ impl Player {
                     let world_pos = WorldPosition(location.0 + face.to_offset());
                     let block_bounding_box = BoundingBox::from_block(&world_pos);
                     let bounding_box = entity.bounding_box.load();
-                    
                     //TODO: Make this check for every entity in that posistion
                     if !bounding_box.intersects(&block_bounding_box) {
                         world.set_block(world_pos, block.default_state_id).await;

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -3,7 +3,8 @@ use std::sync::{atomic::AtomicBool, Arc};
 use crossbeam::atomic::AtomicCell;
 use num_derive::FromPrimitive;
 use pumpkin_core::math::{
-    boundingbox::BoundingBox, get_section_cord, position::WorldPosition, vector2::Vector2, vector3::Vector3
+    boundingbox::BoundingBox, get_section_cord, position::WorldPosition, vector2::Vector2,
+    vector3::Vector3,
 };
 use pumpkin_entity::{entity_type::EntityType, pose::EntityPose, EntityId};
 use pumpkin_protocol::{
@@ -94,7 +95,13 @@ impl Entity {
             self.pos.store(Vector3::new(x, y, z));
 
             let old_box = self.bounding_box.load();
-            self.bounding_box.store(BoundingBox::new_from_pos(pos.x, pos.y, pos.z, old_box.width, old_box.height));
+            self.bounding_box.store(BoundingBox::new_from_pos(
+                pos.x,
+                pos.y,
+                pos.z,
+                old_box.width,
+                old_box.height,
+            ));
 
             let floor_x = x.floor() as i32;
             let floor_y = y.floor() as i32;

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -3,7 +3,7 @@ use std::sync::{atomic::AtomicBool, Arc};
 use crossbeam::atomic::AtomicCell;
 use num_derive::FromPrimitive;
 use pumpkin_core::math::{
-    get_section_cord, position::WorldPosition, vector2::Vector2, vector3::Vector3,
+    boundingbox::BoundingBox, get_section_cord, position::WorldPosition, vector2::Vector2, vector3::Vector3
 };
 use pumpkin_entity::{entity_type::EntityType, pose::EntityPose, EntityId};
 use pumpkin_protocol::{
@@ -50,6 +50,8 @@ pub struct Entity {
     pub standing_eye_height: f32,
     /// The entity's current pose (e.g., standing, sitting, swimming).
     pub pose: AtomicCell<EntityPose>,
+    /// The bounding box of an entity (hitbox)
+    pub bounding_box: BoundingBox,
 }
 
 impl Entity {
@@ -58,6 +60,7 @@ impl Entity {
         world: Arc<World>,
         entity_type: EntityType,
         standing_eye_height: f32,
+        bounding_box: BoundingBox,
     ) -> Self {
         Self {
             entity_id,
@@ -77,6 +80,7 @@ impl Entity {
             velocity: AtomicCell::new(Vector3::new(0.0, 0.0, 0.0)),
             standing_eye_height,
             pose: AtomicCell::new(EntityPose::Standing),
+            bounding_box,
         }
     }
 

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -3,7 +3,10 @@ use std::sync::{atomic::AtomicBool, Arc};
 use crossbeam::atomic::AtomicCell;
 use num_derive::FromPrimitive;
 use pumpkin_core::math::{
-    boundingbox::{BoundingBox, BoundingBoxSize}, get_section_cord, position::WorldPosition, vector2::Vector2,
+    boundingbox::{BoundingBox, BoundingBoxSize}, 
+    get_section_cord, 
+    position::WorldPosition, 
+    vector2::Vector2,
     vector3::Vector3,
 };
 use pumpkin_entity::{entity_type::EntityType, pose::EntityPose, EntityId};

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -3,9 +3,9 @@ use std::sync::{atomic::AtomicBool, Arc};
 use crossbeam::atomic::AtomicCell;
 use num_derive::FromPrimitive;
 use pumpkin_core::math::{
-    boundingbox::{BoundingBox, BoundingBoxSize}, 
-    get_section_cord, 
-    position::WorldPosition, 
+    boundingbox::{BoundingBox, BoundingBoxSize},
+    get_section_cord,
+    position::WorldPosition,
     vector2::Vector2,
     vector3::Vector3,
 };
@@ -88,7 +88,7 @@ impl Entity {
             standing_eye_height,
             pose: AtomicCell::new(EntityPose::Standing),
             bounding_box,
-            bounding_box_size
+            bounding_box_size,
         }
     }
 
@@ -105,7 +105,7 @@ impl Entity {
                 pos.x,
                 pos.y,
                 pos.z,
-                &self.bounding_box_size.load()
+                &self.bounding_box_size.load(),
             ));
 
             let floor_x = x.floor() as i32;

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -51,7 +51,7 @@ pub struct Entity {
     /// The entity's current pose (e.g., standing, sitting, swimming).
     pub pose: AtomicCell<EntityPose>,
     /// The bounding box of an entity (hitbox)
-    pub bounding_box: BoundingBox,
+    pub bounding_box: AtomicCell<BoundingBox>,
 }
 
 impl Entity {
@@ -60,7 +60,7 @@ impl Entity {
         world: Arc<World>,
         entity_type: EntityType,
         standing_eye_height: f32,
-        bounding_box: BoundingBox,
+        bounding_box: AtomicCell<BoundingBox>,
     ) -> Self {
         Self {
             entity_id,
@@ -92,6 +92,9 @@ impl Entity {
         let pos = self.pos.load();
         if pos.x != x || pos.y != y || pos.z != z {
             self.pos.store(Vector3::new(x, y, z));
+
+            let old_box = self.bounding_box.load();
+            self.bounding_box.store(BoundingBox::new_from_pos(pos.x, pos.y, pos.z, old_box.width, old_box.height));
 
             let floor_x = x.floor() as i32;
             let floor_y = y.floor() as i32;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1,5 +1,5 @@
 use std::{
-    cmp::min, collections::{HashMap, VecDeque}, ops::DerefMut, sync::{
+    cmp::min, collections::{HashMap, VecDeque}, sync::{
         atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU8},
         Arc,
     }, time::{Duration, Instant}

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -119,6 +119,7 @@ pub struct Player {
     /// The item currently being held by the player.
     pub carried_item: AtomicCell<Option<ItemStack>>,
 
+
     /// send `send_abilties_update` when changed
     /// The player's abilities and special powers.
     ///
@@ -183,6 +184,7 @@ impl Player {
                 world,
                 EntityType::Player,
                 1.62,
+                BoundingBox::new_default(0.6, 1.8),
             )),
             config: Mutex::new(config),
             gameprofile,
@@ -206,6 +208,7 @@ impl Player {
             pending_chunks: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             pending_chunk_batch: parking_lot::Mutex::new(HashMap::new()),
             cancel_tasks: Notify::new(),
+            
         }
     }
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -181,7 +181,7 @@ impl Player {
                 world,
                 EntityType::Player,
                 1.62,
-                BoundingBox::new_default(0.6, 1.8),
+                AtomicCell::new(BoundingBox::new_default(0.6, 1.8)),
             )),
             config: Mutex::new(config),
             gameprofile,

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -13,7 +13,7 @@ use itertools::Itertools;
 use num_derive::FromPrimitive;
 use pumpkin_config::ADVANCED_CONFIG;
 use pumpkin_core::{
-    math::{boundingbox::BoundingBox, position::WorldPosition, vector2::Vector2, vector3::Vector3},
+    math::{boundingbox::{BoundingBox, BoundingBoxSize}, position::WorldPosition, vector2::Vector2, vector3::Vector3},
     text::TextComponent,
     GameMode,
 };
@@ -177,13 +177,19 @@ impl Player {
             |profile| profile,
         );
         let config = client.config.lock().await.clone().unwrap_or_default();
+        let bounding_box_size = BoundingBoxSize {
+            width: 0.6,
+            height: 1.8,
+        };
+
         Self {
             living_entity: LivingEntity::new(Entity::new(
                 entity_id,
                 world,
                 EntityType::Player,
                 1.62,
-                AtomicCell::new(BoundingBox::new_default(0.6, 1.8)),
+                AtomicCell::new(BoundingBox::new_default(&bounding_box_size)),
+                AtomicCell::new(bounding_box_size),
             )),
             config: Mutex::new(config),
             gameprofile,

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1,11 +1,8 @@
 use std::{
-    cmp::min,
-    collections::{HashMap, VecDeque},
-    sync::{
+    cmp::min, collections::{HashMap, VecDeque}, ops::DerefMut, sync::{
         atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU8},
         Arc,
-    },
-    time::{Duration, Instant},
+    }, time::{Duration, Instant}
 };
 
 use crossbeam::atomic::AtomicCell;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -13,7 +13,12 @@ use itertools::Itertools;
 use num_derive::FromPrimitive;
 use pumpkin_config::ADVANCED_CONFIG;
 use pumpkin_core::{
-    math::{boundingbox::{BoundingBox, BoundingBoxSize}, position::WorldPosition, vector2::Vector2, vector3::Vector3},
+    math::{
+        boundingbox::{BoundingBox, BoundingBoxSize},
+        position::WorldPosition,
+        vector2::Vector2,
+        vector3::Vector3,
+    },
     text::TextComponent,
     GameMode,
 };

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1,8 +1,11 @@
 use std::{
-    cmp::min, collections::{HashMap, VecDeque}, sync::{
+    cmp::min,
+    collections::{HashMap, VecDeque},
+    sync::{
         atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU32, AtomicU8},
         Arc,
-    }, time::{Duration, Instant}
+    },
+    time::{Duration, Instant},
 };
 
 use crossbeam::atomic::AtomicCell;
@@ -116,7 +119,6 @@ pub struct Player {
     /// The item currently being held by the player.
     pub carried_item: AtomicCell<Option<ItemStack>>,
 
-
     /// send `send_abilties_update` when changed
     /// The player's abilities and special powers.
     ///
@@ -205,7 +207,6 @@ impl Player {
             pending_chunks: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             pending_chunk_batch: parking_lot::Mutex::new(HashMap::new()),
             cancel_tasks: Notify::new(),
-            
         }
     }
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,3 +1,4 @@
+use core::sync;
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
     sync::Arc,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,4 +1,3 @@
-use core::sync;
 use std::{
     collections::{hash_map::Entry, HashMap, VecDeque},
     sync::Arc,


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Added bounding boxes to every Entity, where a block has a width: 1.0 and a height: 1.0. A player has a width: 0.6 and a height: 1.8.
When placing a block, pumpkin now creates a temporary bounding box from that target position and checks whether the player's box collides with it or not. This way player are not able to place blocks in themself.

<!-- A description of the tests performed to verify the changes -->
## Testing
Tried placing blocks under myself and beside myself.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
- Check collision with bounding box of air block and other entities standing in that block, not only with player's own [ ]

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
