### PR TITLE
Implemented /msg, /tell and /w commands

### DIFF
--- a/pumpkin/src/command/commands/cmd_msg.rs
+++ b/pumpkin/src/command/commands/cmd_msg.rs
@@ -1,0 +1,71 @@
+use async_trait::async_trait;
+use pumpkin_core::text::{color::NamedColor, TextComponent};
+
+use crate::command::{
+    args::{arg_message::MsgArgConsumer, arg_players::PlayersArgumentConsumer, Arg, ConsumedArgs},
+    tree::CommandTree,
+    tree_builder::{argument, require},
+    CommandExecutor, CommandSender, InvalidTreeError,
+};
+use InvalidTreeError::InvalidConsumptionError;
+
+const NAMES: [&str; 3] = ["msg", "tell", "w"];
+
+const DESCRIPTION: &str = "Sends a private message to one or more players.";
+
+const ARG_TARGET: &str = "target";
+const ARG_MESSAGE: &str = "message";
+
+struct MsgExecutor;
+
+#[async_trait]
+impl CommandExecutor for MsgExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        _server: &crate::server::Server,
+        args: &ConsumedArgs<'a>,
+    ) -> Result<(), InvalidTreeError> {
+        let sender_name = match sender {
+            CommandSender::Console => "Console",
+            CommandSender::Rcon(_) => "Rcon",
+            CommandSender::Player(player) => &player.gameprofile.name.clone(),
+        };
+
+        let Some(Arg::Players(targets)) = args.get(&ARG_TARGET) else {
+            return Err(InvalidConsumptionError(Some(ARG_TARGET.into())));
+        };
+
+        let Some(Arg::Msg(msg)) = args.get(ARG_MESSAGE) else {
+            return Err(InvalidConsumptionError(Some(ARG_MESSAGE.into())));
+        };
+
+        for target_player in targets {
+            let recipient_message = format!("{sender_name} whispers to you: {msg}");
+            let sender_message =
+                format!("you whisper to {}: {msg}", target_player.gameprofile.name);
+
+            let recipient_text = TextComponent::text(&recipient_message)
+                .color_named(NamedColor::Gray)
+                .italic();
+
+            let sender_text = TextComponent::text(&sender_message)
+                .color_named(NamedColor::Gray)
+                .italic();
+
+            target_player.send_system_message(&recipient_text).await;
+            sender.send_message(sender_text).await;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn init_command_tree<'a>() -> CommandTree<'a> {
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        require(&|sender| sender.permission_lvl() >= 2).with_child(
+            argument(ARG_TARGET, &PlayersArgumentConsumer)
+                .with_child(argument(ARG_MESSAGE, &MsgArgConsumer).execute(&MsgExecutor)),
+        ),
+    )
+}

--- a/pumpkin/src/command/commands/cmd_msg.rs
+++ b/pumpkin/src/command/commands/cmd_msg.rs
@@ -4,7 +4,7 @@ use pumpkin_core::text::{color::NamedColor, TextComponent};
 use crate::command::{
     args::{arg_message::MsgArgConsumer, arg_players::PlayersArgumentConsumer, Arg, ConsumedArgs},
     tree::CommandTree,
-    tree_builder::{argument, require},
+    tree_builder::argument,
     CommandExecutor, CommandSender, InvalidTreeError,
 };
 use InvalidTreeError::InvalidConsumptionError;
@@ -63,9 +63,7 @@ impl CommandExecutor for MsgExecutor {
 
 pub fn init_command_tree<'a>() -> CommandTree<'a> {
     CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(&|sender| sender.permission_lvl() >= 2).with_child(
-            argument(ARG_TARGET, &PlayersArgumentConsumer)
-                .with_child(argument(ARG_MESSAGE, &MsgArgConsumer).execute(&MsgExecutor)),
-        ),
+        argument(ARG_TARGET, &PlayersArgumentConsumer)
+            .with_child(argument(ARG_MESSAGE, &MsgArgConsumer).execute(&MsgExecutor)),
     )
 }

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod cmd_clear;
 pub mod cmd_echest;
 pub mod cmd_gamemode;
 pub mod cmd_give;

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -1,4 +1,3 @@
-pub mod cmd_clear;
 pub mod cmd_echest;
 pub mod cmd_gamemode;
 pub mod cmd_give;
@@ -6,6 +5,7 @@ pub mod cmd_help;
 pub mod cmd_kick;
 pub mod cmd_kill;
 pub mod cmd_list;
+pub mod cmd_msg;
 pub mod cmd_pumpkin;
 pub mod cmd_say;
 pub mod cmd_stop;

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
-    cmd_clear, cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill, cmd_list,
+    cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill, cmd_list, cmd_msg,
     cmd_pumpkin, cmd_say, cmd_stop, cmd_teleport, cmd_worldborder,
 };
 use dispatcher::InvalidTreeError;
@@ -84,7 +84,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_teleport::init_command_tree());
     dispatcher.register(cmd_give::init_command_tree());
     dispatcher.register(cmd_list::init_command_tree());
-    dispatcher.register(cmd_clear::init_command_tree());
+    dispatcher.register(cmd_msg::init_command_tree());
 
     Arc::new(dispatcher)
 }

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
-    cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill, cmd_list, cmd_msg,
+    cmd_clear, cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill, cmd_list, cmd_msg,
     cmd_pumpkin, cmd_say, cmd_stop, cmd_teleport, cmd_worldborder,
 };
 use dispatcher::InvalidTreeError;
@@ -84,6 +84,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_teleport::init_command_tree());
     dispatcher.register(cmd_give::init_command_tree());
     dispatcher.register(cmd_list::init_command_tree());
+    dispatcher.register(cmd_clear::init_command_tree());
     dispatcher.register(cmd_msg::init_command_tree());
 
     Arc::new(dispatcher)

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -4,7 +4,7 @@ use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
     cmd_clear, cmd_craft, cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill,
-    cmd_list, cmd_pumpkin, cmd_say, cmd_stop, cmd_teleport, cmd_worldborder, cmd_msg
+    cmd_list, cmd_msg, cmd_pumpkin, cmd_say, cmd_stop, cmd_teleport, cmd_worldborder,
 };
 use dispatcher::InvalidTreeError;
 use pumpkin_core::math::vector3::Vector3;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description

- Added `/msg` command.
- Added `/tell` command.
- Added `/w` command.

All commands were implemented according to the [wiki](https://minecraft.fandom.com/wiki/Commands/msg).

<!-- A description of the tests performed to verify the changes -->
## Testing
- [x] Msg command on self, player, players.
- [x] This pull request has been tested and compared against both Vanilla and Paper versions.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
