### PR TITLE
Fix block replace

### DIFF
--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -179,8 +179,8 @@ impl ChunkBlocks {
     }
 
     /// Gets the given block in the chunk
-    pub fn get_block(&self, position: ChunkRelativeBlockCoordinates) -> u16 {
-        self.blocks[Self::convert_index(position)]
+    pub fn get_block(&self, position: ChunkRelativeBlockCoordinates) -> Option<u16> {
+        self.blocks.get(Self::convert_index(position)).copied()
     }
 
     /// Sets the given block in the chunk, returning the old block

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -609,12 +609,21 @@ impl Player {
                         }
                     }
 
-                    let world_pos = WorldPosition(location.0 + face.to_offset());
+                    let clicked_world_pos = WorldPosition(location.0);
+                    let clicked_block_state = world.get_block_state(clicked_world_pos).await?;
 
-                    let previous_block_state = world.get_block_state(world_pos).await?;
-                    if !previous_block_state.replaceable {
-                        return Ok(());
-                    }
+                    let world_pos = if clicked_block_state.replaceable {
+                        clicked_world_pos
+                    } else {
+                        let world_pos = WorldPosition(location.0 + face.to_offset());
+                        let previous_block_state = world.get_block_state(world_pos).await?;
+
+                        if !previous_block_state.replaceable {
+                            return Ok(());
+                        }
+
+                        world_pos
+                    };
 
                     let block_bounding_box = BoundingBox::from_block(&world_pos);
                     let bounding_box = entity.bounding_box.load();

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{
     command::CommandSender,
     entity::player::{ChatMode, Hand, Player},
+    error::PumpkinError,
     server::Server,
     world::player_chunker,
 };
@@ -32,11 +33,24 @@ use pumpkin_protocol::{
     },
 };
 use pumpkin_world::block::{block_registry::get_block_by_item, BlockFace};
+use thiserror::Error;
 
 use super::PlayerConfig;
 
 fn modulus(a: f32, b: f32) -> f32 {
     ((a % b) + b) % b
+}
+
+#[derive(Debug, Error)]
+pub enum PlayerError {
+    BlockOutOfReach,
+    InvalidBlockFace,
+}
+
+impl std::fmt::Display for PlayerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
 }
 
 /// Handles all Play Packets send by a real Player
@@ -565,12 +579,15 @@ impl Player {
             .await;
     }
 
-    pub async fn handle_use_item_on(&self, use_item_on: SUseItemOn) {
+    pub async fn handle_use_item_on(
+        &self,
+        use_item_on: SUseItemOn,
+    ) -> Result<(), Box<dyn PumpkinError>> {
         let location = use_item_on.location;
 
         if !self.can_interact_with_block_at(&location, 1.0) {
             // TODO: maybe log?
-            return;
+            return Err(PlayerError::BlockOutOfReach.into());
         }
 
         if let Some(face) = BlockFace::from_i32(use_item_on.face.0) {
@@ -593,6 +610,12 @@ impl Player {
                     }
 
                     let world_pos = WorldPosition(location.0 + face.to_offset());
+
+                    let previous_block_state = world.get_block_state(world_pos).await?;
+                    if !previous_block_state.replaceable {
+                        return Ok(());
+                    }
+
                     let block_bounding_box = BoundingBox::from_block(&world_pos);
                     let bounding_box = entity.bounding_box.load();
                     //TODO: Make this check for every entity in that posistion
@@ -606,8 +629,10 @@ impl Player {
                     .send_packet(&CAcknowledgeBlockChange::new(use_item_on.sequence))
                     .await;
             }
+
+            Ok(())
         } else {
-            self.kick(TextComponent::text("Invalid block face")).await;
+            Err(PlayerError::InvalidBlockFace.into())
         }
     }
 

--- a/pumpkin/src/command/commands/cmd_setblock.rs
+++ b/pumpkin/src/command/commands/cmd_setblock.rs
@@ -56,11 +56,12 @@ impl CommandExecutor for SetblockExecutor {
                 true
             }
             Mode::Keep => match world.get_block_state(pos).await {
-                Some(old_state) if old_state.air => {
+                Ok(old_state) if old_state.air => {
                     world.set_block_state(pos, block_state_id).await;
                     true
                 }
-                _ => false,
+                Ok(_) => false,
+                Err(e) => return Err(CommandError::OtherPumpkin(e.into())),
             },
         };
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -872,7 +872,7 @@ impl Player {
                 self.handle_swing_arm(SSwingArm::read(bytebuf)?).await;
             }
             SUseItemOn::PACKET_ID => {
-                self.handle_use_item_on(SUseItemOn::read(bytebuf)?).await;
+                self.handle_use_item_on(SUseItemOn::read(bytebuf)?).await?;
             }
             SUseItem::PACKET_ID => self.handle_use_item(&SUseItem::read(bytebuf)?),
             SCommandSuggestion::PACKET_ID => {

--- a/pumpkin/src/error.rs
+++ b/pumpkin/src/error.rs
@@ -3,6 +3,8 @@ use pumpkin_inventory::InventoryError;
 use pumpkin_protocol::bytebuf::DeserializerError;
 use std::fmt::Display;
 
+use crate::{client::player_packet::PlayerError, world::WorldError};
+
 pub trait PumpkinError: Send + std::error::Error + Display {
     fn is_kick(&self) -> bool;
 
@@ -63,5 +65,41 @@ impl PumpkinError for DeserializerError {
 
     fn client_kick_reason(&self) -> Option<String> {
         None
+    }
+}
+
+impl PumpkinError for WorldError {
+    fn is_kick(&self) -> bool {
+        false
+    }
+
+    fn severity(&self) -> log::Level {
+        log::Level::Warn
+    }
+
+    fn client_kick_reason(&self) -> Option<String> {
+        None
+    }
+}
+
+impl PumpkinError for PlayerError {
+    fn is_kick(&self) -> bool {
+        match self {
+            Self::BlockOutOfReach => false,
+            Self::InvalidBlockFace => true,
+        }
+    }
+
+    fn severity(&self) -> log::Level {
+        match self {
+            Self::BlockOutOfReach | Self::InvalidBlockFace => log::Level::Warn,
+        }
+    }
+
+    fn client_kick_reason(&self) -> Option<String> {
+        match self {
+            Self::BlockOutOfReach => None,
+            Self::InvalidBlockFace => Some("Invalid block face".into()),
+        }
     }
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
this fixes two related bugs:
- irreplaceable blocks are no longer replaced when players place blocks inside of them (eg. by clicking the top face of a block below a chest)
- replaceable blocks are now replaced when players try to place blocks on them (eg. by clicking grass)

<!-- A description of the tests performed to verify the changes -->
## Testing
- start server
- try the examples mentioned above
- observe correct behavior

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
