### PR TITLE
Disallow illegal characters in chat

### DIFF
--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -344,7 +344,8 @@ impl Player {
         }
 
         if message.chars().any(|c| c == '§' || c < ' ' || c == '\x7F') {
-            self.kick(TextComponent::text("Illegal characters in chat")).await;
+            self.kick(TextComponent::text("Illegal characters in chat"))
+                .await;
             return;
         }
 

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -343,7 +343,11 @@ impl Player {
             return;
         }
 
-        // TODO: filter message & validation
+        if message.chars().any(|c| c == '§' || c < ' ' || c == '\x7F') {
+            self.kick(TextComponent::text("Illegal characters in chat")).await;
+            return;
+        }
+
         let gameprofile = &self.gameprofile;
         log::info!("<chat>{}: {}", gameprofile.name, message);
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This will disallow any illegal characters in chat.
It functions exactly the same as in the vanilla minecraft server, see net.minecraft.server.PlayerConnectiona(PacketPlayInChat packetplayinchat) net.minecraft.server.SharedConstants.isAllowedChatCharacter(char c0).


<!-- A description of the tests performed to verify the changes -->
## Testing
I tested by running "MinecraftClient.getInstance().player.networkHandler.sendChatMessage" on the client with ANSI escape codes, disallowed Unicode and '§'.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
