### PR TITLE
Add RGB support to TextComponent, Fix some style

### DIFF
--- a/pumpkin-core/src/text/README.md
+++ b/pumpkin-core/src/text/README.md
@@ -3,7 +3,7 @@ Here we build Mojang's Textcomponent, Which is used across many places, Often wh
 
 ### Features
 - Colors
-  - [ ] RBG
+  - [x] RBG
   - [x] Black
   - [x] Dark Blue  
   - [x] Dark Green  

--- a/pumpkin-core/src/text/color.rs
+++ b/pumpkin-core/src/text/color.rs
@@ -11,7 +11,7 @@ pub enum Color {
     #[default]
     Reset,
     /// RGB Color
-    Rgb(u32),
+    Rgb(RGBColor),
     /// One of the 16 named Minecraft colors
     Named(NamedColor),
 }
@@ -25,10 +25,21 @@ impl<'de> Deserialize<'de> for Color {
 
         if s == "reset" {
             Ok(Color::Reset)
-        } else if s.starts_with('#') {
-            let rgb = u32::from_str_radix(&s.replace("#", ""), 16)
-                .map_err(|_| serde::de::Error::custom("Invalid hex color"))?;
-            Ok(Color::Rgb(rgb))
+        } else if let Some(hex) = s.strip_prefix('#') {
+            if s.len() != 7 {
+                return Err(serde::de::Error::custom(
+                    "Hex color must be in the format '#RRGGBB'",
+                ));
+            }
+
+            let r = u8::from_str_radix(&hex[0..2], 16)
+                .map_err(|_| serde::de::Error::custom("Invalid red component in hex color"))?;
+            let g = u8::from_str_radix(&hex[2..4], 16)
+                .map_err(|_| serde::de::Error::custom("Invalid green component in hex color"))?;
+            let b = u8::from_str_radix(&hex[4..6], 16)
+                .map_err(|_| serde::de::Error::custom("Invalid blue component in hex color"))?;
+
+            return Ok(Color::Rgb(RGBColor::new(r, g, b)));
         } else {
             Ok(Color::Named(NamedColor::try_from(s.as_str()).map_err(
                 |_| serde::de::Error::custom("Invalid named color"),
@@ -59,8 +70,34 @@ impl Color {
                 NamedColor::Yellow => text.bright_yellow(),
                 NamedColor::White => text.white(),
             },
-            Color::Rgb(_) => todo!(),
+            // TODO: Check if terminal supports true color
+            Color::Rgb(color) => text.truecolor(color.red, color.green, color.blue),
         }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, Eq, Hash, PartialEq)]
+pub struct RGBColor {
+    red: u8,
+    green: u8,
+    blue: u8,
+}
+
+impl RGBColor {
+    pub fn new(red: u8, green: u8, blue: u8) -> Self {
+        RGBColor { red, green, blue }
+    }
+}
+
+impl Serialize for RGBColor {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&format!(
+            "#{:02X}{:02X}{:02X}",
+            self.red, self.green, self.blue
+        ))
     }
 }
 

--- a/pumpkin-core/src/text/hover.rs
+++ b/pumpkin-core/src/text/hover.rs
@@ -8,7 +8,7 @@ use super::Text;
 #[serde(tag = "action", content = "contents", rename_all = "snake_case")]
 pub enum HoverEvent<'a> {
     /// Displays a tooltip with the given text.
-    ShowText(Text<'a>),
+    ShowText(Cow<'a, str>),
     /// Shows an item.
     ShowItem {
         /// Resource identifier of the item

--- a/pumpkin-core/src/text/mod.rs
+++ b/pumpkin-core/src/text/mod.rs
@@ -16,6 +16,8 @@ pub mod style;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
+// TODO: Use this instead of TextComponent alone to allow for example text with different colors
+// TODO: Allow to mix TextComponent and String
 pub struct Text<'a>(pub Box<TextComponent<'a>>);
 
 // Represents a Text component
@@ -95,6 +97,11 @@ impl<'a> TextComponent<'a> {
 
     pub fn color_named(mut self, color: color::NamedColor) -> Self {
         self.style.color = Some(Color::Named(color));
+        self
+    }
+
+    pub fn color_rgb(mut self, color: color::RGBColor) -> Self {
+        self.style.color = Some(Color::Rgb(color));
         self
     }
 

--- a/pumpkin-core/src/text/style.rs
+++ b/pumpkin-core/src/text/style.rs
@@ -7,6 +7,7 @@ use super::{
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
 pub struct Style<'a> {
     /// Changes the color to render the content
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Add RGB support to TextComponent
Fix click_event, hover_event, hover ShowText

<!-- A description of the tests performed to verify the changes -->
## Testing
used TextComponent with click_event(coppy) and hover_event(show) in console and client

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
