### PR TITLE
Fix Minor Spelling Errors

### DIFF
--- a/docs/config/authentication.md
+++ b/docs/config/authentication.md
@@ -9,7 +9,7 @@ Servers authenthicate with Mojang's session servers in order to ensure the clien
 
 #### `enabled`: Boolean
 
-Weather authenthication is enabled or not.
+Whether authenthication is enabled or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -20,7 +20,7 @@ enabled = false
 
 #### `prevent_proxy_connections`: Boolean
 
-Weather to block proxy connections or not.
+Whether to block proxy connections or not.
 
 :::code-group
 ```toml [features.toml] {3}
@@ -123,7 +123,7 @@ allowed_url_domains = [".minecraft.net", ".mojang.com"]
 ### Texture Types
 
 #### `skin`: Boolean
-Weather to use player skins or not.
+Whether to use player skins or not.
 
 :::code-group
 ```toml [features.toml] {3}
@@ -133,7 +133,7 @@ skin = true
 :::
 
 #### `cape`: Boolean
-Weather to use player capes or not.
+Whether to use player capes or not.
 
 :::code-group
 ```toml [features.toml] {3}
@@ -143,7 +143,7 @@ cape = true
 :::
 
 #### `elytra`: Boolean
-Weather to use player elytras or not.
+Whether to use player elytras or not.
 
 :::code-group
 ```toml [features.toml] {3}

--- a/docs/config/commands.md
+++ b/docs/config/commands.md
@@ -3,7 +3,7 @@ Pumpkin supports Vanilla commands and allows you to configure where they can be 
 
 ## Configuring Commands
 #### `use_console`: Boolean
-Weather commands from the console are accepted or not.
+Whether commands from the console are accepted or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -13,7 +13,7 @@ use_console = false
 :::
 
 #### `log_console`: Boolean
-Weather commands from players should be logged into the console or not.
+Whether commands from players should be logged into the console or not.
 
 :::code-group
 ```toml [features.toml] {2}

--- a/docs/config/commands.md
+++ b/docs/config/commands.md
@@ -13,7 +13,7 @@ use_console = false
 :::
 
 #### `log_console`: Boolean
-Whether commands from players should be logged into the console or not.
+Whether commands from players should be logged in the console or not.
 
 :::code-group
 ```toml [features.toml] {2}

--- a/docs/config/compression.md
+++ b/docs/config/compression.md
@@ -1,5 +1,5 @@
 # Compression
-Compression is used to reduce the size of packets. This is benefical to reduce bandwidth server side and also help players on slower internet connections.
+Compression is used to reduce the size of packets. This is benefical to reduce bandwidth server side and also to help players on slower internet connections.
 
 ## Configuring Compression
 

--- a/docs/config/compression.md
+++ b/docs/config/compression.md
@@ -4,7 +4,7 @@ Compression is used to reduce the size of packets. This is benefical to reduce b
 ## Configuring Compression
 
 #### `enabled`: Boolean
-Weather packet compression is enabled or not.
+Whether packet compression is enabled or not.
 
 > [!TIP]
 > It might be benefical to disable compression if the server is behind a proxy.

--- a/docs/config/introduction.md
+++ b/docs/config/introduction.md
@@ -14,7 +14,7 @@ Pumpkin's Configuration is split into a basic Configuration made for quick chang
 Pumpkin aims to support the latest Minecraft Version. If you want to host a Pumpkin server in any other version, there is a project called [ViaProxy](https://github.com/ViaVersion/ViaProxy).
 
 - Make sure to allow Proxy connections.
-- Pumpkin and ViaProxy have no connection, don't submit issues reguarding their code. Furthermore, this is a 3rd party proxy and Pumpkin does not take any responsability for the good or the bad.
+- Pumpkin and ViaProxy have no connection, don't submit issues reguarding their code. Furthermore, this is a 3rd party proxy and Pumpkin does not take any responsibility for the good or the bad.
 
 #### Key Features:
 

--- a/docs/config/lan-broadcast.md
+++ b/docs/config/lan-broadcast.md
@@ -28,7 +28,7 @@ motd = "[your MOTD here]"
 :::
 
 #### `port`: Integer (0-65535) (optional)
-What port to bind to. If not specified, will bind to port 0 (any availible port on the system).
+What port to bind to. If not specified, will bind to port 0 (any available port on the system).
 
 > [!IMPORTANT]
 > The protocol defines what port to broadcast to. This option only exists to specify which port to bind to on the host. This option purely exists so that the port can be predictable.

--- a/docs/config/lan-broadcast.md
+++ b/docs/config/lan-broadcast.md
@@ -4,7 +4,7 @@ Pumpkin can broadcast the server across the network in order to make it easier f
 ## Configuring LAN Broadcast
 
 #### `enabled`: Boolean
-Weather LAN Broadcast is enabled or not.
+Whether LAN Broadcast is enabled or not.
 
 :::code-group
 ```toml [features.toml] {2}

--- a/docs/config/logging.md
+++ b/docs/config/logging.md
@@ -4,7 +4,7 @@ Pumpkin allows you to customize what you want in your logs.
 ## Configuring Logging
 
 #### `enabled`: Boolean
-Weather logging is enabled or not.
+Whether logging is enabled or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -31,7 +31,7 @@ level = "Debug"
 :::
 
 #### `env`: Boolean
-Weather to allow choosing the log level by setting the `RUST_LOG` environment variable or not.
+Whether to allow choosing the log level by setting the `RUST_LOG` environment variable or not.
 
 :::code-group
 ```toml [features.toml] {3}
@@ -42,7 +42,7 @@ env = true
 :::
 
 #### `threads`: Boolean
-Weather to print threads in the logging message or not.
+Whether to print threads in the logging message or not.
 
 :::code-group
 ```toml [features.toml] {3}
@@ -53,7 +53,7 @@ threads = false
 :::
 
 #### `color`: Boolean
-Weather to print with color to the console or not.
+Whether to print with color to the console or not.
 
 :::code-group
 ```toml [features.toml] {3}
@@ -64,7 +64,7 @@ color = false
 :::
 
 #### `timestamp`: Boolean
-Weather to print the timestamp in the meessage or not.
+Whether to print the timestamp in the meessage or not.
 
 :::code-group
 ```toml [features.toml] {3}

--- a/docs/config/proxy.md
+++ b/docs/config/proxy.md
@@ -24,7 +24,7 @@ enabled = true
 
 #### `enabled`: Boolean
 
-Weather Velocity support is enabled or not.
+Whether Velocity support is enabled or not.
 
 :::code-group
 ```toml [features.toml]{2}
@@ -48,7 +48,7 @@ secret = "[proxy secret here]"
 ### BungeeCord
 
 #### `enabled`: Boolean
-Weather BungeeCord support is enabled or not.
+Whether BungeeCord support is enabled or not.
 
 :::code-group
 ```toml [features.toml]{2}

--- a/docs/config/pvp.md
+++ b/docs/config/pvp.md
@@ -4,7 +4,7 @@ PVP is a core part of vanilla mechanics, with even the smallest change affecting
 ## Configuring PVP
 
 #### `enabled`: Boolean
-Weather PVP is enabled or not.
+Whether PVP is enabled or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -14,7 +14,7 @@ enabled = true
 :::
 
 #### `hurt_animation`: Boolean
-Weather to show red hurt animation and FOV bobbing or not.
+Whether to show red hurt animation and FOV bobbing or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -24,7 +24,7 @@ hurt_animation = true
 :::
 
 #### `protect_creative`: Boolean
-Weather to protect players in creative againest PVP or not.
+Whether to protect players in creative againest PVP or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -34,7 +34,7 @@ protect_creative = true
 :::
 
 #### `knockback`: Boolean
-Weather attacks should have knockback or not.
+Whether attacks should have knockback or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -44,7 +44,7 @@ knockback = true
 :::
 
 #### `swing`: Boolean
-Weather players should swing when attacking or not.
+Whether players should swing when attacking or not.
 
 :::code-group
 ```toml [features.toml] {2}

--- a/docs/config/query.md
+++ b/docs/config/query.md
@@ -4,7 +4,7 @@ Query protocol is an simple way to query the server about its status. Pumpkin fu
 ## Configuring Query
 
 #### `enabled`: Boolean
-Weather to listen for query protocol requests or not.
+Whether to listen for query protocol requests or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -14,7 +14,7 @@ enabled = true
 :::
 
 #### `port`: Integer (0-65535) (optional)
-What port to listen to query protocol requests. If not specified, uses the same port as the server.
+What port to listen to query protocol requests. If not specified, it uses the same port as the server.
 
 :::code-group
 ```toml [features.toml] {3}

--- a/docs/config/rcon.md
+++ b/docs/config/rcon.md
@@ -47,7 +47,7 @@ max_connections = 5
 
 ### Logging
 #### `log_logged_successfully`: Boolean
-Weather successful logins should be logged to console or not.
+Whether successful logins should be logged to console or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -57,7 +57,7 @@ log_logged_successfully = true
 :::
 
 #### `log_wrong_password`: Boolean
-Weather wrong password attempts should be logged to console or not.
+Whether wrong password attempts should be logged to console or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -67,7 +67,7 @@ log_logged_successfully = true
 :::
 
 #### `log_commands`: Boolean
-Weather to log commands ran from RCON to console or not.
+Whether to log commands ran from RCON to console or not.
 
 :::code-group
 ```toml [features.toml] {2}

--- a/docs/config/resource-pack.md
+++ b/docs/config/resource-pack.md
@@ -7,7 +7,7 @@ Servers can send resource packs to the client in order to change the appearance 
 ## Configuring Resource Pack
 
 #### `enabled`: Boolean
-Weather a resource pack is enabled or not.
+Whether a resource pack is enabled or not.
 
 :::code-group
 ```toml [features.toml] {2}
@@ -72,7 +72,7 @@ prompt_message = "[your message here]"
 :::
 
 #### `force`: Boolean
-Weather to force the client to download the resource pack or not. If the client declines the download, they will be kicked from the server.
+Whether to force the client to download the resource pack or not. If the client declines the download, they will be kicked from the server.
 
 :::code-group
 ```toml [features.toml] {3}


### PR DESCRIPTION
<!-- A Detailed Description -->
## Description
Mostly just corrected a few minor spelling mistakes in some of the configuration pages on the docs, with an occasional word change or addition for better flow of the overall sentence.

