### PR TITLE
Use tauri-winres

### DIFF
--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0-dev"
 description = "Empowering everyone to host fast and efficient Minecraft servers."
 edition = "2021"
 
-[package.metadata.winresource]
+[package.metadata.tauri-winres]
 # FileDescription is handled as the Program name by Windows!
 FileDescription = "Pumpkin"
 OriginalFilename = "pumpkin.exe"
@@ -75,5 +75,5 @@ sys-info = "0.9.1"
 async-trait = "0.1.83"
 
 [build-dependencies]
-winresource = "0.1.17"
+tauri-winres = "0.1.1"
 git-version = "0.3.9"

--- a/pumpkin/build.rs
+++ b/pumpkin/build.rs
@@ -3,7 +3,7 @@ use std::env;
 
 fn main() {
     if cfg!(target_os = "windows") {
-        let mut res = winresource::WindowsResource::new();
+        let mut res = tauri_winres::WindowsResource::new();
         res.set_icon("../assets/icon.ico");
         res.set_language(0x0009); // English
         res.compile().unwrap();


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
tauri-winres is way faster because it is using embed_resource and this also means it does not rely on rc.exe or windres.exe and ar.exe, making cross-compile possible.

(See https://github.com/Snowiiii/Pumpkin/issues/312#issuecomment-2483389125)
<!-- A description of the tests performed to verify the changes -->
## Testing

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
