### PR TITLE
git: ignore compose `data/` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ Cargo.lock
 plugins/*
 world/*
 
+# docker-compose
+data/*
+
 # project's configurations
 configuration.toml
 features.toml


### PR DESCRIPTION
## Description

Should be fairly clear, with the recent changes made in #255 the docker-compose.yml will bind mount `data/` to `/pumpkin`.

<!-- A description of the tests performed to verify the changes -->
## Testing

When spinning up pumpkin with `docker compose up --build` none of the new files created under `data/` will be in `git status`.
