### PR TITLE
Added /playsound command (missing minVolume)

### DIFF
--- a/pumpkin-config/src/compression.rs
+++ b/pumpkin-config/src/compression.rs
@@ -19,7 +19,7 @@ impl Default for CompressionConfig {
     }
 }
 
-#[derive(Deserialize, Serialize, Clone)]
+#[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(default)]
 /// We have this in a Seperate struct so we can use it outside of the Config
 pub struct CompressionInfo {

--- a/pumpkin-core/Cargo.toml
+++ b/pumpkin-core/Cargo.toml
@@ -8,6 +8,7 @@ serde.workspace = true
 uuid.workspace = true
 num-traits.workspace = true
 num-derive.workspace = true
+log.workspace = true
 
 fastnbt = { git = "https://github.com/owengage/fastnbt.git" }
 colored = "2"

--- a/pumpkin-core/Cargo.toml
+++ b/pumpkin-core/Cargo.toml
@@ -9,6 +9,7 @@ uuid.workspace = true
 num-traits.workspace = true
 num-derive.workspace = true
 log.workspace = true
+serde_json.workspace = true
 
 fastnbt = { git = "https://github.com/owengage/fastnbt.git" }
 colored = "2"

--- a/pumpkin-core/src/lib.rs
+++ b/pumpkin-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod gamemode;
 pub mod math;
 pub mod random;
+pub mod sound;
 pub mod text;
 
 pub use gamemode::GameMode;

--- a/pumpkin-core/src/math/boundingbox.rs
+++ b/pumpkin-core/src/math/boundingbox.rs
@@ -1,6 +1,6 @@
 use super::{position::WorldPosition, vector3::Vector3};
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct BoundingBox {
     pub min_x: f64,
     pub min_y: f64,
@@ -67,7 +67,7 @@ impl BoundingBox {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct BoundingBoxSize {
     pub width: f64,
     pub height: f64,

--- a/pumpkin-core/src/math/position.rs
+++ b/pumpkin-core/src/math/position.rs
@@ -5,7 +5,7 @@ use crate::math::vector2::Vector2;
 use num_traits::Euclid;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 /// Aka Block Position
 pub struct WorldPosition(pub Vector3<i32>);
 

--- a/pumpkin-core/src/sound.rs
+++ b/pumpkin-core/src/sound.rs
@@ -1,0 +1,37 @@
+use std::str::FromStr;
+
+pub enum SoundCategory {
+    Master,
+    Music,
+    Records,
+    Weather,
+    Blocks,
+    Hostile,
+    Neutral,
+    Players,
+    Ambient,
+    Voice,
+}
+
+impl FromStr for SoundCategory {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "master" => Ok(Self::Master),
+            "music" => Ok(Self::Music),
+            "records" => Ok(Self::Records),
+            "weather" => Ok(Self::Weather),
+            "blocks" => Ok(Self::Blocks),
+            "hostile" => Ok(Self::Hostile),
+            "neutral" => Ok(Self::Neutral),
+            "players" => Ok(Self::Players),
+            "ambient" => Ok(Self::Ambient),
+            "voice" => Ok(Self::Voice),
+            _ => {
+                log::info!("Unexpected SoundCategory {}", s);
+                Err(())
+            }
+        }
+    }
+}

--- a/pumpkin-core/src/sound.rs
+++ b/pumpkin-core/src/sound.rs
@@ -3,18 +3,15 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct Sound {
-    name: String,
-    id: u16,
+    pub name: String,
+    pub id: u16,
 }
 
 pub static SOUNDS: LazyLock<HashMap<String, u16>> = LazyLock::new(|| {
-    serde_json::from_str::<Vec<Sound>>(include_str!("../../assets/sounds.json"))
+    serde_json::from_str(include_str!("../../assets/sounds.json"))
         .expect("Could not parse sounds.json registry.")
-        .into_iter()
-        .map(|val| (val.name, val.id))
-        .collect()
 });
 
 #[derive(Debug, Copy, Clone)]
@@ -31,25 +28,25 @@ pub enum SoundCategory {
     Voice,
 }
 
+pub static SOUND_CATEGORIES: LazyLock<HashMap<String, SoundCategory>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    map.insert("master".to_string(), SoundCategory::Master);
+    map.insert("music".to_string(), SoundCategory::Music);
+    map.insert("records".to_string(), SoundCategory::Records);
+    map.insert("weather".to_string(), SoundCategory::Weather);
+    map.insert("blocks".to_string(), SoundCategory::Blocks);
+    map.insert("hostile".to_string(), SoundCategory::Hostile);
+    map.insert("neutral".to_string(), SoundCategory::Neutral);
+    map.insert("players".to_string(), SoundCategory::Players);
+    map.insert("ambient".to_string(), SoundCategory::Ambient);
+    map.insert("voice".to_string(), SoundCategory::Voice);
+    map
+});
+
 impl FromStr for SoundCategory {
     type Err = ();
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "master" => Ok(Self::Master),
-            "music" => Ok(Self::Music),
-            "records" => Ok(Self::Records),
-            "weather" => Ok(Self::Weather),
-            "blocks" => Ok(Self::Blocks),
-            "hostile" => Ok(Self::Hostile),
-            "neutral" => Ok(Self::Neutral),
-            "players" => Ok(Self::Players),
-            "ambient" => Ok(Self::Ambient),
-            "voice" => Ok(Self::Voice),
-            _ => {
-                log::info!("Unexpected SoundCategory {}", s);
-                Err(())
-            }
-        }
+        SOUND_CATEGORIES.get(s).cloned().ok_or(())
     }
 }

--- a/pumpkin-core/src/sound.rs
+++ b/pumpkin-core/src/sound.rs
@@ -1,5 +1,23 @@
+use serde::Deserialize;
+use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
+#[derive(Deserialize, Debug)]
+pub struct Sound {
+    name: String,
+    id: u16,
+}
+
+pub static SOUNDS: LazyLock<HashMap<String, u16>> = LazyLock::new(|| {
+    serde_json::from_str::<Vec<Sound>>(include_str!("../../assets/sounds.json"))
+        .expect("Could not parse sounds.json registry.")
+        .into_iter()
+        .map(|val| (val.name, val.id))
+        .collect()
+});
+
+#[derive(Debug, Copy, Clone)]
 pub enum SoundCategory {
     Master,
     Music,

--- a/pumpkin-entity/src/entity_type.rs
+++ b/pumpkin-entity/src/entity_type.rs
@@ -1,5 +1,5 @@
 // TODO
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[repr(i32)]
 pub enum EntityType {
     AcaciaBoat = 0,

--- a/pumpkin-entity/src/pose.rs
+++ b/pumpkin-entity/src/pose.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 #[repr(i32)]
 pub enum EntityPose {
     Standing = 0,

--- a/pumpkin-inventory/src/open_container.rs
+++ b/pumpkin-inventory/src/open_container.rs
@@ -1,11 +1,21 @@
 use crate::crafting::check_if_matches_crafting;
 use crate::{Container, WindowType};
 use pumpkin_world::item::ItemStack;
+use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
 pub struct OpenContainer {
     players: Vec<i32>,
     container: Arc<Mutex<Box<dyn Container>>>,
+}
+
+impl Debug for OpenContainer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenContainer")
+            .field("players", &self.players)
+            .finish()
+    }
 }
 
 impl OpenContainer {

--- a/pumpkin-inventory/src/player.rs
+++ b/pumpkin-inventory/src/player.rs
@@ -5,6 +5,7 @@ use pumpkin_world::item::ItemStack;
 use std::iter::Chain;
 use std::slice::IterMut;
 
+#[derive(Debug)]
 pub struct PlayerInventory {
     // Main Inventory + Hotbar
     crafting: [Option<ItemStack>; 4],

--- a/pumpkin-macros/Cargo.toml
+++ b/pumpkin-macros/Cargo.toml
@@ -14,3 +14,4 @@ itertools.workspace = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "2.0"
+pumpkin-core = { path = "../pumpkin-core" }

--- a/pumpkin-macros/src/lib.rs
+++ b/pumpkin-macros/src/lib.rs
@@ -1,7 +1,6 @@
+extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
-
-extern crate proc_macro;
 
 mod packet;
 #[proc_macro_attribute]

--- a/pumpkin-macros/src/sound.rs
+++ b/pumpkin-macros/src/sound.rs
@@ -1,12 +1,6 @@
-use std::{collections::HashMap, sync::LazyLock};
-
 use proc_macro::TokenStream;
+use pumpkin_core::sound::SOUNDS;
 use quote::quote;
-
-static SOUNDS: LazyLock<HashMap<String, u16>> = LazyLock::new(|| {
-    serde_json::from_str(include_str!("../../assets/sounds.json"))
-        .expect("Could not parse sounds.json registry.")
-});
 
 pub(crate) fn sound_impl(item: TokenStream) -> TokenStream {
     let input_string = item.to_string();

--- a/pumpkin-protocol/src/client/config/c_registry_data.rs
+++ b/pumpkin-protocol/src/client/config/c_registry_data.rs
@@ -17,6 +17,7 @@ impl<'a> CRegistryData<'a> {
     }
 }
 
+#[derive(Debug)]
 pub struct RegistryEntry<'a> {
     pub entry_id: &'a str,
     pub data: Vec<u8>,

--- a/pumpkin-protocol/src/client/play/c_entity_sound_effect.rs
+++ b/pumpkin-protocol/src/client/play/c_entity_sound_effect.rs
@@ -1,7 +1,7 @@
+use crate::VarInt;
+use pumpkin_core::sound::SoundCategory;
 use pumpkin_macros::client_packet;
 use serde::Serialize;
-
-use crate::{SoundCategory, VarInt};
 
 #[derive(Serialize)]
 #[client_packet("play:sound_entity")]

--- a/pumpkin-protocol/src/client/play/c_sound_effect.rs
+++ b/pumpkin-protocol/src/client/play/c_sound_effect.rs
@@ -1,7 +1,7 @@
+use crate::VarInt;
+use pumpkin_core::sound::SoundCategory;
 use pumpkin_macros::client_packet;
 use serde::Serialize;
-
-use crate::{SoundCategory, VarInt};
 
 #[derive(Serialize)]
 #[client_packet("play:sound")]

--- a/pumpkin-protocol/src/client/play/c_update_objectives.rs
+++ b/pumpkin-protocol/src/client/play/c_update_objectives.rs
@@ -65,6 +65,7 @@ pub enum Mode {
 }
 
 #[repr(i32)]
+#[derive(Debug)]
 pub enum RenderType {
     Integer,
     Hearts,

--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -55,6 +55,7 @@ impl From<VarInt> for ConnectionState {
     }
 }
 
+#[derive(Debug)]
 pub struct RawPacket {
     pub id: VarInt,
     pub bytebuf: ByteBuffer,
@@ -68,7 +69,7 @@ pub trait ServerPacket: Packet + Sized {
     fn read(bytebuf: &mut ByteBuffer) -> Result<Self, DeserializerError>;
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct StatusResponse {
     /// The version on which the Server is running. Optional
     pub version: Option<Version>,
@@ -81,7 +82,7 @@ pub struct StatusResponse {
     /// Players are forced to use Secure chat
     pub enforce_secure_chat: bool,
 }
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Version {
     /// The current name of the Version (e.g. 1.21.3)
     pub name: String,
@@ -89,7 +90,7 @@ pub struct Version {
     pub protocol: u32,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Players {
     /// The maximum Player count the server allows
     pub max: u32,
@@ -100,7 +101,7 @@ pub struct Players {
     pub sample: Vec<Sample>,
 }
 
-#[derive(Serialize)]
+#[derive(Debug, Serialize)]
 pub struct Sample {
     /// Players Name
     pub name: String,
@@ -124,7 +125,7 @@ pub struct KnownPack<'a> {
     pub version: &'a str,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub enum NumberFormat<'a> {
     /// Show nothing
     Blank,

--- a/pumpkin-protocol/src/lib.rs
+++ b/pumpkin-protocol/src/lib.rs
@@ -55,19 +55,6 @@ impl From<VarInt> for ConnectionState {
     }
 }
 
-pub enum SoundCategory {
-    Master,
-    Music,
-    Records,
-    Weather,
-    Blocks,
-    Hostile,
-    Neutral,
-    Players,
-    Ambient,
-    Voice,
-}
-
 pub struct RawPacket {
     pub id: VarInt,
     pub bytebuf: ByteBuffer,

--- a/pumpkin-protocol/src/packet_decoder.rs
+++ b/pumpkin-protocol/src/packet_decoder.rs
@@ -14,7 +14,7 @@ type Cipher = cfb8::Decryptor<aes::Aes128>;
 // Decoder: Client -> Server
 // Supports ZLib decoding/decompression
 // Supports Aes128 Encyption
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PacketDecoder {
     buf: BytesMut,
     decompress_buf: BytesMut,

--- a/pumpkin-protocol/src/packet_encoder.rs
+++ b/pumpkin-protocol/src/packet_encoder.rs
@@ -17,7 +17,7 @@ type Cipher = cfb8::Encryptor<aes::Aes128>;
 // Encoder: Server -> Client
 // Supports ZLib endecoding/compression
 // Supports Aes128 Encyption
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PacketEncoder {
     buf: BytesMut,
     compress_buf: Vec<u8>,

--- a/pumpkin-registry/src/lib.rs
+++ b/pumpkin-registry/src/lib.rs
@@ -40,6 +40,7 @@ pub static SYNCED_REGISTRIES: LazyLock<SyncedRegistry> = LazyLock::new(|| {
         .expect("Could not parse synced_registries.json registry.")
 });
 
+#[derive(Debug)]
 pub struct Registry {
     pub registry_id: String,
     pub registry_entries: Vec<RegistryEntry<'static>>,

--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -54,10 +54,13 @@ pub enum CompressionError {
     LZ4Error(std::io::Error),
 }
 
+#[derive(Debug)]
 pub struct ChunkData {
     pub blocks: ChunkBlocks,
     pub position: Vector2<i32>,
 }
+
+#[derive(Debug)]
 pub struct ChunkBlocks {
     // TODO make this a Vec that doesn't store the upper layers that only contain air
 

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -5,6 +5,7 @@ use num_traits::Zero;
 use pumpkin_config::BASIC_CONFIG;
 use pumpkin_core::math::vector2::Vector2;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use std::fmt::{Debug, Formatter};
 use tokio::{
     sync::{mpsc, RwLock},
     task::JoinHandle,
@@ -37,7 +38,17 @@ pub struct Level {
     world_gen: Arc<dyn WorldGenerator>,
 }
 
-#[derive(Clone)]
+impl Debug for Level {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Level")
+            .field("save_file", &self.save_file)
+            .field("loaded_chunks", &self.loaded_chunk_count())
+            .field("chunk_watchers", &self.chunk_watchers.len())
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct SaveFile {
     pub root_folder: PathBuf,
     pub region_folder: PathBuf,

--- a/pumpkin/src/client/combat.rs
+++ b/pumpkin/src/client/combat.rs
@@ -1,10 +1,11 @@
 use std::f32::consts::PI;
 
 use pumpkin_core::math::vector3::Vector3;
+use pumpkin_core::sound::SoundCategory;
 use pumpkin_macros::{particle, sound};
 use pumpkin_protocol::{
     client::play::{CEntityVelocity, CParticle},
-    SoundCategory, VarInt,
+    VarInt,
 };
 use pumpkin_world::item::ItemStack;
 

--- a/pumpkin/src/client/combat.rs
+++ b/pumpkin/src/client/combat.rs
@@ -127,6 +127,8 @@ pub async fn player_attack_sound(pos: &Vector3<f64>, world: &World, attack_type:
                     sound!("minecraft:entity.player.attack.knockback"),
                     SoundCategory::Players,
                     pos,
+                    1.0,
+                    1.0,
                 )
                 .await;
         }
@@ -136,6 +138,8 @@ pub async fn player_attack_sound(pos: &Vector3<f64>, world: &World, attack_type:
                     sound!("minecraft:entity.player.attack.crit"),
                     SoundCategory::Players,
                     pos,
+                    1.0,
+                    1.0,
                 )
                 .await;
         }
@@ -145,6 +149,8 @@ pub async fn player_attack_sound(pos: &Vector3<f64>, world: &World, attack_type:
                     sound!("minecraft:entity.player.attack.sweep"),
                     SoundCategory::Players,
                     pos,
+                    1.0,
+                    1.0,
                 )
                 .await;
         }
@@ -154,6 +160,8 @@ pub async fn player_attack_sound(pos: &Vector3<f64>, world: &World, attack_type:
                     sound!("minecraft:entity.player.attack.strong"),
                     SoundCategory::Players,
                     pos,
+                    1.0,
+                    1.0,
                 )
                 .await;
         }
@@ -163,6 +171,8 @@ pub async fn player_attack_sound(pos: &Vector3<f64>, world: &World, attack_type:
                     sound!("minecraft:entity.player.attack.weak"),
                     SoundCategory::Players,
                     pos,
+                    1.0,
+                    1.0,
                 )
                 .await;
         }

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -47,7 +47,7 @@ pub mod player_packet;
 /// **Usage:**
 ///
 /// This struct is typically used to store and manage a player's preferences. It can be sent to the server when a player joins or when they change their settings.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlayerConfig {
     /// The player's preferred language.
     pub locale: String, // 16
@@ -84,6 +84,7 @@ impl Default for PlayerConfig {
 
 /// Everything which makes a Connection with our Server is a `Client`.
 /// Client will become Players when they reach the `Play` state
+#[derive(Debug)]
 pub struct Client {
     /// The client id. This is good for coorelating a connection with a player
     /// Only used for logging purposes

--- a/pumpkin/src/command/args/arg_bounded_num.rs
+++ b/pumpkin/src/command/args/arg_bounded_num.rs
@@ -82,7 +82,7 @@ impl<'a, T: ToFromNumber> FindArg<'a> for BoundedNumArgumentConsumer<T> {
 
 pub(crate) type NotInBounds = ();
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) enum Number {
     F64(f64),
     F32(f32),

--- a/pumpkin/src/command/args/arg_sound.rs
+++ b/pumpkin/src/command/args/arg_sound.rs
@@ -1,12 +1,27 @@
-use crate::command::args::{Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg};
-use crate::command::dispatcher::InvalidTreeError;
+use crate::command::args::{
+    Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg, GetClientSideArgParser,
+};
+use crate::command::dispatcher::CommandError;
 use crate::command::tree::RawArgs;
 use crate::command::CommandSender;
 use crate::server::Server;
 use async_trait::async_trait;
-use pumpkin_core::sound::SOUNDS;
+use pumpkin_core::sound::{Sound, SOUNDS};
+use pumpkin_protocol::client::play::{
+    CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType,
+};
 
 pub(crate) struct SoundArgumentConsumer;
+
+impl GetClientSideArgParser for SoundArgumentConsumer {
+    fn get_client_side_parser(&self) -> ProtoCmdArgParser {
+        ProtoCmdArgParser::ResourceLocation
+    }
+
+    fn get_client_side_suggestion_type_override(&self) -> Option<ProtoCmdArgSuggestionType> {
+        Some(ProtoCmdArgSuggestionType::AvailableSounds)
+    }
+}
 
 #[async_trait]
 impl ArgumentConsumer for SoundArgumentConsumer {
@@ -16,7 +31,22 @@ impl ArgumentConsumer for SoundArgumentConsumer {
         _server: &'a Server,
         args: &mut RawArgs<'a>,
     ) -> Option<Arg<'a>> {
-        SOUNDS.get(args.pop()?).map(|sound| Arg::Sound(*sound))
+        let name = args.pop()?;
+        SOUNDS.get(name).map(|id| {
+            Arg::Sound(Sound {
+                name: name.to_string(),
+                id: *id,
+            })
+        })
+    }
+
+    async fn suggest<'a>(
+        &self,
+        _sender: &CommandSender<'a>,
+        _server: &'a Server,
+        _input: &'a str,
+    ) -> Result<Option<Vec<CommandSuggestion<'a>>>, CommandError> {
+        Ok(None)
     }
 }
 
@@ -31,17 +61,12 @@ impl DefaultNameArgConsumer for SoundArgumentConsumer {
 }
 
 impl<'a> FindArg<'a> for SoundArgumentConsumer {
-    type Data = u16;
+    type Data = Sound;
 
-    fn find_arg(
-        args: &'a super::ConsumedArgs,
-        name: &'a str,
-    ) -> Result<Self::Data, InvalidTreeError> {
+    fn find_arg(args: &'a super::ConsumedArgs, name: &'a str) -> Result<Self::Data, CommandError> {
         match args.get(name) {
-            Some(Arg::Sound(data)) => Ok(*data),
-            _ => Err(InvalidTreeError::InvalidConsumptionError(Some(
-                name.to_string(),
-            ))),
+            Some(Arg::Sound(sound)) => Ok(sound.clone()),
+            _ => Err(CommandError::InvalidConsumption(Some(name.to_string()))),
         }
     }
 }

--- a/pumpkin/src/command/args/arg_sound.rs
+++ b/pumpkin/src/command/args/arg_sound.rs
@@ -1,0 +1,47 @@
+use crate::command::args::{Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg};
+use crate::command::dispatcher::InvalidTreeError;
+use crate::command::tree::RawArgs;
+use crate::command::CommandSender;
+use crate::server::Server;
+use async_trait::async_trait;
+use pumpkin_core::sound::SOUNDS;
+
+pub(crate) struct SoundArgumentConsumer;
+
+#[async_trait]
+impl ArgumentConsumer for SoundArgumentConsumer {
+    async fn consume<'a>(
+        &self,
+        _sender: &CommandSender<'a>,
+        _server: &'a Server,
+        args: &mut RawArgs<'a>,
+    ) -> Option<Arg<'a>> {
+        SOUNDS.get(args.pop()?).map(|sound| Arg::Sound(*sound))
+    }
+}
+
+impl DefaultNameArgConsumer for SoundArgumentConsumer {
+    fn default_name(&self) -> &'static str {
+        "sound"
+    }
+
+    fn get_argument_consumer(&self) -> &dyn ArgumentConsumer {
+        &SoundArgumentConsumer
+    }
+}
+
+impl<'a> FindArg<'a> for SoundArgumentConsumer {
+    type Data = u16;
+
+    fn find_arg(
+        args: &'a super::ConsumedArgs,
+        name: &'a str,
+    ) -> Result<Self::Data, InvalidTreeError> {
+        match args.get(name) {
+            Some(Arg::Sound(data)) => Ok(*data),
+            _ => Err(InvalidTreeError::InvalidConsumptionError(Some(
+                name.to_string(),
+            ))),
+        }
+    }
+}

--- a/pumpkin/src/command/args/arg_sound_category.rs
+++ b/pumpkin/src/command/args/arg_sound_category.rs
@@ -1,0 +1,50 @@
+use crate::command::args::{Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg};
+use crate::command::dispatcher::InvalidTreeError;
+use crate::command::tree::RawArgs;
+use crate::command::CommandSender;
+use crate::server::Server;
+use async_trait::async_trait;
+use pumpkin_core::sound::SoundCategory;
+use std::str::FromStr;
+
+pub(crate) struct SoundCategoryArgumentConsumer;
+
+#[async_trait]
+impl ArgumentConsumer for SoundCategoryArgumentConsumer {
+    async fn consume<'a>(
+        &self,
+        _sender: &CommandSender<'a>,
+        _server: &'a Server,
+        args: &mut RawArgs<'a>,
+    ) -> Option<Arg<'a>> {
+        SoundCategory::from_str(args.pop()?)
+            .ok()
+            .map(Arg::SoundCategory)
+    }
+}
+
+impl DefaultNameArgConsumer for SoundCategoryArgumentConsumer {
+    fn default_name(&self) -> &'static str {
+        "sound"
+    }
+
+    fn get_argument_consumer(&self) -> &dyn ArgumentConsumer {
+        &SoundCategoryArgumentConsumer
+    }
+}
+
+impl<'a> FindArg<'a> for SoundCategoryArgumentConsumer {
+    type Data = SoundCategory;
+
+    fn find_arg(
+        args: &'a super::ConsumedArgs,
+        name: &'a str,
+    ) -> Result<Self::Data, InvalidTreeError> {
+        match args.get(name) {
+            Some(Arg::SoundCategory(data)) => Ok(*data),
+            _ => Err(InvalidTreeError::InvalidConsumptionError(Some(
+                name.to_string(),
+            ))),
+        }
+    }
+}

--- a/pumpkin/src/command/args/arg_sound_category.rs
+++ b/pumpkin/src/command/args/arg_sound_category.rs
@@ -1,13 +1,28 @@
-use crate::command::args::{Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg};
-use crate::command::dispatcher::InvalidTreeError;
+use crate::command::args::{
+    Arg, ArgumentConsumer, DefaultNameArgConsumer, FindArg, GetClientSideArgParser,
+};
+use crate::command::dispatcher::CommandError;
 use crate::command::tree::RawArgs;
 use crate::command::CommandSender;
 use crate::server::Server;
 use async_trait::async_trait;
-use pumpkin_core::sound::SoundCategory;
+use pumpkin_core::sound::{SoundCategory, SOUND_CATEGORIES};
+use pumpkin_protocol::client::play::{
+    CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType, StringProtoArgBehavior,
+};
 use std::str::FromStr;
 
 pub(crate) struct SoundCategoryArgumentConsumer;
+
+impl GetClientSideArgParser for SoundCategoryArgumentConsumer {
+    fn get_client_side_parser(&self) -> ProtoCmdArgParser {
+        ProtoCmdArgParser::String(StringProtoArgBehavior::SingleWord)
+    }
+
+    fn get_client_side_suggestion_type_override(&self) -> Option<ProtoCmdArgSuggestionType> {
+        Some(ProtoCmdArgSuggestionType::AskServer)
+    }
+}
 
 #[async_trait]
 impl ArgumentConsumer for SoundCategoryArgumentConsumer {
@@ -20,6 +35,29 @@ impl ArgumentConsumer for SoundCategoryArgumentConsumer {
         SoundCategory::from_str(args.pop()?)
             .ok()
             .map(Arg::SoundCategory)
+    }
+
+    async fn suggest<'a>(
+        &self,
+        _sender: &CommandSender<'a>,
+        _server: &'a Server,
+        input: &'a str,
+    ) -> Result<Option<Vec<CommandSuggestion<'a>>>, CommandError> {
+        let sound_category_names = SOUND_CATEGORIES.keys();
+        let args = input.split_whitespace().collect::<Vec<_>>();
+        let Some(input) = args.get(2) else {
+            return Ok(Some(
+                sound_category_names
+                    .map(|name| CommandSuggestion::new(name, None))
+                    .collect(),
+            ));
+        };
+        Ok(Some(
+            sound_category_names
+                .filter(|name| name.starts_with(input))
+                .map(|name| CommandSuggestion::new(name, None))
+                .collect(),
+        ))
     }
 }
 
@@ -36,15 +74,10 @@ impl DefaultNameArgConsumer for SoundCategoryArgumentConsumer {
 impl<'a> FindArg<'a> for SoundCategoryArgumentConsumer {
     type Data = SoundCategory;
 
-    fn find_arg(
-        args: &'a super::ConsumedArgs,
-        name: &'a str,
-    ) -> Result<Self::Data, InvalidTreeError> {
+    fn find_arg(args: &'a super::ConsumedArgs, name: &'a str) -> Result<Self::Data, CommandError> {
         match args.get(name) {
             Some(Arg::SoundCategory(data)) => Ok(*data),
-            _ => Err(InvalidTreeError::InvalidConsumptionError(Some(
-                name.to_string(),
-            ))),
+            _ => Err(CommandError::InvalidConsumption(Some(name.to_string()))),
         }
     }
 }

--- a/pumpkin/src/command/args/mod.rs
+++ b/pumpkin/src/command/args/mod.rs
@@ -71,7 +71,7 @@ pub(crate) trait DefaultNameArgConsumer: ArgumentConsumer {
     fn get_argument_consumer(&self) -> &dyn ArgumentConsumer;
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) enum Arg<'a> {
     Entities(Vec<Arc<Player>>),
     Entity(Arc<Player>),

--- a/pumpkin/src/command/args/mod.rs
+++ b/pumpkin/src/command/args/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, hash::Hash, sync::Arc};
 use crate::{entity::player::Player, server::Server};
 use arg_bounded_num::{NotInBounds, Number};
 use async_trait::async_trait;
-use pumpkin_core::sound::SoundCategory;
+use pumpkin_core::sound::{Sound, SoundCategory};
 use pumpkin_core::{
     math::{position::WorldPosition, vector2::Vector2, vector3::Vector3},
     GameMode,
@@ -86,7 +86,7 @@ pub(crate) enum Arg<'a> {
     Block(String),
     Msg(String),
     Num(Result<Number, NotInBounds>),
-    Sound(u16),
+    Sound(Sound),
     SoundCategory(SoundCategory),
     #[allow(unused)]
     Simple(String),

--- a/pumpkin/src/command/args/mod.rs
+++ b/pumpkin/src/command/args/mod.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, hash::Hash, sync::Arc};
 
+use crate::{entity::player::Player, server::Server};
 use arg_bounded_num::{NotInBounds, Number};
 use async_trait::async_trait;
+use pumpkin_core::sound::SoundCategory;
 use pumpkin_core::{
     math::{position::WorldPosition, vector2::Vector2, vector3::Vector3},
     GameMode,
@@ -9,8 +11,6 @@ use pumpkin_core::{
 use pumpkin_protocol::client::play::{
     CommandSuggestion, ProtoCmdArgParser, ProtoCmdArgSuggestionType,
 };
-
-use crate::{entity::player::Player, server::Server};
 
 use super::{
     dispatcher::CommandError,
@@ -32,6 +32,8 @@ pub(crate) mod arg_position_3d;
 pub(crate) mod arg_postition_block;
 pub(crate) mod arg_rotation;
 pub(crate) mod arg_simple;
+pub(crate) mod arg_sound;
+pub(crate) mod arg_sound_category;
 mod coordinate;
 
 /// see [`crate::commands::tree_builder::argument`]
@@ -84,6 +86,8 @@ pub(crate) enum Arg<'a> {
     Block(String),
     Msg(String),
     Num(Result<Number, NotInBounds>),
+    Sound(u16),
+    SoundCategory(SoundCategory),
     #[allow(unused)]
     Simple(String),
 }

--- a/pumpkin/src/command/commands/cmd_playsound.rs
+++ b/pumpkin/src/command/commands/cmd_playsound.rs
@@ -111,7 +111,7 @@ impl CommandExecutor for PlaySoundExecutor {
 
         for world in worlds {
             world
-                .play_sound(sound, source, &position, volume, pitch)
+                .play_sound(sound.id, source, &position, volume, pitch)
                 .await;
         }
 

--- a/pumpkin/src/command/commands/cmd_playsound.rs
+++ b/pumpkin/src/command/commands/cmd_playsound.rs
@@ -1,0 +1,149 @@
+use crate::command::args::arg_sound::SoundArgumentConsumer;
+use crate::command::args::arg_sound_category::SoundCategoryArgumentConsumer;
+use crate::command::args::{
+    arg_bounded_num::BoundedNumArgumentConsumer, arg_players::PlayersArgumentConsumer,
+    arg_position_3d::Position3DArgumentConsumer, ConsumedArgs, FindArg, FindArgDefaultName,
+};
+use crate::command::tree_builder::argument_default_name;
+use crate::command::{
+    dispatcher::InvalidTreeError,
+    tree::CommandTree,
+    tree_builder::{argument, require},
+    CommandExecutor, CommandSender,
+};
+use crate::server::Server;
+use async_trait::async_trait;
+use pumpkin_core::text::color::NamedColor;
+use pumpkin_core::text::TextComponent;
+
+const NAMES: [&str; 1] = ["playsound"];
+const DESCRIPTION: &str = "Plays a sound at a location.";
+
+const ARG_SOUND: &str = "sound";
+const ARG_SOURCE: &str = "source";
+const ARG_TARGETS: &str = "targets";
+const ARG_POSITION: &str = "pos";
+const ARG_VOLUME: &str = "volume";
+const ARG_PITCH: &str = "pitch";
+const ARG_MIN_VOLUME: &str = "minVolume";
+
+static VOLUME_CONSUMER: BoundedNumArgumentConsumer<f32> =
+    BoundedNumArgumentConsumer::new().min(0.0).name(ARG_VOLUME);
+static PITCH_CONSUMER: BoundedNumArgumentConsumer<f32> =
+    BoundedNumArgumentConsumer::new().min(0.0).name(ARG_PITCH);
+static MIN_VOLUME_CONSUMER: BoundedNumArgumentConsumer<f32> = BoundedNumArgumentConsumer::new()
+    .max(1.0)
+    .min(0.0)
+    .name(ARG_MIN_VOLUME);
+
+struct PlaySoundExecutor;
+
+#[async_trait]
+impl CommandExecutor for PlaySoundExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        _server: &Server,
+        args: &ConsumedArgs<'a>,
+    ) -> Result<(), InvalidTreeError> {
+        let sound = SoundArgumentConsumer::find_arg(args, ARG_SOUND)?;
+        let source = SoundCategoryArgumentConsumer::find_arg(args, ARG_SOURCE)?;
+        let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
+        let position = match Position3DArgumentConsumer::find_arg(args, ARG_POSITION).ok() {
+            Some(pos) => pos,
+            None => {
+                if let Some(player) = sender.as_player() {
+                    player.living_entity.entity.pos.load()
+                } else {
+                    sender
+                        .send_message(
+                            TextComponent::text(
+                                "You must specify a position if you are not a player",
+                            )
+                            .color_named(NamedColor::Red),
+                        )
+                        .await;
+                    return Ok(());
+                }
+            }
+        };
+        let Ok(volume) = VOLUME_CONSUMER
+            .find_arg_default_name(args)
+            .unwrap_or(Ok(1.0))
+        else {
+            sender
+                .send_message(
+                    TextComponent::text("Invalid volume, must be positive")
+                        .color_named(NamedColor::Red),
+                )
+                .await;
+            return Ok(());
+        };
+        let Ok(pitch) = PITCH_CONSUMER
+            .find_arg_default_name(args)
+            .unwrap_or(Ok(1.0))
+        else {
+            sender
+                .send_message(
+                    TextComponent::text("Invalid pitch, must be positive")
+                        .color_named(NamedColor::Red),
+                )
+                .await;
+            return Ok(());
+        };
+        // TODO: Use this value
+        let Ok(_min_volume) = MIN_VOLUME_CONSUMER
+            .find_arg_default_name(args)
+            .unwrap_or(Ok(0.0))
+        else {
+            sender
+                .send_message(
+                    TextComponent::text("Invalid minimum volume, must be between 0.0 and 1.0")
+                        .color_named(NamedColor::Red),
+                )
+                .await;
+            return Ok(());
+        };
+        let worlds = targets
+            .iter()
+            .map(|target| target.living_entity.entity.world.clone())
+            .collect::<Vec<_>>();
+
+        for world in worlds {
+            world
+                .play_sound(sound, source, &position, volume, pitch)
+                .await;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn init_command_tree<'a>() -> CommandTree<'a> {
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        require(&|sender| sender.permission_lvl() >= 2).with_child(
+            argument(ARG_SOUND, &SoundArgumentConsumer).with_child(
+                argument(ARG_SOURCE, &SoundCategoryArgumentConsumer).with_child(
+                    argument(ARG_TARGETS, &PlayersArgumentConsumer)
+                        .with_child(
+                            argument(ARG_POSITION, &Position3DArgumentConsumer)
+                                .with_child(
+                                    argument_default_name(&VOLUME_CONSUMER)
+                                        .with_child(
+                                            argument_default_name(&PITCH_CONSUMER)
+                                                .with_child(
+                                                    argument_default_name(&MIN_VOLUME_CONSUMER)
+                                                        .execute(&PlaySoundExecutor),
+                                                )
+                                                .execute(&PlaySoundExecutor),
+                                        )
+                                        .execute(&PlaySoundExecutor),
+                                )
+                                .execute(&PlaySoundExecutor),
+                        )
+                        .execute(&PlaySoundExecutor),
+                ),
+            ),
+        ),
+    )
+}

--- a/pumpkin/src/command/commands/cmd_playsound.rs
+++ b/pumpkin/src/command/commands/cmd_playsound.rs
@@ -1,20 +1,19 @@
-use crate::command::args::arg_sound::SoundArgumentConsumer;
-use crate::command::args::arg_sound_category::SoundCategoryArgumentConsumer;
 use crate::command::args::{
     arg_bounded_num::BoundedNumArgumentConsumer, arg_players::PlayersArgumentConsumer,
-    arg_position_3d::Position3DArgumentConsumer, ConsumedArgs, FindArg, FindArgDefaultName,
+    arg_position_3d::Position3DArgumentConsumer, arg_sound::SoundArgumentConsumer,
+    arg_sound_category::SoundCategoryArgumentConsumer, ConsumedArgs, FindArg, FindArgDefaultName,
 };
-use crate::command::tree_builder::argument_default_name;
 use crate::command::{
-    dispatcher::InvalidTreeError,
+    dispatcher::CommandError,
     tree::CommandTree,
+    tree_builder::argument_default_name,
     tree_builder::{argument, require},
     CommandExecutor, CommandSender,
 };
+use crate::entity::player::PermissionLvl;
 use crate::server::Server;
 use async_trait::async_trait;
-use pumpkin_core::text::color::NamedColor;
-use pumpkin_core::text::TextComponent;
+use pumpkin_core::text::{color::NamedColor, TextComponent};
 
 const NAMES: [&str; 1] = ["playsound"];
 const DESCRIPTION: &str = "Plays a sound at a location.";
@@ -45,7 +44,7 @@ impl CommandExecutor for PlaySoundExecutor {
         sender: &mut CommandSender<'a>,
         _server: &Server,
         args: &ConsumedArgs<'a>,
-    ) -> Result<(), InvalidTreeError> {
+    ) -> Result<(), CommandError> {
         let sound = SoundArgumentConsumer::find_arg(args, ARG_SOUND)?;
         let source = SoundCategoryArgumentConsumer::find_arg(args, ARG_SOURCE)?;
         let targets = PlayersArgumentConsumer::find_arg(args, ARG_TARGETS)?;
@@ -121,7 +120,7 @@ impl CommandExecutor for PlaySoundExecutor {
 
 pub fn init_command_tree<'a>() -> CommandTree<'a> {
     CommandTree::new(NAMES, DESCRIPTION).with_child(
-        require(&|sender| sender.permission_lvl() >= 2).with_child(
+        require(&|sender| sender.has_permission_lvl(PermissionLvl::Two)).with_child(
             argument(ARG_SOUND, &SoundArgumentConsumer).with_child(
                 argument(ARG_SOURCE, &SoundCategoryArgumentConsumer).with_child(
                     argument(ARG_TARGETS, &PlayersArgumentConsumer)

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod cmd_help;
 pub mod cmd_kick;
 pub mod cmd_kill;
 pub mod cmd_list;
+pub mod cmd_playsound;
 pub mod cmd_pumpkin;
 pub mod cmd_say;
 pub mod cmd_setblock;

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -46,7 +46,7 @@ impl CommandError {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CommandDispatcher<'a> {
     pub(crate) commands: HashMap<&'a str, Command<'a>>,
 }

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -10,7 +10,8 @@ use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
     cmd_clear, cmd_craft, cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill,
-    cmd_list, cmd_pumpkin, cmd_say, cmd_setblock, cmd_stop, cmd_teleport, cmd_worldborder,
+    cmd_list, cmd_playsound,
+    cmd_pumpkin, cmd_say, cmd_setblock, cmd_stop, cmd_teleport, cmd_worldborder,
 };
 use dispatcher::CommandError;
 use pumpkin_core::math::vector3::Vector3;
@@ -124,6 +125,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_clear::init_command_tree());
     dispatcher.register(cmd_setblock::init_command_tree());
     dispatcher.register(cmd_transfer::init_command_tree());
+    dispatcher.register(cmd_playsound::init_command_tree());
 
     Arc::new(dispatcher)
 }

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -25,6 +25,7 @@ mod tree;
 mod tree_builder;
 mod tree_format;
 
+#[derive(Debug)]
 pub enum CommandSender<'a> {
     Rcon(&'a tokio::sync::Mutex<Vec<String>>),
     Console,

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -10,8 +10,8 @@ use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
     cmd_clear, cmd_craft, cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill,
-    cmd_list, cmd_playsound,
-    cmd_pumpkin, cmd_say, cmd_setblock, cmd_stop, cmd_teleport, cmd_worldborder,
+    cmd_list, cmd_playsound, cmd_pumpkin, cmd_say, cmd_setblock, cmd_stop, cmd_teleport,
+    cmd_worldborder,
 };
 use dispatcher::CommandError;
 use pumpkin_core::math::vector3::Vector3;

--- a/pumpkin/src/command/tree.rs
+++ b/pumpkin/src/command/tree.rs
@@ -45,6 +45,7 @@ impl Debug for NodeType<'_> {
     }
 }
 
+#[derive(Debug)]
 pub enum Command<'a> {
     Tree(CommandTree<'a>),
     Alias(&'a str),

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -9,6 +9,7 @@ use super::Entity;
 /// Represents a living entity within the game world.
 ///
 /// This struct encapsulates the core properties and behaviors of living entities, including players, mobs, and other creatures.
+#[derive(Debug)]
 pub struct LivingEntity {
     /// The underlying entity object, providing basic entity information and functionality.
     pub entity: Entity,

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -21,6 +21,7 @@ pub mod living;
 pub mod player;
 
 /// Represents a not living Entity (e.g. Item, Egg, Snowball...)
+#[derive(Debug)]
 pub struct Entity {
     /// A unique identifier for the entity
     pub entity_id: EntityId,

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -60,6 +60,7 @@ use crate::{error::PumpkinError, world::player_chunker::get_view_distance};
 
 use super::living::LivingEntity;
 
+#[derive(Debug)]
 pub struct ChunkHandleWrapper {
     handle: Option<JoinHandle<()>>,
     aborted: bool,
@@ -99,6 +100,7 @@ pub type PlayerPendingChunks =
 /// Represents a Minecraft player entity.
 ///
 /// A `Player` is a special type of entity that represents a human player connected to the server.
+#[derive(Debug)]
 pub struct Player {
     /// The underlying living entity object that represents the player.
     pub living_entity: LivingEntity,
@@ -903,6 +905,7 @@ impl Player {
 /// Represents a player's abilities and special powers.
 ///
 /// This struct contains information about the player's current abilities, such as flight, invulnerability, and creative mode.
+#[derive(Debug)]
 pub struct Abilities {
     /// Indicates whether the player is invulnerable to damage.
     pub invulnerable: bool,
@@ -932,7 +935,7 @@ impl Default for Abilities {
 }
 
 /// Represents the player's dominant hand.
-#[derive(FromPrimitive, Clone)]
+#[derive(FromPrimitive, Clone, Debug)]
 pub enum Hand {
     /// The player's primary hand (usually the right hand).
     Main,
@@ -941,7 +944,7 @@ pub enum Hand {
 }
 
 /// Represents the player's chat mode settings.
-#[derive(FromPrimitive, Clone)]
+#[derive(FromPrimitive, Clone, Debug)]
 pub enum ChatMode {
     /// Chat is enabled for the player.
     Enabled,

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -11,6 +11,7 @@ use crossbeam::atomic::AtomicCell;
 use itertools::Itertools;
 use num_derive::{FromPrimitive, ToPrimitive};
 use pumpkin_config::ADVANCED_CONFIG;
+use pumpkin_core::sound::SoundCategory;
 use pumpkin_core::{
     math::{
         boundingbox::{BoundingBox, BoundingBoxSize},
@@ -39,7 +40,7 @@ use pumpkin_protocol::{
         SPlayerCommand, SPlayerInput, SPlayerPosition, SPlayerPositionRotation, SPlayerRotation,
         SSetCreativeSlot, SSetHeldItem, SSetPlayerGround, SSwingArm, SUseItem, SUseItemOn,
     },
-    RawPacket, ServerPacket, SoundCategory, VarInt,
+    RawPacket, ServerPacket, VarInt,
 };
 use pumpkin_world::{cylindrical_chunk_iterator::Cylindrical, item::ItemStack};
 use tokio::sync::{Mutex, Notify};

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -955,7 +955,7 @@ pub enum ChatMode {
 }
 
 /// the player's permission level
-#[derive(FromPrimitive, ToPrimitive, Clone, Copy)]
+#[derive(FromPrimitive, ToPrimitive, Clone, Copy, Debug)]
 #[repr(i8)]
 pub enum PermissionLvl {
     Zero = 0,

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -371,6 +371,8 @@ impl Player {
                     sound!("minecraft:entity.player.attack.nodamage"),
                     SoundCategory::Players,
                     &pos,
+                    1.0,
+                    1.0,
                 )
                 .await;
             return;
@@ -381,6 +383,8 @@ impl Player {
                 sound!("minecraft:entity.player.hurt"),
                 SoundCategory::Players,
                 &pos,
+                1.0,
+                1.0,
             )
             .await;
 

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -36,6 +36,7 @@ fn load_icon_from_bytes(png_data: &[u8]) -> Result<String, Box<dyn error::Error>
     Ok(result)
 }
 
+#[derive(Debug)]
 pub struct CachedStatus {
     status_response: StatusResponse,
     // We cache the json response here so we don't parse it every time someone makes a Status request.
@@ -43,6 +44,7 @@ pub struct CachedStatus {
     status_response_json: String,
 }
 
+#[derive(Debug)]
 pub struct CachedBranding {
     /// Cached Server brand buffer so we don't have to rebuild them every time a player joins
     cached_server_brand: Vec<u8>,

--- a/pumpkin/src/server/key_store.rs
+++ b/pumpkin/src/server/key_store.rs
@@ -7,6 +7,7 @@ use sha2::Digest;
 
 use crate::client::EncryptionError;
 
+#[derive(Debug)]
 pub struct KeyStore {
     pub private_key: RsaPrivateKey,
     pub public_key_der: Box<[u8]>,

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -35,6 +35,7 @@ pub mod ticker;
 pub const CURRENT_MC_VERSION: &str = "1.21.3";
 
 /// Represents a Minecraft server instance.
+#[derive(Debug)]
 pub struct Server {
     /// Handles cryptographic keys for secure communication.
     key_store: KeyStore,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -147,15 +147,15 @@ impl World {
         &self,
         sound_id: u16,
         category: SoundCategory,
-        posistion: &Vector3<f64>,
+        position: &Vector3<f64>,
     ) {
         let seed = thread_rng().gen::<f64>();
         self.broadcast_packet_all(&CSoundEffect::new(
             VarInt(i32::from(sound_id)),
             category,
-            posistion.x,
-            posistion.y,
-            posistion.z,
+            position.x,
+            position.y,
+            position.z,
             1.0,
             1.0,
             seed,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -16,12 +16,10 @@ use crate::{
 use pumpkin_config::BasicConfiguration;
 use pumpkin_core::math::vector2::Vector2;
 use pumpkin_core::math::{position::WorldPosition, vector3::Vector3};
+use pumpkin_core::sound::SoundCategory;
 use pumpkin_core::text::{color::NamedColor, TextComponent};
 use pumpkin_entity::{entity_type::EntityType, EntityId};
-use pumpkin_protocol::{
-    client::play::{CBlockUpdate, CSoundEffect, CWorldEvent},
-    SoundCategory,
-};
+use pumpkin_protocol::client::play::{CBlockUpdate, CSoundEffect, CWorldEvent};
 use pumpkin_protocol::{
     client::play::{
         CChunkData, CGameEvent, CLogin, CPlayerInfoUpdate, CRemoveEntities, CRemovePlayerInfo,

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -148,6 +148,8 @@ impl World {
         sound_id: u16,
         category: SoundCategory,
         position: &Vector3<f64>,
+        volume: f32,
+        pitch: f32,
     ) {
         let seed = thread_rng().gen::<f64>();
         self.broadcast_packet_all(&CSoundEffect::new(
@@ -156,8 +158,8 @@ impl World {
             position.x,
             position.y,
             position.z,
-            1.0,
-            1.0,
+            volume,
+            pitch,
             seed,
         ))
         .await;

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -88,6 +88,7 @@ impl PumpkinError for GetBlockError {
 /// - Manages the `Level` instance for handling chunk-related operations.
 /// - Stores and tracks active `Player` entities within the world.
 /// - Provides a central hub for interacting with the world's entities and environment.
+#[derive(Debug)]
 pub struct World {
     /// The underlying level, responsible for chunk management and terrain generation.
     pub level: Arc<Level>,

--- a/pumpkin/src/world/scoreboard.rs
+++ b/pumpkin/src/world/scoreboard.rs
@@ -8,7 +8,7 @@ use pumpkin_protocol::{
 
 use super::World;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Scoreboard {
     objectives: HashMap<String, ScoreboardObjective<'static>>,
     //  teams: HashMap<String, Team>,
@@ -75,6 +75,7 @@ impl Scoreboard {
     // }
 }
 
+#[derive(Debug)]
 pub struct ScoreboardObjective<'a> {
     name: &'a str,
     display_name: TextComponent<'a>,

--- a/pumpkin/src/world/worldborder.rs
+++ b/pumpkin/src/world/worldborder.rs
@@ -7,6 +7,7 @@ use crate::client::Client;
 
 use super::World;
 
+#[derive(Debug)]
 pub struct Worldborder {
     pub center_x: f64,
     pub center_z: f64,


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This PR adds a first incomplete implementation of the playsound command (the minVolume is just ignored and not used for the moment). 
It also adds the Debug trait on an amount of data structures
And finally it moves the sound data structure from pumpkin-macros to pumpkin-core

<!-- A description of the tests performed to verify the changes -->
## Testing
The command has been tested functionnaly in game with various inputs.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
