### PR TITLE
fix(protocol): Don't reserve memory on packet decoding error

### DIFF
--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -503,7 +503,10 @@ impl Client {
                     return true;
                 }
                 Ok(None) => (), //log::debug!("Waiting for more data to complete packet..."),
-                Err(err) => log::warn!("Failed to decode packet for: {}", err.to_string()),
+                Err(err) => {
+                    log::warn!("Failed to decode packet for: {}", err.to_string());
+                    return true; // return to avoid reserving additional bytes
+                }
             }
 
             dec.reserve(4096);

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -505,7 +505,8 @@ impl Client {
                 Ok(None) => (), //log::debug!("Waiting for more data to complete packet..."),
                 Err(err) => {
                     log::warn!("Failed to decode packet for: {}", err.to_string());
-                    return true; // return to avoid reserving additional bytes
+                    self.close();
+                    return false; // return to avoid reserving additional bytes
                 }
             }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This MR fix https://github.com/Snowiiii/Pumpkin/issues/354 by returning in client poll function to avoid reserving 4096 bytes for each wrong packet

<!-- A description of the tests performed to verify the changes -->
## Testing
Using the small program provided in https://github.com/Snowiiii/Pumpkin/issues/354 and see that ram never went up

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
