### PR TITLE
Make auth urls optional, fix issues in prevent proxy connections

### DIFF
--- a/pumpkin-config/src/auth.rs
+++ b/pumpkin-config/src/auth.rs
@@ -6,9 +6,9 @@ use serde::{Deserialize, Serialize};
 pub struct AuthenticationConfig {
     /// Whether to use Mojang authentication.
     pub enabled: bool,
-    pub auth_url: String,
+    pub auth_url: Option<String>,
     pub prevent_proxy_connections: bool,
-    pub prevent_proxy_connection_auth_url: String,
+    pub prevent_proxy_connection_auth_url: Option<String>,
     /// Player profile handling.
     pub player_profile: PlayerProfileConfig,
     /// Texture handling.
@@ -22,8 +22,8 @@ impl Default for AuthenticationConfig {
             prevent_proxy_connections: false,
             player_profile: Default::default(),
             textures: Default::default(),
-            auth_url: "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}".to_string(),
-            prevent_proxy_connection_auth_url: "https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}&ip={ip}".to_string(),
+            auth_url: None,
+            prevent_proxy_connection_auth_url: None,
         }
     }
 }

--- a/pumpkin/src/client/authentication.rs
+++ b/pumpkin/src/client/authentication.rs
@@ -59,16 +59,24 @@ pub async fn authenticate(
 ) -> Result<GameProfile, AuthError> {
     assert!(ADVANCED_CONFIG.authentication.enabled);
     let address = if ADVANCED_CONFIG.authentication.prevent_proxy_connections {
-        ADVANCED_CONFIG
+        let auth_url = ADVANCED_CONFIG
             .authentication
-            .auth_url
+            .prevent_proxy_connection_auth_url
+            .as_deref()
+            .unwrap_or("https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}&ip={ip}");
+
+        auth_url
             .replace("{username}", username)
             .replace("{server_hash}", server_hash)
-            .replace("{}", &ip.to_string())
+            .replace("{ip}", &ip.to_string())
     } else {
-        ADVANCED_CONFIG
+        let auth_url = ADVANCED_CONFIG
             .authentication
             .auth_url
+            .as_deref()
+            .unwrap_or("https://sessionserver.mojang.com/session/minecraft/hasJoined?username={username}&serverId={server_hash}");
+
+        auth_url
             .replace("{username}", username)
             .replace("{server_hash}", server_hash)
     };


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Currently the auth URLs are not optional in features.toml. However, 99% of users will not change these values in the config file. This PR makes these URLs optional in the config file and falls back to the default auth URLs when not specified. By making them optional, they will be supported config options but not required in the config.

While making the URLs optional, I realized that there was a small issue in the code where the auth URL is still used even when `prevent-proxy-connections` is enabled. I fixed that and also fixed the IP address not being added to the URL correctly.
<!-- A description of the tests performed to verify the changes -->
## Testing
Tested with building and joining the server 👍 
<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Make auth URLs optional
- [x] Fix issues with `prevent-proxy-connections`
- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings `cargo clippy`
