### PR TITLE
Text component children + fix nbt serialization for sequences of maps

### DIFF
--- a/pumpkin-core/src/text/mod.rs
+++ b/pumpkin-core/src/text/mod.rs
@@ -187,7 +187,15 @@ impl<'a> TextComponent<'a> {
             #[serde(rename = "extra")]
             extra: Vec<&'a TempStruct<'a>>,
         }
-        let temp_extra: Vec<TempStruct> = self.extra.iter().map(|x| TempStruct { text: &x.content, style: &x.style, extra: vec![] }).collect();
+        let temp_extra: Vec<TempStruct> = self
+            .extra
+            .iter()
+            .map(|x| TempStruct {
+                text: &x.content,
+                style: &x.style,
+                extra: vec![],
+            })
+            .collect();
         let temp_extra_refs: Vec<&TempStruct> = temp_extra.iter().collect();
         let astruct = TempStruct {
             text: &self.content,

--- a/pumpkin-core/src/text/mod.rs
+++ b/pumpkin-core/src/text/mod.rs
@@ -31,6 +31,8 @@ pub struct TextComponent<'a> {
     /// Also has `ClickEvent
     #[serde(flatten)]
     pub style: Style<'a>,
+    /// Extra text components
+    pub extra: Vec<TextComponent<'a>>,
 }
 
 impl<'a> TextComponent<'a> {
@@ -38,6 +40,7 @@ impl<'a> TextComponent<'a> {
         Self {
             content: TextContent::Text { text: text.into() },
             style: Style::default(),
+            extra: vec![],
         }
     }
 
@@ -45,7 +48,13 @@ impl<'a> TextComponent<'a> {
         Self {
             content: TextContent::Text { text: text.into() },
             style: Style::default(),
+            extra: vec![],
         }
+    }
+
+    pub fn add_child(mut self, child: TextComponent<'a>) -> Self {
+        self.extra.push(child);
+        self
     }
 
     pub fn to_pretty_console(self) -> String {
@@ -174,12 +183,19 @@ impl<'a> TextComponent<'a> {
             text: &'a TextContent<'a>,
             #[serde(flatten)]
             style: &'a Style<'a>,
+            #[serde(default, skip_serializing_if = "Vec::is_empty")]
+            #[serde(rename = "extra")]
+            extra: Vec<&'a TempStruct<'a>>,
         }
+        let temp_extra: Vec<TempStruct> = self.extra.iter().map(|x| TempStruct { text: &x.content, style: &x.style, extra: vec![] }).collect();
+        let temp_extra_refs: Vec<&TempStruct> = temp_extra.iter().collect();
         let astruct = TempStruct {
             text: &self.content,
             style: &self.style,
+            extra: temp_extra_refs,
         };
         // dbg!(&serde_json::to_string(&astruct));
+        // dbg!(pumpkin_nbt::serializer::to_bytes_unnamed(&astruct).unwrap().to_vec());
 
         // TODO
         pumpkin_nbt::serializer::to_bytes_unnamed(&astruct)

--- a/pumpkin-nbt/src/serializer.rs
+++ b/pumpkin-nbt/src/serializer.rs
@@ -327,7 +327,13 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        self.output.put_u8(COMPOUND_ID);
+        if let State::FirstListElement { .. } = self.state {
+            self.parse_state(COMPOUND_ID)?;
+        } else if let State::ListElement = self.state {
+            return Ok(self);
+        } else {
+            self.output.put_u8(COMPOUND_ID);
+        }
         Ok(self)
     }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This PR contains 2 main changes:
### Fix NBT serialization of map inside sequence
When serializing a sequence to NBT, it is necessary to add a header containing the type of the elements and the length of the sequence. While the `serialize_seq` method sets the state to `FirstListElement`, this state is never parsed when the elements are maps (this issue could possibly exist even for other element types, however I havent been able to test this). In this change I have modified the `serialize_map` function to handle the cases where the state is either a `FirstListElement` or a `ListElement`.
```diff
fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+   if let State::FirstListElement { .. } = self.state {
+       self.parse_state(COMPOUND_ID)?;
+   } else if let State::ListElement = self.state {
+       return Ok(self);
+   } else {
        self.output.put_u8(COMPOUND_ID);
+   }
    Ok(self)
}
```
### Add extra field to text components
Based on the [wiki](https://wiki.vg/Text_formatting#Content_fields), text components can have a `extra` field which contains other text components, which inherit the styling of their parent text component, but can also modify thier own style (and other attributes). This change adds a `add_child` method which accepts a `TextComponent` and returns `Self`:
```rs
TextComponent::text("Some parent")
    .add_child(TextComponent::text("A child component"))
    .add_child(TextComponent::text("Colored").color_named(NamedColor::Red))
```

<!-- A description of the tests performed to verify the changes -->
## Testing
Existing test pass without an issue, and trying to send a message with extra text components works as expected.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
