### PR TITLE
Replace Bruteforce search with Hashmap lookup in block_registry

### DIFF
--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -1,4 +1,5 @@
 use std::sync::LazyLock;
+use std::collections::HashMap;
 
 use serde::Deserialize;
 
@@ -7,15 +8,57 @@ pub static BLOCKS: LazyLock<TopLevel> = LazyLock::new(|| {
         .expect("Could not parse blocks.json registry.")
 });
 
+pub static BLOCKS_BY_ID: LazyLock<HashMap<u16, Block>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    for block in &BLOCKS.blocks {
+        map.insert(block.id, block.clone());
+    }
+    map
+});
+
+pub static BLOCK_ID_BY_REGISTRY_ID: LazyLock<HashMap<String, u16>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    for block in &BLOCKS.blocks {
+        map.insert(block.name.clone(), block.id);
+    }
+    map
+});
+
+pub static BLOCK_ID_BY_STATE_ID: LazyLock<HashMap<u16, u16>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    for block in &BLOCKS.blocks {
+        for state in &block.states {
+            map.insert(state.id, block.id);
+        }
+    }
+    map
+});
+
+pub static STATE_INDEX_BY_STATE_ID: LazyLock<HashMap<u16, u16>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    for block in &BLOCKS.blocks {
+        for (index, state) in block.states.iter().enumerate() {
+            map.insert(state.id, index as u16);
+        }
+    }
+    map
+});
+
+pub static BLOCK_ID_BY_ITEM_ID: LazyLock<HashMap<u16, u16>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    for block in &BLOCKS.blocks {
+        map.insert(block.item_id, block.id);
+    }
+    map
+});
+
 pub fn get_block(registry_id: &str) -> Option<&Block> {
-    BLOCKS
-        .blocks
-        .iter()
-        .find(|&block| block.name == registry_id)
+    let id = BLOCK_ID_BY_REGISTRY_ID.get(registry_id)?;
+    BLOCKS_BY_ID.get(id)
 }
 
 pub fn get_block_by_id<'a>(id: u16) -> Option<&'a Block> {
-    BLOCKS.blocks.iter().find(|&block| block.id == id)
+    BLOCKS_BY_ID.get(&id)
 }
 
 pub fn get_state_by_state_id<'a>(id: u16) -> Option<&'a State> {
@@ -23,23 +66,21 @@ pub fn get_state_by_state_id<'a>(id: u16) -> Option<&'a State> {
 }
 
 pub fn get_block_by_state_id<'a>(id: u16) -> Option<&'a Block> {
-    get_block_and_state_by_state_id(id).map(|(block, _)| block)
+    let block_id = BLOCK_ID_BY_STATE_ID.get(&id)?;
+    BLOCKS_BY_ID.get(block_id)
 }
 
 pub fn get_block_and_state_by_state_id<'a>(id: u16) -> Option<(&'a Block, &'a State)> {
-    for block in &BLOCKS.blocks {
-        for state in &block.states {
-            if state.id == id {
-                return Some((block, state));
-            }
-        }
-    }
-
-    None
+    let block_id = BLOCK_ID_BY_STATE_ID.get(&id)?;
+    let block = BLOCKS_BY_ID.get(block_id)?;
+    let state_index = STATE_INDEX_BY_STATE_ID.get(&id)?;
+    let state = block.states.get(*state_index as usize)?;
+    Some((block, state))
 }
 
 pub fn get_block_by_item<'a>(item_id: u16) -> Option<&'a Block> {
-    BLOCKS.blocks.iter().find(|&block| block.item_id == item_id)
+    let block_id = BLOCK_ID_BY_ITEM_ID.get(&item_id)?;
+    BLOCKS_BY_ID.get(block_id)
 }
 #[expect(dead_code)]
 #[derive(Deserialize, Clone, Debug)]

--- a/pumpkin-world/src/block/block_registry.rs
+++ b/pumpkin-world/src/block/block_registry.rs
@@ -1,5 +1,5 @@
-use std::sync::LazyLock;
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use serde::Deserialize;
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Multiple functions in `block_registry` would do a brute force search by iterating through all blocks until it found a match. This PR would add multiple hashmaps to improve lookup times and improve performance

<!-- A description of the tests performed to verify the changes -->
## Testing
- Tested world generation, setblock command, block placing and destroying
- Compared memory usage before and after changes on windows, added `~3.2MB` of memory usage

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
