### PR TITLE
Fix packet side in extractor

### DIFF
--- a/assets/packets.json
+++ b/assets/packets.json
@@ -1,5 +1,5 @@
 {
-  "serverbound": {
+  "clientbound": {
     "status": {
       "status_response": 0,
       "pong_response": 1
@@ -165,7 +165,7 @@
       "server_links": 130
     }
   },
-  "clientbound": {
+  "serverbound": {
     "handshake": {
       "intention": 0
     },

--- a/extractor/src/main/kotlin/de/snowii/extractor/extractors/Packets.kt
+++ b/extractor/src/main/kotlin/de/snowii/extractor/extractors/Packets.kt
@@ -22,14 +22,14 @@ class Packets : Extractor.Extractor {
     override fun extract(server: MinecraftServer): JsonElement {
         val packetsJson = JsonObject()
 
-        val serverBound = arrayOf(
+        val clientBound = arrayOf(
             QueryStates.S2C_FACTORY,
             LoginStates.S2C_FACTORY,
             ConfigurationStates.S2C_FACTORY,
             PlayStateFactories.S2C
         )
 
-        val clientBound = arrayOf(
+        val serverBound = arrayOf(
             HandshakeStates.C2S_FACTORY,
             QueryStates.C2S_FACTORY,
             LoginStates.C2S_FACTORY,

--- a/pumpkin-macros/src/lib.rs
+++ b/pumpkin-macros/src/lib.rs
@@ -10,7 +10,7 @@ pub fn client_packet(input: TokenStream, item: TokenStream) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
 
-    let input: proc_macro2::TokenStream = packet::packet_clientbound(input);
+    let input: proc_macro2::TokenStream = packet::packet_serverbound(input);
     let item: proc_macro2::TokenStream = item.into();
 
     let gen = quote! {
@@ -29,7 +29,7 @@ pub fn server_packet(input: TokenStream, item: TokenStream) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
 
-    let input: proc_macro2::TokenStream = packet::packet_serverbound(input);
+    let input: proc_macro2::TokenStream = packet::packet_clientbound(input);
     let item: proc_macro2::TokenStream = item.into();
 
     let gen = quote! {

--- a/pumpkin-macros/src/lib.rs
+++ b/pumpkin-macros/src/lib.rs
@@ -10,7 +10,7 @@ pub fn client_packet(input: TokenStream, item: TokenStream) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
 
-    let input: proc_macro2::TokenStream = packet::packet_serverbound(input);
+    let input: proc_macro2::TokenStream = packet::packet_clientbound(input);
     let item: proc_macro2::TokenStream = item.into();
 
     let gen = quote! {
@@ -29,7 +29,7 @@ pub fn server_packet(input: TokenStream, item: TokenStream) -> TokenStream {
     let name = &ast.ident;
     let (impl_generics, ty_generics, _) = ast.generics.split_for_impl();
 
-    let input: proc_macro2::TokenStream = packet::packet_clientbound(input);
+    let input: proc_macro2::TokenStream = packet::packet_serverbound(input);
     let item: proc_macro2::TokenStream = item.into();
 
     let gen = quote! {

--- a/pumpkin-macros/src/packet.rs
+++ b/pumpkin-macros/src/packet.rs
@@ -20,7 +20,7 @@ pub(crate) fn packet_clientbound(item: TokenStream) -> proc_macro2::TokenStream 
     let packet_name = input_string.trim_matches('"');
     let packet_name_split: Vec<&str> = packet_name.split(":").collect();
     let phase = PACKETS
-        .serverbound
+        .clientbound
         .get(packet_name_split[0])
         .expect("Invalid Phase");
     let id = phase
@@ -35,7 +35,7 @@ pub(crate) fn packet_serverbound(item: TokenStream) -> proc_macro2::TokenStream 
     let packet_name_split: Vec<&str> = packet_name.split(":").collect();
 
     let phase = PACKETS
-        .clientbound
+        .serverbound
         .get(packet_name_split[0])
         .expect("Invalid Phase");
     let id = phase


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Previously in `packets.json`, `clientbound` packets where called `serverbound`, vice versa.
For example the `Login (Play)` packet was in `serverbound` when it's actually sent by the server to the client

<!-- A description of the tests performed to verify the changes -->
## Testing
Joining the server works as before

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
