### PR TITLE
Lefthand and sneaking fixes

### DIFF
--- a/pumpkin-protocol/src/client/play/c_entity_animation.rs
+++ b/pumpkin-protocol/src/client/play/c_entity_animation.rs
@@ -20,10 +20,11 @@ impl CEntityAnimation {
     }
 }
 
+#[derive(Debug)]
 #[repr(u8)]
 pub enum Animation {
     SwingMainArm,
-    LeaveBed,
+    LeaveBed = 2,
     SwingOffhand,
     CriticalEffect,
     MagicCriticaleffect,

--- a/pumpkin/src/client/mod.rs
+++ b/pumpkin/src/client/mod.rs
@@ -76,7 +76,7 @@ impl Default for PlayerConfig {
             chat_mode: ChatMode::Enabled,
             chat_colors: true,
             skin_parts: 0,
-            main_hand: Hand::Main,
+            main_hand: Hand::Right,
             text_filtering: false,
             server_listing: false,
         }

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -438,11 +438,11 @@ impl Player {
             Hand::from_i32(client_information.main_hand.into()),
             ChatMode::from_i32(client_information.chat_mode.into()),
         ) {
-            let config = self.config.lock().await;
+            let mut config = self.config.lock().await;
             let update =
                 config.main_hand != main_hand || config.skin_parts != client_information.skin_parts;
 
-            *self.config.lock().await = PlayerConfig {
+            *config = PlayerConfig {
                 locale: client_information.locale,
                 // A Negative view distance would be impossible and make no sense right ?, Mojang: Lets make is signed :D
                 view_distance: client_information.view_distance as u8,
@@ -453,6 +453,7 @@ impl Player {
                 text_filtering: client_information.text_filtering,
                 server_listing: client_information.server_listing,
             };
+            drop(config);
             if update {
                 self.update_client_information().await;
             }

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -439,7 +439,8 @@ impl Player {
             ChatMode::from_i32(client_information.chat_mode.into()),
         ) {
             let config = self.config.lock().await;
-            let update = config.main_hand != main_hand || config.skin_parts != client_information.skin_parts;
+            let update =
+                config.main_hand != main_hand || config.skin_parts != client_information.skin_parts;
 
             *self.config.lock().await = PlayerConfig {
                 locale: client_information.locale,

--- a/pumpkin/src/client/player_packet.rs
+++ b/pumpkin/src/client/player_packet.rs
@@ -438,6 +438,9 @@ impl Player {
             Hand::from_i32(client_information.main_hand.into()),
             ChatMode::from_i32(client_information.chat_mode.into()),
         ) {
+            let config = self.config.lock().await;
+            let update = config.main_hand != main_hand || config.skin_parts != client_information.skin_parts;
+
             *self.config.lock().await = PlayerConfig {
                 locale: client_information.locale,
                 // A Negative view distance would be impossible and make no sense right ?, Mojang: Lets make is signed :D
@@ -449,7 +452,9 @@ impl Player {
                 text_filtering: client_information.text_filtering,
                 server_listing: client_information.server_listing,
             };
-            self.update_client_information().await;
+            if update {
+                self.update_client_information().await;
+            }
         } else {
             self.kick(TextComponent::text("Invalid hand or chat type"))
                 .await;

--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -176,11 +176,11 @@ impl Entity {
         self.sneaking
             .store(sneaking, std::sync::atomic::Ordering::Relaxed);
         self.set_flag(Flag::Sneaking, sneaking).await;
-        // if sneaking {
-        //     self.set_pose(EntityPose::Crouching).await;
-        // } else {
-        //     self.set_pose(EntityPose::Standing).await;
-        // }
+        if sneaking {
+            self.set_pose(EntityPose::Crouching).await;
+        } else {
+            self.set_pose(EntityPose::Standing).await;
+        }
     }
 
     pub async fn set_sprinting(&self, sprinting: bool) {
@@ -218,7 +218,7 @@ impl Entity {
         let pose = pose as i32;
         let packet = CSetEntityMetadata::<VarInt>::new(
             self.entity_id.into(),
-            Metadata::new(6, 20.into(), (pose).into()),
+            Metadata::new(6, 21.into(), pose.into()),
         );
         self.world.broadcast_packet_all(&packet).await;
     }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -866,7 +866,7 @@ impl Default for Abilities {
 }
 
 /// Represents the player's dominant hand.
-#[derive(Debug, FromPrimitive, Clone, Copy)]
+#[derive(Debug, FromPrimitive, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Hand {
     /// Usually the player's off-hand.

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -292,6 +292,7 @@ impl World {
             }],
         ))
         .await;
+        player.update_client_information().await;
 
         // here we send all the infos of already joined players
         let mut entries = Vec::new();


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
* Fixes #361 
* Fixed sneaking not working

<!-- A description of the tests performed to verify the changes -->
## Testing
* Sneaking in-front of other players work.
* Switching between left and right handed is shown on the client.
* Hit animation swings with right arm for both self and others.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
