### PR TITLE
Move container to `LivingEntity`

### DIFF
--- a/pumpkin-inventory/src/lib.rs
+++ b/pumpkin-inventory/src/lib.rs
@@ -128,6 +128,34 @@ pub trait Container: Sync + Send {
     fn recipe_used(&mut self) {}
 }
 
+pub struct EmptyContainer;
+
+impl Container for EmptyContainer {
+    fn window_type(&self) -> &'static WindowType {
+        unreachable!(
+            "you should never be able to get here because this type is always wrapped in an option"
+        );
+    }
+
+    fn window_name(&self) -> &'static str {
+        unreachable!(
+            "you should never be able to get here because this type is always wrapped in an option"
+        );
+    }
+
+    fn all_slots(&mut self) -> Vec<&mut Option<ItemStack>> {
+        unreachable!(
+            "you should never be able to get here because this type is always wrapped in an option"
+        );
+    }
+
+    fn all_slots_ref(&self) -> Vec<Option<&ItemStack>> {
+        unreachable!(
+            "you should never be able to get here because this type is always wrapped in an option"
+        );
+    }
+}
+
 pub fn handle_item_take(
     carried_item: &mut Option<ItemStack>,
     item_slot: &mut Option<ItemStack>,

--- a/pumpkin/src/client/combat.rs
+++ b/pumpkin/src/client/combat.rs
@@ -29,7 +29,7 @@ impl AttackType {
         let sprinting = entity.sprinting.load(std::sync::atomic::Ordering::Relaxed);
         let on_ground = entity.on_ground.load(std::sync::atomic::Ordering::Relaxed);
         let sword = player
-            .inventory
+            .inventory()
             .lock()
             .await
             .held_item()

--- a/pumpkin/src/client/container.rs
+++ b/pumpkin/src/client/container.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 impl Player {
     pub async fn open_container(&self, server: &Server, window_type: WindowType) {
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         inventory.state_id = 0;
         inventory.total_opened_containers += 1;
         let mut container = self.get_open_container(server).await;
@@ -48,7 +48,7 @@ impl Player {
     }
 
     pub async fn set_container_content(&self, container: Option<&mut Box<dyn Container>>) {
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
 
         let total_opened_containers = inventory.total_opened_containers;
         let id = if container.is_some() {
@@ -83,7 +83,7 @@ impl Player {
 
     /// The official Minecraft client is weird, and will always just close *any* window that is opened when this gets sent
     pub async fn close_container(&self) {
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         inventory.total_opened_containers += 1;
         self.client
             .send_packet(&CCloseContainer::new(
@@ -99,7 +99,7 @@ impl Player {
         let (id, value) = window_property.into_tuple();
         self.client
             .send_packet(&CSetContainerProperty::new(
-                self.inventory.lock().await.total_opened_containers.into(),
+                self.inventory().lock().await.total_opened_containers.into(),
                 id,
                 value,
             ))
@@ -118,7 +118,7 @@ impl Player {
         };
         let drag_handler = &server.drag_handler;
 
-        let state_id = self.inventory.lock().await.state_id;
+        let state_id = self.inventory().lock().await.state_id;
         // This is just checking for regular desync, client hasn't done anything malicious
         if state_id != packet.state_id.0 as u32 {
             self.set_container_content(opened_container.as_deref_mut())
@@ -127,7 +127,7 @@ impl Player {
         }
 
         if opened_container.is_some() {
-            let total_containers = self.inventory.lock().await.total_opened_containers;
+            let total_containers = self.inventory().lock().await.total_opened_containers;
             if packet.window_id.0 != total_containers {
                 return Err(InventoryError::ClosedContainerInteract(self.entity_id()));
             }
@@ -145,7 +145,7 @@ impl Player {
             packet.slot,
         )?;
         let (crafted_item, crafted_item_slot) = {
-            let mut inventory = self.inventory.lock().await;
+            let mut inventory = self.inventory().lock().await;
             let combined =
                 OptionallyCombinedContainer::new(&mut inventory, opened_container.as_deref_mut());
             (
@@ -173,7 +173,7 @@ impl Player {
         .await?;
         // Checks for if crafted item has been taken
         {
-            let mut inventory = self.inventory.lock().await;
+            let mut inventory = self.inventory().lock().await;
             let mut combined =
                 OptionallyCombinedContainer::new(&mut inventory, opened_container.as_deref_mut());
             if combined.crafted_item_slot().is_none() && crafted_item.is_some() {
@@ -191,7 +191,7 @@ impl Player {
                 drop(opened_container);
                 self.send_whole_container_change(server).await?;
             } else if let container_click::Slot::Normal(slot_index) = click_slot {
-                let mut inventory = self.inventory.lock().await;
+                let mut inventory = self.inventory().lock().await;
                 let combined_container =
                     OptionallyCombinedContainer::new(&mut inventory, Some(&mut opened_container));
                 if let Some(slot) = combined_container.get_slot_excluding_inventory(slot_index) {
@@ -275,7 +275,7 @@ impl Player {
         slot: container_click::Slot,
         taking_crafted: bool,
     ) -> Result<(), InventoryError> {
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
         match slot {
             container_click::Slot::Normal(slot) => {
@@ -299,7 +299,7 @@ impl Player {
         slot: container_click::Slot,
         taking_crafted: bool,
     ) -> Result<(), InventoryError> {
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
 
         match slot {
@@ -357,7 +357,7 @@ impl Player {
             KeyClick::Slot(slot) => slot,
             KeyClick::Offhand => 45,
         };
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         let mut changing_item_slot = inventory.get_slot(changing_slot as usize)?.to_owned();
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
 
@@ -379,7 +379,7 @@ impl Player {
         if self.gamemode.load() != GameMode::Creative {
             return Err(InventoryError::PermissionError);
         }
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
         if let Some(Some(item)) = container.all_slots().get_mut(slot) {
             self.carried_item.store(Some(item.to_owned()));
@@ -392,7 +392,7 @@ impl Player {
         opened_container: Option<&mut Box<dyn Container>>,
         slot: usize,
     ) -> Result<(), InventoryError> {
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         let mut container = OptionallyCombinedContainer::new(&mut inventory, opened_container);
         let mut slots = container.all_slots();
 
@@ -451,7 +451,7 @@ impl Player {
                 drag_handler.add_slot(container_id, player_id, slot).await
             }
             MouseDragState::End => {
-                let mut inventory = self.inventory.lock().await;
+                let mut inventory = self.inventory().lock().await;
                 let mut container =
                     OptionallyCombinedContainer::new(&mut inventory, opened_container);
                 let mut carried_item = self.carried_item.load();
@@ -511,7 +511,7 @@ impl Player {
         slot: Slot,
     ) -> Result<(), InventoryError> {
         for player in self.get_current_players_in_container(server).await {
-            let mut inventory = player.inventory.lock().await;
+            let mut inventory = player.inventory().lock().await;
             let total_opened_containers = inventory.total_opened_containers;
 
             // Returns previous value
@@ -553,7 +553,7 @@ impl Player {
 
     async fn pickup_items(&self, item: &Item, mut amount: u32) {
         let max_stack = item.components.max_stack_size;
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
         let slots = inventory.slots_with_hotbar_first();
 
         let matching_slots = slots.filter_map(|slot| {

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -618,7 +618,7 @@ impl Player {
         }
 
         if let Some(face) = BlockFace::from_i32(use_item_on.face.0) {
-            let mut inventory = self.inventory.lock().await;
+            let mut inventory = self.inventory().lock().await;
             let item_slot = inventory.held_item_mut();
             if let Some(item) = item_slot {
                 let block = get_block_by_item(item.item_id);
@@ -691,7 +691,7 @@ impl Player {
             self.kick(TextComponent::text("Invalid held slot")).await;
             return;
         }
-        self.inventory.lock().await.set_selected(slot as usize);
+        self.inventory().lock().await.set_selected(slot as usize);
     }
 
     pub async fn handle_set_creative_slot(
@@ -703,7 +703,7 @@ impl Player {
         }
         let valid_slot = packet.slot >= 0 && packet.slot <= 45;
         if valid_slot {
-            self.inventory.lock().await.set_slot(
+            self.inventory().lock().await.set_slot(
                 packet.slot as usize,
                 packet.clicked_item.to_item(),
                 true,
@@ -722,7 +722,7 @@ impl Player {
             return;
         };
         // window_id 0 represents both 9x1 Generic AND inventory here
-        let mut inventory = self.inventory.lock().await;
+        let mut inventory = self.inventory().lock().await;
 
         inventory.state_id = 0;
         let open_container = self.open_container.load();

--- a/pumpkin/src/command/commands/cmd_clear.rs
+++ b/pumpkin/src/command/commands/cmd_clear.rs
@@ -19,7 +19,7 @@ const DESCRIPTION: &str = "Clear yours or targets inventory.";
 const ARG_TARGET: &str = "target";
 
 async fn clear_player(target: &Player) -> usize {
-    let mut inventory = target.inventory.lock().await;
+    let mut inventory = target.inventory().lock().await;
 
     let slots = inventory.all_slots();
     let items_count = slots


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Basically, we need a way to access inventory on entities (player, donkeys, llamas), and this PR refactors the code so that this is possible

<!-- A description of the tests performed to verify the changes -->
## Testing
I have gone through and tested that the basic inventory functions on player still works

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [X] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [X] Code does not produce any clippy warnings: `cargo clippy`
- [X] All unit tests pass: `cargo test`
