### PR TITLE
fix(Docker): improve build and compose files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,31 @@
 FROM rust:1-alpine3.20 AS builder
 ENV RUSTFLAGS="-C target-feature=-crt-static -C target-cpu=native"
 RUN apk add --no-cache musl-dev
+
 WORKDIR /pumpkin
 COPY . /pumpkin
+
+# build release
 RUN --mount=type=cache,sharing=private,target=/pumpkin/target \
     --mount=type=cache,target=/usr/local/cargo/git/db \
     --mount=type=cache,target=/usr/local/cargo/registry/ \
     cargo build --release && cp target/release/pumpkin ./pumpkin.release
+
+# strip debug symbols from binary
 RUN strip pumpkin.release
 
 FROM alpine:3.20
-WORKDIR /pumpkin
+
+# Identifying information for registries like ghcr.io
+LABEL org.opencontainers.image.source=https://github.com/Snowiiii/Pumpkin
+
 RUN apk add --no-cache libgcc
+
 COPY --from=builder /pumpkin/pumpkin.release /pumpkin/pumpkin
+
+# set workdir to /config 
+WORKDIR /config
+
 ENV RUST_BACKTRACE=1
 EXPOSE 25565
-ENTRYPOINT ["/pumpkin/pumpkin"]
+ENTRYPOINT [ "/pumpkin/pumpkin" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN apk add --no-cache libgcc
 
 COPY --from=builder /pumpkin/pumpkin.release /pumpkin/pumpkin
 
-# set workdir to /config 
+# set workdir to /config, this is required to influence the PWD environment variable
+# it allows for bind mounting the server files without overwriting the pumpkin
+# executable (without requiring an `docker cp`-ing the binary to the host folder)
 WORKDIR /config
 
 ENV RUST_BACKTRACE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,13 @@ LABEL org.opencontainers.image.source=https://github.com/Snowiiii/Pumpkin
 
 RUN apk add --no-cache libgcc
 
-COPY --from=builder /pumpkin/pumpkin.release /pumpkin/pumpkin
+COPY --from=builder /pumpkin/pumpkin.release /bin/pumpkin
 
-# set workdir to /config, this is required to influence the PWD environment variable
+# set workdir to /pumpkin, this is required to influence the PWD environment variable
 # it allows for bind mounting the server files without overwriting the pumpkin
 # executable (without requiring an `docker cp`-ing the binary to the host folder)
-WORKDIR /config
+WORKDIR /pumpkin
 
 ENV RUST_BACKTRACE=1
 EXPOSE 25565
-ENTRYPOINT [ "/pumpkin/pumpkin" ]
+ENTRYPOINT [ "/bin/pumpkin" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ services:
     ports:
       - 25565:25565
     volumes:
-      - ./config:/config
+      - ./data:/pumpkin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,4 @@ services:
     ports:
       - 25565:25565
     volumes:
-      - ./configuration.toml:/pumpkin/configuration.toml
-      - ./features.toml:/pumpkin/features.toml
+      - ./config:/config


### PR DESCRIPTION
## Description

While trying to deploy Pumpkin through Docker I noticed that it's impossible to do so without having the pre-generated `configuration.toml` and `features.toml` files.
The current docker configuration mounts these files into the docker container, which is possible and as long as person that's deploying keeps this in mind they can prepare for this by doing the following:
```bash
touch configuration.toml
touch features.toml
```
This process creates the two files required to bind into the container, however the problem that I found out later on was that Pumpkin does not populate these files when they're empty. Meaning that someone who doesn't look into the source code and the lack of documentation is unable to modify any of the settings without relying on someone else to generate these files for them.

- Adapted `Dockerfile` so the PWD will point to the `/config` folder in the image
- Modified the `docker-compose.yml` to follow the Dockerfile logic
- Added a LABEL to the docker image so it points to the Snowiiii/Pumpkin repository

This docker deployment doesn't need to be a fully working production environment, however it should at the least be a correct one for people to base themselves of off.

<!-- A description of the tests performed to verify the changes -->
## Testing

- **OS:** Arch Linux
- **Docker Version:** Docker version 27.3.1, build ce1223035a
- **Docker Compose Version:** Docker Compose version 2.30.2

Build command used to test this deployment:
```bash
docker compose up --build
```

![docker example deployment](https://github.com/user-attachments/assets/0e5a3d8c-4fae-4956-8ebc-c94b04c065bf)

## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`

No Rust code was modified in this PR, left the check boxes just in-case.