### PR TITLE
feat: add envvar for config file paths

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: deploy-docker-image
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  docker-build-deploy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub CR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -5,6 +5,7 @@ use query::QueryConfig;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use std::{
+    env,
     fs,
     net::{Ipv4Addr, SocketAddr},
     path::Path,
@@ -159,7 +160,10 @@ trait LoadConfiguration {
 
 impl LoadConfiguration for AdvancedConfiguration {
     fn get_path() -> &'static Path {
-        Path::new("features.toml")
+        match env::var("FEATURES") {
+            Ok(v) => Path::new(v.leak()),
+            Err(_) => Path::new("features.toml"),
+        }
     }
 
     fn validate(&self) {
@@ -169,7 +173,10 @@ impl LoadConfiguration for AdvancedConfiguration {
 
 impl LoadConfiguration for BasicConfiguration {
     fn get_path() -> &'static Path {
-        Path::new("configuration.toml")
+        match env::var("CONFIG") {
+            Ok(v) => Path::new(v.leak()),
+            Err(_) => Path::new("configuration.toml"),
+        }
     }
 
     fn validate(&self) {

--- a/pumpkin-core/src/math/position.rs
+++ b/pumpkin-core/src/math/position.rs
@@ -66,7 +66,7 @@ impl<'de> Deserialize<'de> for WorldPosition {
     }
 }
 
-impl std::fmt::Display for WorldPosition {
+impl fmt::Display for WorldPosition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}, {}, {}", self.0.x, self.0.y, self.0.z)
     }

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 pumpkin-core = { path = "../pumpkin-core" }
+pumpkin-config = { path = "../pumpkin-config" }
 pumpkin-macros = { path = "../pumpkin-macros" }
 
 tokio.workspace = true

--- a/pumpkin/src/command/commands/cmd_fill.rs
+++ b/pumpkin/src/command/commands/cmd_fill.rs
@@ -1,0 +1,176 @@
+use crate::command::args::arg_block::BlockArgumentConsumer;
+use crate::command::args::arg_postition_block::BlockPosArgumentConsumer;
+use crate::command::args::{ConsumedArgs, FindArg};
+use crate::command::tree::CommandTree;
+use crate::command::tree_builder::{argument, literal, require};
+use crate::command::{CommandError, CommandExecutor, CommandSender};
+use crate::entity::player::PermissionLvl;
+use async_trait::async_trait;
+use pumpkin_core::math::position::WorldPosition;
+use pumpkin_core::math::vector3::Vector3;
+use pumpkin_core::text::TextComponent;
+
+const NAMES: [&str; 1] = ["fill"];
+
+const DESCRIPTION: &str = "Fills all or parts of a region with a specific block.";
+
+const ARG_BLOCK: &str = "block";
+const ARG_FROM: &str = "from";
+const ARG_TO: &str = "to";
+
+#[derive(Clone, Copy, Default)]
+enum Mode {
+    /// Destroys blocks with particles and item drops
+    Destroy,
+    /// Leaves only the outer layer of blocks, removes the inner ones (creates a hollow space)
+    Hollow,
+    /// Only replaces air blocks, keeping non-air blocks unchanged
+    Keep,
+    /// Like Hollow but doesn't replace inner blocks with air, just the outline
+    Outline,
+    /// Replaces all blocks with the new block state, without particles
+    #[default]
+    Replace,
+}
+
+struct SetblockExecutor(Mode);
+
+#[expect(clippy::too_many_lines)]
+#[async_trait]
+impl CommandExecutor for SetblockExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        _server: &crate::server::Server,
+        args: &ConsumedArgs<'a>,
+    ) -> Result<(), CommandError> {
+        let block = BlockArgumentConsumer::find_arg(args, ARG_BLOCK)?;
+        let block_state_id = block.default_state_id;
+        let from = BlockPosArgumentConsumer::find_arg(args, ARG_FROM)?;
+        let to = BlockPosArgumentConsumer::find_arg(args, ARG_TO)?;
+        let mode = self.0;
+
+        let start_x = from.0.x.min(to.0.x);
+        let start_y = from.0.y.min(to.0.y);
+        let start_z = from.0.z.min(to.0.z);
+
+        let end_x = from.0.x.max(to.0.x);
+        let end_y = from.0.y.max(to.0.y);
+        let end_z = from.0.z.max(to.0.z);
+
+        let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
+        let mut placed_blocks = 0;
+
+        match mode {
+            Mode::Destroy => {
+                for x in start_x..=end_x {
+                    for y in start_y..=end_y {
+                        for z in start_z..=end_z {
+                            let block_position = WorldPosition(Vector3 { x, y, z });
+                            world.break_block(block_position, None).await;
+                            world.set_block_state(block_position, block_state_id).await;
+                            placed_blocks += 1;
+                        }
+                    }
+                }
+            }
+            Mode::Replace => {
+                for x in start_x..=end_x {
+                    for y in start_y..=end_y {
+                        for z in start_z..=end_z {
+                            let block_position = WorldPosition(Vector3 { x, y, z });
+                            world.set_block_state(block_position, block_state_id).await;
+                            placed_blocks += 1;
+                        }
+                    }
+                }
+            }
+            Mode::Keep => {
+                for x in start_x..=end_x {
+                    for y in start_y..=end_y {
+                        for z in start_z..=end_z {
+                            let block_position = WorldPosition(Vector3 { x, y, z });
+                            match world.get_block_state(block_position).await {
+                                Ok(old_state) if old_state.air => {
+                                    world.set_block_state(block_position, block_state_id).await;
+                                    placed_blocks += 1;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            Mode::Hollow => {
+                for x in start_x..=end_x {
+                    for y in start_y..=end_y {
+                        for z in start_z..=end_z {
+                            let block_position = WorldPosition(Vector3::new(x, y, z));
+                            let is_edge = x == start_x
+                                || x == end_x
+                                || y == start_y
+                                || y == end_y
+                                || z == start_z
+                                || z == end_z;
+                            if is_edge {
+                                world.set_block_state(block_position, block_state_id).await;
+                            } else {
+                                world.set_block_state(block_position, 0).await;
+                            }
+                            placed_blocks += 1;
+                        }
+                    }
+                }
+            }
+            Mode::Outline => {
+                for x in start_x..=end_x {
+                    for y in start_y..=end_y {
+                        for z in start_z..=end_z {
+                            let block_position = WorldPosition(Vector3::new(x, y, z));
+                            let is_edge = x == start_x
+                                || x == end_x
+                                || y == start_y
+                                || y == end_y
+                                || z == start_z
+                                || z == end_z;
+                            if is_edge {
+                                world.set_block_state(block_position, block_state_id).await;
+                                placed_blocks += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        sender
+            .send_message(TextComponent::text_string(format!(
+                "Placed {} blocks of {} from {from} to {to}",
+                placed_blocks, block.name
+            )))
+            .await;
+
+        Ok(())
+    }
+}
+
+pub fn init_command_tree<'a>() -> CommandTree<'a> {
+    CommandTree::new(NAMES, DESCRIPTION).with_child(
+        require(&|sender| {
+            sender.has_permission_lvl(PermissionLvl::Two) && sender.world().is_some()
+        })
+        .with_child(
+            argument(ARG_FROM, &BlockPosArgumentConsumer).with_child(
+                argument(ARG_TO, &BlockPosArgumentConsumer).with_child(
+                    argument(ARG_BLOCK, &BlockArgumentConsumer)
+                        .with_child(literal("destroy").execute(&SetblockExecutor(Mode::Destroy)))
+                        .with_child(literal("hollow").execute(&SetblockExecutor(Mode::Hollow)))
+                        .with_child(literal("keep").execute(&SetblockExecutor(Mode::Keep)))
+                        .with_child(literal("outline").execute(&SetblockExecutor(Mode::Outline)))
+                        .with_child(literal("replace").execute(&SetblockExecutor(Mode::Replace)))
+                        .execute(&SetblockExecutor(Mode::Replace)),
+                ),
+            ),
+        ),
+    )
+}

--- a/pumpkin/src/command/commands/cmd_seed.rs
+++ b/pumpkin/src/command/commands/cmd_seed.rs
@@ -1,0 +1,60 @@
+use crate::command::tree_builder::require;
+use crate::command::{
+    args::ConsumedArgs, tree::CommandTree, CommandError, CommandExecutor, CommandSender,
+};
+use crate::entity::player::PermissionLvl;
+use async_trait::async_trait;
+use pumpkin_core::text::click::ClickEvent;
+use pumpkin_core::text::hover::HoverEvent;
+use pumpkin_core::text::{color::NamedColor, TextComponent};
+use std::borrow::Cow;
+
+const NAMES: [&str; 1] = ["seed"];
+
+const DESCRIPTION: &str = "Displays the world seed.";
+
+struct PumpkinExecutor;
+
+#[async_trait]
+impl CommandExecutor for PumpkinExecutor {
+    async fn execute<'a>(
+        &self,
+        sender: &mut CommandSender<'a>,
+        server: &crate::server::Server,
+        _args: &ConsumedArgs<'a>,
+    ) -> Result<(), CommandError> {
+        let seed = match sender {
+            CommandSender::Player(player) => {
+                player.living_entity.entity.world.level.seed.0.to_string()
+            }
+            _ => match server.worlds.first() {
+                Some(world) => world.level.seed.0.to_string(),
+                None => {
+                    return Err(CommandError::GeneralCommandIssue(
+                        "Unable to get Seed".to_string(),
+                    ))
+                }
+            },
+        };
+
+        sender
+            .send_message(
+                TextComponent::text(&format!("Seed: [{seed}]"))
+                    .hover_event(HoverEvent::ShowText(Cow::from(
+                        "Click to Copy to Clipboard",
+                    )))
+                    .click_event(ClickEvent::CopyToClipboard(Cow::from(seed)))
+                    .color_named(NamedColor::Green), // TODO: use white and green, when possible
+            )
+            .await;
+        Ok(())
+    }
+}
+
+pub fn init_command_tree<'a>() -> CommandTree<'a> {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .with_child(require(&|sender| {
+            sender.has_permission_lvl(PermissionLvl::Two)
+        }))
+        .execute(&PumpkinExecutor)
+}

--- a/pumpkin/src/command/commands/cmd_setblock.rs
+++ b/pumpkin/src/command/commands/cmd_setblock.rs
@@ -43,6 +43,7 @@ impl CommandExecutor for SetblockExecutor {
         let block_state_id = block.default_state_id;
         let pos = BlockPosArgumentConsumer::find_arg(args, ARG_BLOCK_POS)?;
         let mode = self.0;
+        // TODO: allow console to use the command (seed sender.world)
         let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
 
         let success = match mode {

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod cmd_kill;
 pub mod cmd_list;
 pub mod cmd_pumpkin;
 pub mod cmd_say;
+pub mod cmd_seed;
 pub mod cmd_setblock;
 pub mod cmd_stop;
 pub mod cmd_teleport;

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod cmd_clear;
 pub mod cmd_craft;
 pub mod cmd_echest;
+pub mod cmd_fill;
 pub mod cmd_gamemode;
 pub mod cmd_give;
 pub mod cmd_help;

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
+use crate::command::commands::cmd_seed;
 use crate::command::commands::cmd_transfer;
 use crate::command::dispatcher::CommandDispatcher;
 use crate::entity::player::{PermissionLvl, Player};
@@ -98,6 +99,7 @@ impl<'a> CommandSender<'a> {
     #[must_use]
     pub fn world(&self) -> Option<&World> {
         match self {
+            // TODO: maybe return first world when console
             CommandSender::Console | CommandSender::Rcon(..) => None,
             CommandSender::Player(p) => Some(&p.living_entity.entity.world),
         }
@@ -123,6 +125,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_list::init_command_tree());
     dispatcher.register(cmd_clear::init_command_tree());
     dispatcher.register(cmd_setblock::init_command_tree());
+    dispatcher.register(cmd_seed::init_command_tree());
     dispatcher.register(cmd_transfer::init_command_tree());
 
     Arc::new(dispatcher)

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -10,8 +10,9 @@ use crate::world::World;
 use args::ConsumedArgs;
 use async_trait::async_trait;
 use commands::{
-    cmd_clear, cmd_craft, cmd_echest, cmd_gamemode, cmd_give, cmd_help, cmd_kick, cmd_kill,
-    cmd_list, cmd_pumpkin, cmd_say, cmd_setblock, cmd_stop, cmd_teleport, cmd_worldborder,
+    cmd_clear, cmd_craft, cmd_echest, cmd_fill, cmd_gamemode, cmd_give, cmd_help, cmd_kick,
+    cmd_kill, cmd_list, cmd_pumpkin, cmd_say, cmd_setblock, cmd_stop, cmd_teleport,
+    cmd_worldborder,
 };
 use dispatcher::CommandError;
 use pumpkin_core::math::vector3::Vector3;
@@ -127,6 +128,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_setblock::init_command_tree());
     dispatcher.register(cmd_seed::init_command_tree());
     dispatcher.register(cmd_transfer::init_command_tree());
+    dispatcher.register(cmd_fill::init_command_tree());
 
     Arc::new(dispatcher)
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Docker or Kubernetes deployments would need a method to explicitly set configuration file paths. This PR adds functionality to set these.

<!-- A description of the tests performed to verify the changes -->
## Testing

<!-- Please use Markdown Checkboxes. 
[x] = not done
[] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
