### PR TITLE
feat(protocol): Switch from using flate2 to libdeflater to (de)compress zlib

### DIFF
--- a/pumpkin-protocol/Cargo.toml
+++ b/pumpkin-protocol/Cargo.toml
@@ -21,8 +21,9 @@ num-derive.workspace = true
 
 bytes = "1.8"
 
-flate2 = "1.0"
-
 # encryption
 aes = "0.8.4"
 cfb8 = "0.8.1"
+
+# decryption
+libdeflater = "1.22.0"

--- a/pumpkin-protocol/src/packet_decoder.rs
+++ b/pumpkin-protocol/src/packet_decoder.rs
@@ -224,8 +224,7 @@ mod tests {
 
     /// Helper function to encrypt data using AES-128 CFB-8 mode
     fn encrypt_aes128(data: &[u8], key: &[u8; 16], iv: &[u8; 16]) -> Vec<u8> {
-        let encryptor =
-            Cfb8Encryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
+        let encryptor = Cfb8Encryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
         let mut encrypted = data.to_vec();
         encryptor.encrypt(&mut encrypted);
         encrypted

--- a/pumpkin-protocol/src/packet_decoder.rs
+++ b/pumpkin-protocol/src/packet_decoder.rs
@@ -1,11 +1,7 @@
 use aes::cipher::{generic_array::GenericArray, BlockDecryptMut, BlockSizeUser, KeyIvInit};
 use bytes::{Buf, BytesMut};
+use libdeflater::{DecompressionError, Decompressor};
 use thiserror::Error;
-
-use std::io::Write;
-
-use bytes::BufMut;
-use flate2::write::ZlibDecoder;
 
 use crate::{bytebuf::ByteBuffer, RawPacket, VarInt, VarIntDecodeError, MAX_PACKET_SIZE};
 
@@ -14,12 +10,26 @@ type Cipher = cfb8::Decryptor<aes::Aes128>;
 // Decoder: Client -> Server
 // Supports ZLib decoding/decompression
 // Supports Aes128 Encyption
-#[derive(Default)]
 pub struct PacketDecoder {
     buf: BytesMut,
     decompress_buf: BytesMut,
     compression: bool,
     cipher: Option<Cipher>,
+    decompressor: Decompressor,
+}
+
+// Manual implementation of Default trait for PacketDecoder
+// Since decompressor does not implement Default
+impl Default for PacketDecoder {
+    fn default() -> Self {
+        Self {
+            buf: BytesMut::new(),
+            decompress_buf: BytesMut::new(),
+            compression: false,
+            cipher: None,
+            decompressor: Decompressor::new(),
+        }
+    }
 }
 
 impl PacketDecoder {
@@ -59,14 +69,22 @@ impl PacketDecoder {
             if data_len > 0 {
                 debug_assert!(self.decompress_buf.is_empty());
 
-                self.decompress_buf.put_bytes(0, data_len as usize);
+                // Estimate the maximum decompressed size.
+                self.decompress_buf.resize(data_len as usize, 0);
 
-                // TODO: use libdeflater or zune-inflate?
-                let mut z = ZlibDecoder::new(&mut self.decompress_buf[..]);
+                // Perform decompression using libdeflater
+                let decompressed_size = self
+                    .decompressor
+                    .zlib_decompress(r, &mut self.decompress_buf)
+                    .map_err(PacketDecodeError::from)?;
 
-                z.write_all(r)
-                    .map_err(|e| PacketDecodeError::FailedWrite(e.to_string()))?;
-                z.finish().map_err(|_| PacketDecodeError::FailedFinish)?;
+                if decompressed_size != data_len as usize {
+                    return Err(PacketDecodeError::FailedDecompression(format!(
+                        "Expected {} bytes, got {} bytes",
+                        data_len, decompressed_size
+                    )));
+                }
+                self.decompress_buf.truncate(decompressed_size);
 
                 let total_packet_len = VarInt(packet_len).written_size() + packet_len as usize;
 
@@ -174,4 +192,335 @@ pub enum PacketDecodeError {
     OutOfBounds,
     #[error("malformed packet length VarInt")]
     MalformedLength,
+    #[error("failed to decompress packet: {0}")]
+    FailedDecompression(String), // Updated to include error details
+}
+
+impl From<DecompressionError> for PacketDecodeError {
+    fn from(error: DecompressionError) -> Self {
+        PacketDecodeError::FailedDecompression(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes::Aes128;
+    use cfb8::cipher::AsyncStreamCipher;
+    use cfb8::{Decryptor as Cfb8Decryptor, Encryptor as Cfb8Encryptor};
+    use libdeflater::{CompressionLvl, Compressor};
+    use std::io::Cursor;
+
+    /// Helper function to encode a VarInt into bytes using ByteBuffer
+    fn encode_varint(value: i32) -> Vec<u8> {
+        let varint = VarInt(value);
+        let mut cursor = Cursor::new(Vec::new());
+        varint.encode(&mut cursor).expect("VarInt encoding failed");
+        cursor.into_inner()
+    }
+
+    /// Helper function to compress data using libdeflater's Zlib compressor
+    fn compress_zlib(data: &[u8]) -> Vec<u8> {
+        let mut compressor = Compressor::new(CompressionLvl::default()); // Using compression level 6
+        let mut compressed = vec![0u8; compressor.zlib_compress_bound(data.len())];
+        let compressed_size = compressor
+            .zlib_compress(data, &mut compressed)
+            .expect("Compression failed");
+        compressed.truncate(compressed_size);
+        compressed
+    }
+
+    /// Helper function to encrypt data using AES-128 CFB-8 mode
+    fn encrypt_aes128(data: &[u8], key: &[u8; 16], iv: &[u8; 16]) -> Vec<u8> {
+        let mut encryptor =
+            Cfb8Encryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
+        let mut encrypted = data.to_vec();
+        encryptor.encrypt(&mut encrypted);
+        encrypted
+    }
+
+    /// Helper function to decrypt data using AES-128 CFB-8 mode
+    fn decrypt_aes128(encrypted_data: &[u8], key: &[u8; 16], iv: &[u8; 16]) -> Vec<u8> {
+        let mut decryptor =
+            Cfb8Decryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
+        let mut decrypted = encrypted_data.to_vec();
+        decryptor.decrypt(&mut decrypted);
+        decrypted
+    }
+
+    /// Helper function to build a packet with optional compression and encryption
+    fn build_packet(
+        packet_id: i32,
+        payload: &[u8],
+        compress: bool,
+        key: Option<&[u8; 16]>,
+        iv: Option<&[u8; 16]>,
+    ) -> Vec<u8> {
+        let mut buffer = ByteBuffer::empty();
+
+        if compress {
+            // Create a buffer that includes packet_id_varint and payload
+            let mut data_to_compress = ByteBuffer::empty();
+            let packet_id_varint = VarInt(packet_id);
+            data_to_compress.put_var_int(&packet_id_varint);
+            data_to_compress.put_slice(payload);
+
+            // Compress the combined data
+            let compressed_payload = compress_zlib(&data_to_compress.buf());
+            let data_len = data_to_compress.buf().len() as i32; // 1 + payload.len()
+            let data_len_varint = VarInt(data_len);
+            buffer.put_var_int(&data_len_varint);
+            buffer.put_slice(&compressed_payload);
+        } else {
+            // No compression; data_len is payload length
+            let packet_id_varint = VarInt(packet_id);
+            buffer.put_var_int(&packet_id_varint);
+            buffer.put_slice(payload);
+        }
+
+        // Calculate packet length: length of buffer
+        let packet_len = buffer.buf().len() as i32;
+        let packet_len_varint = VarInt(packet_len);
+        let mut packet_length_encoded = Vec::new();
+        {
+            let mut cursor = Cursor::new(&mut packet_length_encoded);
+            packet_len_varint
+                .encode(&mut cursor)
+                .expect("VarInt encoding failed");
+        }
+
+        // Create a new buffer for the entire packet
+        let mut packet = Vec::new();
+        packet.extend_from_slice(&packet_length_encoded);
+        packet.extend_from_slice(&buffer.buf());
+
+        // Encrypt if key and iv are provided
+        if let (Some(k), Some(v)) = (key, iv) {
+            encrypt_aes128(&packet, k, v)
+        } else {
+            packet
+        }
+    }
+
+    /// Test decoding without compression and encryption
+    #[test]
+    fn test_decode_without_compression_and_encryption() {
+        // Sample packet data: packet_id = 1, payload = "Hello"
+        let packet_id = 1;
+        let payload = b"Hello";
+
+        // Build the packet without compression and encryption
+        let packet = build_packet(packet_id, payload, false, None, None);
+
+        // Initialize the decoder without compression and encryption
+        let mut decoder = PacketDecoder::default();
+        decoder.set_compression(false);
+
+        // Feed the packet to the decoder
+        decoder.queue_slice(&packet);
+
+        // Attempt to decode
+        let result = decoder.decode().expect("Decoding failed");
+        assert!(result.is_some());
+
+        let mut raw_packet = result.unwrap();
+        assert_eq!(raw_packet.id.0, packet_id);
+        assert_eq!(raw_packet.bytebuf.buf().as_ref(), payload);
+    }
+
+    /// Test decoding with compression
+    #[test]
+    fn test_decode_with_compression() {
+        // Sample packet data: packet_id = 2, payload = "Hello, compressed world!"
+        let packet_id = 2;
+        let payload = b"Hello, compressed world!";
+
+        // Build the packet with compression enabled
+        let packet = build_packet(packet_id, payload, true, None, None);
+
+        // Initialize the decoder with compression enabled
+        let mut decoder = PacketDecoder::default();
+        decoder.set_compression(true);
+
+        // Feed the packet to the decoder
+        decoder.queue_slice(&packet);
+
+        // Attempt to decode
+        let result = decoder.decode().expect("Decoding failed");
+        assert!(result.is_some());
+
+        let mut raw_packet = result.unwrap();
+        assert_eq!(raw_packet.id.0, packet_id);
+        assert_eq!(raw_packet.bytebuf.buf().as_ref(), payload);
+    }
+
+    /// Test decoding with encryption
+    #[test]
+    fn test_decode_with_encryption() {
+        // Sample packet data: packet_id = 3, payload = "Hello, encrypted world!"
+        let packet_id = 3;
+        let payload = b"Hello, encrypted world!";
+
+        // Define encryption key and IV
+        let key = [0x00u8; 16]; // Example key
+        let iv = [0x00u8; 16]; // Example IV
+
+        // Build the packet with encryption enabled (no compression)
+        let packet = build_packet(packet_id, payload, false, Some(&key), Some(&iv));
+
+        // Initialize the decoder with encryption enabled
+        let mut decoder = PacketDecoder::default();
+        decoder.set_compression(false);
+        decoder.set_encryption(Some(&key));
+
+        // Feed the encrypted packet to the decoder
+        decoder.queue_slice(&packet);
+
+        // Attempt to decode
+        let result = decoder.decode().expect("Decoding failed");
+        assert!(result.is_some());
+
+        let mut raw_packet = result.unwrap();
+        assert_eq!(raw_packet.id.0, packet_id);
+        assert_eq!(raw_packet.bytebuf.buf().as_ref(), payload);
+    }
+
+    /// Test decoding with both compression and encryption
+    #[test]
+    fn test_decode_with_compression_and_encryption() {
+        // Sample packet data: packet_id = 4, payload = "Hello, compressed and encrypted world!"
+        let packet_id = 4;
+        let payload = b"Hello, compressed and encrypted world!";
+
+        // Define encryption key and IV
+        let key = [0x01u8; 16]; // Example key
+        let iv = [0x01u8; 16]; // Example IV
+
+        // Build the packet with both compression and encryption enabled
+        let packet = build_packet(packet_id, payload, true, Some(&key), Some(&iv));
+
+        // Initialize the decoder with both compression and encryption enabled
+        let mut decoder = PacketDecoder::default();
+        decoder.set_compression(true);
+        decoder.set_encryption(Some(&key));
+
+        // Feed the encrypted and compressed packet to the decoder
+        decoder.queue_slice(&packet);
+
+        // Attempt to decode
+        let result = decoder.decode().expect("Decoding failed");
+        assert!(result.is_some());
+
+        let mut raw_packet = result.unwrap();
+        assert_eq!(raw_packet.id.0, packet_id);
+        assert_eq!(raw_packet.bytebuf.buf().as_ref(), payload);
+    }
+
+    /// Test decoding with invalid compressed data
+    #[test]
+    fn test_decode_with_invalid_compressed_data() {
+        // Sample packet data: packet_id = 5, payload_len = 10, but compressed data is invalid
+        let packet_id = 5;
+        let data_len = 10; // Expected decompressed size
+        let invalid_compressed_data = vec![0xFF, 0xFF, 0xFF]; // Invalid Zlib data
+
+        // Build the packet with compression enabled but invalid compressed data
+        let mut buffer = ByteBuffer::empty();
+        let data_len_varint = VarInt(data_len);
+        buffer.put_var_int(&data_len_varint);
+        buffer.put_slice(&invalid_compressed_data);
+
+        // Calculate packet length: VarInt(data_len) + invalid compressed data
+        let packet_len = buffer.buf().len() as i32;
+        let packet_len_varint = VarInt(packet_len);
+
+        // Create a new buffer for the entire packet
+        let mut packet_buffer = ByteBuffer::empty();
+        packet_buffer.put_var_int(&packet_len_varint);
+        packet_buffer.put_slice(&buffer.buf());
+
+        let packet_bytes = packet_buffer.buf().to_vec();
+
+        // Initialize the decoder with compression enabled
+        let mut decoder = PacketDecoder::default();
+        decoder.set_compression(true);
+
+        // Feed the invalid compressed packet to the decoder
+        decoder.queue_slice(&packet_bytes);
+
+        // Attempt to decode and expect a decompression error
+        let result = decoder.decode();
+        assert!(matches!(
+            result,
+            Err(PacketDecodeError::FailedDecompression(_))
+        ));
+    }
+
+    /// Test decoding with a zero-length packet
+    #[test]
+    fn test_decode_with_zero_length_packet() {
+        // Sample packet data: packet_id = 7, payload = "" (empty)
+        let packet_id = 7;
+        let payload = b"";
+
+        // Build the packet without compression and encryption
+        let packet = build_packet(packet_id, payload, false, None, None);
+
+        // Initialize the decoder without compression and encryption
+        let mut decoder = PacketDecoder::default();
+        decoder.set_compression(false);
+
+        // Feed the packet to the decoder
+        decoder.queue_slice(&packet);
+
+        // Attempt to decode
+        let result = decoder.decode().expect("Decoding failed");
+        assert!(result.is_some());
+
+        let mut raw_packet = result.unwrap();
+        assert_eq!(raw_packet.id.0, packet_id);
+        assert_eq!(raw_packet.bytebuf.buf().as_ref(), payload);
+    }
+
+    /// Test decoding with maximum length packet
+    #[test]
+    fn test_decode_with_maximum_length_packet() {
+        // Sample packet data: packet_id = 8, payload = "A" repeated MAX_PACKET_SIZE times
+        // Sample packet data: packet_id = 8, payload = "A" repeated (MAX_PACKET_SIZE - 1) times
+        let packet_id = 8;
+        let payload = vec![0x41u8; (MAX_PACKET_SIZE - 1) as usize]; // "A" repeated
+        let payload_len = payload.len() as i32;
+
+        // Build the packet with compression enabled
+        let packet = build_packet(packet_id, &payload, true, None, None);
+        println!(
+            "Built packet (with compression, maximum length): {:?}",
+            packet
+        );
+
+        // Initialize the decoder with compression enabled
+        let mut decoder = PacketDecoder::default();
+        decoder.set_compression(true);
+
+        // Feed the packet to the decoder
+        decoder.queue_slice(&packet);
+
+        // Attempt to decode
+        let result = decoder.decode().expect("Decoding failed");
+        assert!(
+            result.is_some(),
+            "Decoder returned None when it should have decoded a packet"
+        );
+
+        let mut raw_packet = result.unwrap();
+        assert_eq!(
+            raw_packet.id.0, packet_id,
+            "Decoded packet_id does not match"
+        );
+        assert_eq!(
+            raw_packet.bytebuf.buf().as_ref(),
+            &payload[..],
+            "Decoded payload does not match"
+        );
+    }
 }

--- a/pumpkin-protocol/src/packet_encoder.rs
+++ b/pumpkin-protocol/src/packet_encoder.rs
@@ -255,8 +255,7 @@ mod tests {
 
     /// Helper function to decrypt data using AES-128 CFB-8 mode
     fn decrypt_aes128(encrypted_data: &[u8], key: &[u8; 16], iv: &[u8; 16]) -> Vec<u8> {
-        let decryptor =
-            Cfb8Decryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
+        let decryptor = Cfb8Decryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
         let mut decrypted = encrypted_data.to_vec();
         decryptor.decrypt(&mut decrypted);
         decrypted

--- a/pumpkin-protocol/src/packet_encoder.rs
+++ b/pumpkin-protocol/src/packet_encoder.rs
@@ -5,10 +5,7 @@ use bytes::{BufMut, BytesMut};
 use pumpkin_config::compression::CompressionInfo;
 use thiserror::Error;
 
-use std::io::Read;
-
-use flate2::bufread::ZlibEncoder;
-use flate2::Compression;
+use libdeflater::{CompressionLvl, Compressor};
 
 use crate::{bytebuf::ByteBuffer, ClientPacket, VarInt, MAX_PACKET_SIZE};
 
@@ -17,12 +14,26 @@ type Cipher = cfb8::Encryptor<aes::Aes128>;
 // Encoder: Server -> Client
 // Supports ZLib endecoding/compression
 // Supports Aes128 Encyption
-#[derive(Default)]
 pub struct PacketEncoder {
     buf: BytesMut,
     compress_buf: Vec<u8>,
     compression: Option<CompressionInfo>,
     cipher: Option<Cipher>,
+    compressor: Compressor, // Reuse the compressor for all packets
+}
+
+// Manual implementation of Default trait for PacketEncoder
+// Since compressor does not implement Default
+impl Default for PacketEncoder {
+    fn default() -> Self {
+        Self {
+            buf: BytesMut::with_capacity(1024),
+            compress_buf: Vec::with_capacity(1024),
+            compression: None,
+            cipher: None,
+            compressor: Compressor::new(CompressionLvl::fastest()), // init compressor with no compression level
+        }
+    }
 }
 
 impl PacketEncoder {
@@ -44,20 +55,35 @@ impl PacketEncoder {
 
         if let Some(compression) = &self.compression {
             if data_len > compression.threshold as usize {
-                let mut z =
-                    ZlibEncoder::new(&self.buf[start_len..], Compression::new(compression.level));
+                // Get the data to compress
+                let data_to_compress = &self.buf[start_len..];
 
+                // Clear the compression buffer
                 self.compress_buf.clear();
+
+                // Compute the maximum size of compressed data
+                let max_compressed_size =
+                    self.compressor.zlib_compress_bound(data_to_compress.len());
+
+                // Ensure compress_buf has enough capacity
+                self.compress_buf.resize(max_compressed_size, 0);
+
+                // Compress the data
+                let compressed_size = self
+                    .compressor
+                    .zlib_compress(data_to_compress, &mut self.compress_buf)
+                    .map_err(|_| PacketEncodeError::CompressionFailed)?;
+
+                // Resize compress_buf to actual compressed size
+                self.compress_buf.resize(compressed_size, 0);
 
                 let data_len_size = VarInt(data_len as i32).written_size();
 
-                let packet_len = data_len_size + z.read_to_end(&mut self.compress_buf).unwrap();
+                let packet_len = data_len_size + compressed_size;
 
                 if packet_len >= MAX_PACKET_SIZE as usize {
-                    Err(PacketEncodeError::TooLong)?
+                    return Err(PacketEncodeError::TooLong);
                 }
-
-                drop(z);
 
                 self.buf.truncate(start_len);
 
@@ -134,6 +160,18 @@ impl PacketEncoder {
     /// Enables ZLib Compression
     pub fn set_compression(&mut self, compression: Option<CompressionInfo>) {
         self.compression = compression;
+
+        // Reset the compressor with the new compression level
+        if let Some(compression) = &self.compression {
+            let compression_level = compression.level as i32;
+
+            let level = match CompressionLvl::new(compression_level) {
+                Ok(level) => level,
+                Err(_) => return,
+            };
+
+            self.compressor = Compressor::new(level);
+        }
     }
 
     pub fn take(&mut self) -> BytesMut {
@@ -160,11 +198,406 @@ pub enum PacketEncodeError {
     EncodeFailedWrite,
     #[error("packet exceeds maximum length")]
     TooLong,
+    #[error("invalid compression level")]
+    InvalidCompressionLevel,
+    #[error("compression failed")]
+    CompressionFailed,
 }
 
 impl PacketEncodeError {
     pub fn kickable(&self) -> bool {
         // We no longer have a connection, so dont try to kick the player, just close
         !matches!(self, Self::EncodeData | Self::EncodeFailedWrite)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bytebuf::packet_id::Packet;
+    use crate::client::status::CStatusResponse;
+    use crate::VarIntDecodeError;
+    use aes::Aes128;
+    use cfb8::cipher::AsyncStreamCipher;
+    use cfb8::Decryptor as Cfb8Decryptor;
+    use libdeflater::{DecompressionError, Decompressor};
+    use pumpkin_macros::client_packet;
+    use serde::Serialize;
+
+    /// Define a custom packet for testing maximum packet size
+    #[derive(Serialize)]
+    #[client_packet("status:status_response")]
+    pub struct MaxSizePacket {
+        data: Vec<u8>,
+    }
+
+    impl MaxSizePacket {
+        pub fn new(size: usize) -> Self {
+            Self {
+                data: vec![0xAB; size], // Fill with arbitrary data
+            }
+        }
+    }
+
+    /// Helper function to decode a VarInt from bytes
+    fn decode_varint(buffer: &mut &[u8]) -> Result<i32, VarIntDecodeError> {
+        VarInt::decode(buffer).map(|varint| varint.0)
+    }
+
+    /// Helper function to decompress data using libdeflater's Zlib decompressor
+    fn decompress_zlib(data: &[u8], expected_size: usize) -> Result<Vec<u8>, DecompressionError> {
+        let mut decompressor = Decompressor::new();
+        let mut decompressed = vec![0u8; expected_size];
+        let actual_size = decompressor.zlib_decompress(data, &mut decompressed)?;
+        decompressed.truncate(actual_size);
+        Ok(decompressed)
+    }
+
+    /// Helper function to decrypt data using AES-128 CFB-8 mode
+    fn decrypt_aes128(encrypted_data: &[u8], key: &[u8; 16], iv: &[u8; 16]) -> Vec<u8> {
+        let mut decryptor =
+            Cfb8Decryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
+        let mut decrypted = encrypted_data.to_vec();
+        decryptor.decrypt(&mut decrypted);
+        decrypted
+    }
+
+    /// Helper function to build a packet with optional compression and encryption
+    fn build_packet_with_encoder<T: ClientPacket>(
+        packet: &T,
+        compression_info: Option<CompressionInfo>,
+        key: Option<&[u8; 16]>,
+    ) -> BytesMut {
+        let mut encoder = PacketEncoder::default();
+
+        if let Some(compression) = compression_info {
+            encoder.set_compression(Some(compression));
+        } else {
+            encoder.set_compression(None);
+        }
+
+        if let Some(key) = key {
+            encoder.set_encryption(Some(key));
+        }
+
+        encoder
+            .append_packet(packet)
+            .expect("Failed to append packet");
+
+        encoder.take()
+    }
+
+    /// Test encoding without compression and encryption
+    #[test]
+    fn test_encode_without_compression_and_encryption() {
+        // Create a CStatusResponse packet
+        let packet = CStatusResponse::new("{\"description\": \"A Minecraft Server\"}");
+
+        // Build the packet without compression and encryption
+        let packet_bytes = build_packet_with_encoder(&packet, None, None);
+
+        // Decode the packet manually to verify correctness
+        let mut buffer = &packet_bytes[..];
+
+        // Read packet length VarInt
+        let packet_length = decode_varint(&mut buffer).expect("Failed to decode packet length");
+        assert_eq!(
+            packet_length as usize,
+            buffer.len(),
+            "Packet length mismatch"
+        );
+
+        // Read packet ID VarInt
+        let decoded_packet_id = decode_varint(&mut buffer).expect("Failed to decode packet ID");
+        assert_eq!(decoded_packet_id, CStatusResponse::PACKET_ID);
+
+        // Remaining buffer is the payload
+        // We need to obtain the expected payload
+        let mut expected_payload = ByteBuffer::empty();
+        packet.write(&mut expected_payload);
+
+        assert_eq!(buffer, expected_payload.buf());
+    }
+
+    /// Test encoding with compression
+    #[test]
+    fn test_encode_with_compression() {
+        // Create a CStatusResponse packet
+        let packet = CStatusResponse::new("{\"description\": \"A Minecraft Server\"}");
+
+        // Compression threshold is set to 0 to force compression
+        let compression_info = CompressionInfo {
+            threshold: 0,
+            level: 6, // Standard compression level
+        };
+
+        // Build the packet with compression enabled
+        let packet_bytes = build_packet_with_encoder(&packet, Some(compression_info), None);
+
+        // Decode the packet manually to verify correctness
+        let mut buffer = &packet_bytes[..];
+
+        // Read packet length VarInt
+        let packet_length = decode_varint(&mut buffer).expect("Failed to decode packet length");
+        assert_eq!(
+            packet_length as usize,
+            buffer.len(),
+            "Packet length mismatch"
+        );
+
+        // Read data length VarInt (uncompressed data length)
+        let data_length = decode_varint(&mut buffer).expect("Failed to decode data length");
+        let mut expected_payload = ByteBuffer::empty();
+        packet.write(&mut expected_payload);
+        let uncompressed_data_length =
+            VarInt(CStatusResponse::PACKET_ID).written_size() + expected_payload.buf().len();
+        assert_eq!(data_length as usize, uncompressed_data_length);
+
+        // Remaining buffer is the compressed data
+        let compressed_data = buffer;
+
+        // Decompress the data
+        let decompressed_data = decompress_zlib(compressed_data, data_length as usize)
+            .expect("Failed to decompress data");
+
+        // Verify packet ID and payload
+        let mut decompressed_buffer = &decompressed_data[..];
+
+        // Read packet ID VarInt
+        let decoded_packet_id =
+            decode_varint(&mut decompressed_buffer).expect("Failed to decode packet ID");
+        assert_eq!(decoded_packet_id, CStatusResponse::PACKET_ID);
+
+        // Remaining buffer is the payload
+        assert_eq!(decompressed_buffer, expected_payload.buf());
+    }
+
+    /// Test encoding with encryption
+    #[test]
+    fn test_encode_with_encryption() {
+        // Create a CStatusResponse packet
+        let packet = CStatusResponse::new("{\"description\": \"A Minecraft Server\"}");
+
+        // Encryption key and IV (IV is the same as key in this case)
+        let key = [0x00u8; 16]; // Example key
+
+        // Build the packet with encryption enabled (no compression)
+        let packet_bytes = build_packet_with_encoder(&packet, None, Some(&key));
+
+        // Decrypt the packet
+        let decrypted_packet = decrypt_aes128(&packet_bytes, &key, &key);
+
+        // Decode the packet manually to verify correctness
+        let mut buffer = &decrypted_packet[..];
+
+        // Read packet length VarInt
+        let packet_length = decode_varint(&mut buffer).expect("Failed to decode packet length");
+        assert_eq!(
+            packet_length as usize,
+            buffer.len(),
+            "Packet length mismatch"
+        );
+
+        // Read packet ID VarInt
+        let decoded_packet_id = decode_varint(&mut buffer).expect("Failed to decode packet ID");
+        assert_eq!(decoded_packet_id, CStatusResponse::PACKET_ID);
+
+        // Remaining buffer is the payload
+        let mut expected_payload = ByteBuffer::empty();
+        packet.write(&mut expected_payload);
+
+        assert_eq!(buffer, expected_payload.buf());
+    }
+
+    /// Test encoding with both compression and encryption
+    #[test]
+    fn test_encode_with_compression_and_encryption() {
+        // Create a CStatusResponse packet
+        let packet = CStatusResponse::new("{\"description\": \"A Minecraft Server\"}");
+
+        // Compression threshold is set to 0 to force compression
+        let compression_info = CompressionInfo {
+            threshold: 0,
+            level: 6, // Standard compression level
+        };
+
+        // Encryption key and IV (IV is the same as key in this case)
+        let key = [0x01u8; 16]; // Example key
+
+        // Build the packet with both compression and encryption enabled
+        let packet_bytes = build_packet_with_encoder(&packet, Some(compression_info), Some(&key));
+
+        // Decrypt the packet
+        let decrypted_packet = decrypt_aes128(&packet_bytes, &key, &key);
+
+        // Decode the packet manually to verify correctness
+        let mut buffer = &decrypted_packet[..];
+
+        // Read packet length VarInt
+        let packet_length = decode_varint(&mut buffer).expect("Failed to decode packet length");
+        assert_eq!(
+            packet_length as usize,
+            buffer.len(),
+            "Packet length mismatch"
+        );
+
+        // Read data length VarInt (uncompressed data length)
+        let data_length = decode_varint(&mut buffer).expect("Failed to decode data length");
+        let mut expected_payload = ByteBuffer::empty();
+        packet.write(&mut expected_payload);
+        let uncompressed_data_length =
+            VarInt(CStatusResponse::PACKET_ID).written_size() + expected_payload.buf().len();
+        assert_eq!(data_length as usize, uncompressed_data_length);
+
+        // Remaining buffer is the compressed data
+        let compressed_data = buffer;
+
+        // Decompress the data
+        let decompressed_data = decompress_zlib(compressed_data, data_length as usize)
+            .expect("Failed to decompress data");
+
+        // Verify packet ID and payload
+        let mut decompressed_buffer = &decompressed_data[..];
+
+        // Read packet ID VarInt
+        let decoded_packet_id =
+            decode_varint(&mut decompressed_buffer).expect("Failed to decode packet ID");
+        assert_eq!(decoded_packet_id, CStatusResponse::PACKET_ID);
+
+        // Remaining buffer is the payload
+        assert_eq!(decompressed_buffer, expected_payload.buf());
+    }
+
+    /// Test encoding with zero-length payload
+    #[test]
+    fn test_encode_with_zero_length_payload() {
+        // Create a CStatusResponse packet with empty payload
+        let packet = CStatusResponse::new("");
+
+        // Build the packet without compression and encryption
+        let packet_bytes = build_packet_with_encoder(&packet, None, None);
+
+        // Decode the packet manually to verify correctness
+        let mut buffer = &packet_bytes[..];
+
+        // Read packet length VarInt
+        let packet_length = decode_varint(&mut buffer).expect("Failed to decode packet length");
+        assert_eq!(
+            packet_length as usize,
+            buffer.len(),
+            "Packet length mismatch"
+        );
+
+        // Read packet ID VarInt
+        let decoded_packet_id = decode_varint(&mut buffer).expect("Failed to decode packet ID");
+        assert_eq!(decoded_packet_id, CStatusResponse::PACKET_ID);
+
+        // Remaining buffer is the payload (empty)
+        let mut expected_payload = ByteBuffer::empty();
+        packet.write(&mut expected_payload);
+
+        assert_eq!(
+            buffer.len(),
+            expected_payload.buf().len(),
+            "Payload length mismatch"
+        );
+        assert_eq!(buffer, expected_payload.buf());
+    }
+
+    /// Test encoding with maximum length payload
+    #[test]
+    fn test_encode_with_maximum_string_length() {
+        // Maximum allowed string length is 32767 bytes
+        let max_string_length = 32767;
+        let payload_str = "A".repeat(max_string_length);
+        let packet = CStatusResponse::new(&payload_str);
+
+        // Build the packet without compression and encryption
+        let packet_bytes = build_packet_with_encoder(&packet, None, None);
+
+        // Verify that the packet size does not exceed MAX_PACKET_SIZE
+        assert!(
+            packet_bytes.len() <= MAX_PACKET_SIZE as usize,
+            "Packet size exceeds maximum allowed size"
+        );
+
+        // Decode the packet manually to verify correctness
+        let mut buffer = &packet_bytes[..];
+
+        // Read packet length VarInt
+        let packet_length = decode_varint(&mut buffer).expect("Failed to decode packet length");
+        assert_eq!(
+            packet_length as usize,
+            buffer.len(),
+            "Packet length mismatch"
+        );
+
+        // Read packet ID VarInt
+        let decoded_packet_id = decode_varint(&mut buffer).expect("Failed to decode packet ID");
+        // Assume packet ID is 0 for CStatusResponse
+        assert_eq!(decoded_packet_id, CStatusResponse::PACKET_ID);
+
+        // Remaining buffer is the payload
+        let mut expected_payload = ByteBuffer::empty();
+        packet.write(&mut expected_payload);
+
+        assert_eq!(buffer, expected_payload.buf());
+    }
+
+    /// Test encoding a packet that exceeds MAX_PACKET_SIZE
+    #[test]
+    #[should_panic(expected = "TooLong")]
+    fn test_encode_packet_exceeding_maximum_size() {
+        // Create a custom packet with data exceeding MAX_PACKET_SIZE
+        let data_size = MAX_PACKET_SIZE as usize + 1; // Exceed by 1 byte
+        let packet = MaxSizePacket::new(data_size);
+
+        // Build the packet without compression and encryption
+        // This should panic with PacketEncodeError::TooLong
+        build_packet_with_encoder(&packet, None, None);
+    }
+
+    /// Test encoding with a small payload that should not be compressed
+    #[test]
+    fn test_encode_small_payload_no_compression() {
+        // Create a CStatusResponse packet with small payload
+        let packet = CStatusResponse::new("Hi");
+
+        // Compression threshold is set to a value higher than payload length
+        let compression_info = CompressionInfo {
+            threshold: 10,
+            level: 6, // Standard compression level
+        };
+
+        // Build the packet with compression enabled
+        let packet_bytes = build_packet_with_encoder(&packet, Some(compression_info), None);
+
+        // Decode the packet manually to verify that it was not compressed
+        let mut buffer = &packet_bytes[..];
+
+        // Read packet length VarInt
+        let packet_length = decode_varint(&mut buffer).expect("Failed to decode packet length");
+        assert_eq!(
+            packet_length as usize,
+            buffer.len(),
+            "Packet length mismatch"
+        );
+
+        // Read data length VarInt (should be 0 indicating no compression)
+        let data_length = decode_varint(&mut buffer).expect("Failed to decode data length");
+        assert_eq!(
+            data_length, 0,
+            "Data length should be 0 indicating no compression"
+        );
+
+        // Read packet ID VarInt
+        let decoded_packet_id = decode_varint(&mut buffer).expect("Failed to decode packet ID");
+        assert_eq!(decoded_packet_id, CStatusResponse::PACKET_ID);
+
+        // Remaining buffer is the payload
+        let mut expected_payload = ByteBuffer::empty();
+        packet.write(&mut expected_payload);
+
+        assert_eq!(buffer, expected_payload.buf());
     }
 }

--- a/pumpkin-protocol/src/packet_encoder.rs
+++ b/pumpkin-protocol/src/packet_encoder.rs
@@ -255,7 +255,7 @@ mod tests {
 
     /// Helper function to decrypt data using AES-128 CFB-8 mode
     fn decrypt_aes128(encrypted_data: &[u8], key: &[u8; 16], iv: &[u8; 16]) -> Vec<u8> {
-        let mut decryptor =
+        let decryptor =
             Cfb8Decryptor::<Aes128>::new_from_slices(key, iv).expect("Invalid key/iv");
         let mut decrypted = encrypted_data.to_vec();
         decryptor.decrypt(&mut decrypted);


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This merge request change the lib flate2 used to (de)compress packet to using directly [libdeflater](https://github.com/adamkewley/libdeflater) which is a Rust binding of the C heavily optimized libdeflate

Some change have been made:
- first we only create one instance of Decompressor and Compressor since the new constructor can be heavily to be created at each packet encoding / decoding.
- added validation on decompression to ensure the decompressed_size is at the good size, this will avoid some CPU attack when the zlib encoding is wrong

Some benchmark directly from the lib
https://github.com/adamkewley/libdeflater?tab=readme-ov-file#benchmarks
<!-- A description of the tests performed to verify the changes -->
## Testing
I have created unit test based on previous system with flate2, run them with the new system to ensure we got the same result
And just launched the server and connected to ensure all was working and that I can play

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [x] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
