### PR TITLE
Fixed the issue where the player's second skin layer did not appear after respawn (issue #284).

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -41,7 +41,7 @@ use pumpkin_protocol::{
 };
 use tokio::sync::{Mutex, Notify};
 use tokio::task::JoinHandle;
-
+use pumpkin_protocol::client::play::{CSetEntityMetadata, Metadata};
 use pumpkin_protocol::server::play::{SClickContainer, SKeepAlive};
 use pumpkin_world::{cylindrical_chunk_iterator::Cylindrical, item::ItemStack};
 
@@ -583,6 +583,15 @@ impl Player {
             .await;
 
         let entity = &self.living_entity.entity;
+        let entity_id = entity.entity_id;
+
+
+        let skin_parts = self.config.lock().await.skin_parts.clone();
+        let entity_metadata_packet = CSetEntityMetadata::new(
+            entity_id.into(),
+            Metadata::new(17, VarInt(0), &skin_parts)
+        );
+
         world
             .broadcast_packet_except(
                 &[self.gameprofile.id],
@@ -606,7 +615,7 @@ impl Player {
             .await;
 
         player_chunker::player_join(world, self.clone()).await;
-
+        world.broadcast_packet_all(&entity_metadata_packet).await;
         // update commands
 
         self.set_health(20.0, 20, 20.0).await;

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -24,6 +24,8 @@ use pumpkin_core::{
 use pumpkin_entity::{entity_type::EntityType, EntityId};
 use pumpkin_inventory::player::PlayerInventory;
 use pumpkin_macros::sound;
+use pumpkin_protocol::client::play::{CSetEntityMetadata, Metadata};
+use pumpkin_protocol::server::play::{SClickContainer, SKeepAlive};
 use pumpkin_protocol::{
     bytebuf::packet_id::Packet,
     client::play::{
@@ -39,11 +41,9 @@ use pumpkin_protocol::{
     },
     RawPacket, ServerPacket, SoundCategory, VarInt,
 };
+use pumpkin_world::{cylindrical_chunk_iterator::Cylindrical, item::ItemStack};
 use tokio::sync::{Mutex, Notify};
 use tokio::task::JoinHandle;
-use pumpkin_protocol::client::play::{CSetEntityMetadata, Metadata};
-use pumpkin_protocol::server::play::{SClickContainer, SKeepAlive};
-use pumpkin_world::{cylindrical_chunk_iterator::Cylindrical, item::ItemStack};
 
 use super::Entity;
 use crate::{
@@ -585,12 +585,9 @@ impl Player {
         let entity = &self.living_entity.entity;
         let entity_id = entity.entity_id;
 
-
-        let skin_parts = self.config.lock().await.skin_parts.clone();
-        let entity_metadata_packet = CSetEntityMetadata::new(
-            entity_id.into(),
-            Metadata::new(17, VarInt(0), &skin_parts)
-        );
+        let skin_parts = self.config.lock().await.skin_parts;
+        let entity_metadata_packet =
+            CSetEntityMetadata::new(entity_id.into(), Metadata::new(17, VarInt(0), &skin_parts));
 
         world
             .broadcast_packet_except(


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
The issue has been fixed by broadcasting the entity metadata packet with the skin parts inside the respawn function 

<!-- A description of the tests performed to verify the changes -->
## Testing

I tested it and it works completly fine after this changes 

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
