### PR TITLE
fix(player/abilities): only set `allow_flying` on Creative mode

### DIFF
--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     },
 };
 use pumpkin_config::BasicConfiguration;
-use pumpkin_core::math::vector2::Vector2;
+use pumpkin_core::{math::vector2::Vector2, GameMode};
 use pumpkin_core::math::{position::WorldPosition, vector3::Vector3};
 use pumpkin_core::text::{color::NamedColor, TextComponent};
 use pumpkin_entity::{entity_type::EntityType, EntityId};
@@ -200,7 +200,9 @@ impl World {
         log::debug!("Sending player abilities to {}", player.gameprofile.name);
         {
             let mut abilities = player.abilities.lock().await;
-            abilities.allow_flying = true;
+            if player.gamemode.load() == GameMode::Creative {
+                abilities.allow_flying = true;
+            }
         }
         player.send_abilties_update().await;
 

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -194,18 +194,6 @@ impl World {
                 false,
             ))
             .await;
-
-        // player abilities
-        // TODO: this is for debug purpose, remove later
-        log::debug!("Sending player abilities to {}", player.gameprofile.name);
-        {
-            let mut abilities = player.abilities.lock().await;
-            if player.gamemode.load() == GameMode::Creative {
-                abilities.allow_flying = true;
-            }
-        }
-        player.send_abilties_update().await;
-
         // permissions, i. e. the commands a player may use
         player.send_permission_lvl_update().await;
         client_cmd_suggestions::send_c_commands_packet(&player, command_dispatcher).await;

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -13,9 +13,9 @@ use crate::{
     },
 };
 use pumpkin_config::BasicConfiguration;
+use pumpkin_core::math::vector2::Vector2;
 use pumpkin_core::math::{position::WorldPosition, vector3::Vector3};
 use pumpkin_core::text::{color::NamedColor, TextComponent};
-use pumpkin_core::math::vector2::Vector2;
 use pumpkin_entity::{entity_type::EntityType, EntityId};
 use pumpkin_protocol::{
     client::play::{CBlockUpdate, CSoundEffect, CWorldEvent},

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -13,9 +13,9 @@ use crate::{
     },
 };
 use pumpkin_config::BasicConfiguration;
-use pumpkin_core::{math::vector2::Vector2, GameMode};
 use pumpkin_core::math::{position::WorldPosition, vector3::Vector3};
 use pumpkin_core::text::{color::NamedColor, TextComponent};
+use pumpkin_core::{math::vector2::Vector2, GameMode};
 use pumpkin_entity::{entity_type::EntityType, EntityId};
 use pumpkin_protocol::{
     client::play::{CBlockUpdate, CSoundEffect, CWorldEvent},

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 use pumpkin_config::BasicConfiguration;
 use pumpkin_core::math::{position::WorldPosition, vector3::Vector3};
 use pumpkin_core::text::{color::NamedColor, TextComponent};
-use pumpkin_core::{math::vector2::Vector2, GameMode};
+use pumpkin_core::math::vector2::Vector2;
 use pumpkin_entity::{entity_type::EntityType, EntityId};
 use pumpkin_protocol::{
     client::play::{CBlockUpdate, CSoundEffect, CWorldEvent},


### PR DESCRIPTION
## Testing

- In Survival, press space bar 2 times and you should be falling / jumping.
- In Creative, press space bar 2 times and you should be flying.

## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt` (a963bd727)
- [x] Code does not produce any clippy warnings `cargo clippy`
