### PR TITLE
fix(combat): kick players attacking dead players (health <= 0.0)

### DIFF
--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -454,7 +454,11 @@ impl Player {
                         .await;
                     return;
                 };
-
+                if victim.living_entity.health.load() <= 0.0 {
+                    self.kick(TextComponent::text("Interacted with dead entity"))
+                        .await;
+                    return;
+                }
                 self.attack(&victim).await;
             }
             ActionType::Interact | ActionType::InteractAt => {

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -455,8 +455,8 @@ impl Player {
                     return;
                 };
                 if victim.living_entity.health.load() <= 0.0 {
-                    self.kick(TextComponent::text("Interacted with dead entity"))
-                        .await;
+                    // you can trigger this from a non-modded / innocent client client,
+                    // so we shouldn't kick the player
                     return;
                 }
                 self.attack(&victim).await;


### PR DESCRIPTION
This doesn't need a description... the 4 line (5 if you count the extra one that the formatter added) diff explains it all.

<!-- A Detailed Description -->
## Description

```rs
if victim.living_entity.health.load() <= 0.0 {
    // you can trigger this from a non-modded / innocent client client,
    // so we shouldn't kick the player
    return;
}
```

## Testing

Hit a dead player (e.g. another player, for testing this, you would usually just open another client and hit that client's player) and see if any damage occurs (it doesn't).

## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
