### PR TITLE
fix respawn position being inside top block

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -557,7 +557,7 @@ impl Player {
         let x = 10.0;
         let z = 10.0;
         let top = world.get_top_block(Vector2::new(x as i32, z as i32)).await;
-        let position = Vector3::new(x, f64::from(top), z);
+        let position = Vector3::new(x, f64::from(top + 1), z);
         let yaw = 10.0;
         let pitch = 10.0;
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Add one to the y coordinate of the respawn position so players spawn on top of the top block rather than iside of it.

<!-- A description of the tests performed to verify the changes -->
## Testing
- use /kill
- observe not being inside of a block

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
