### PR TITLE
Fix chunk loading

### DIFF
--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -5,10 +5,7 @@ use num_traits::Zero;
 use pumpkin_config::BASIC_CONFIG;
 use pumpkin_core::math::vector2::Vector2;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use tokio::{
-    sync::{mpsc, RwLock},
-    task::JoinHandle,
-};
+use tokio::sync::{mpsc, RwLock};
 
 use crate::{
     chunk::{
@@ -16,8 +13,6 @@ use crate::{
     },
     world_gen::{get_world_gen, Seed, WorldGenerator},
 };
-
-pub type ConcurrentChunkResult = Vec<(Vector2<i32>, JoinHandle<()>)>;
 
 /// The `Level` module provides functionality for working with chunks within or outside a Minecraft world.
 ///
@@ -140,6 +135,7 @@ impl Level {
             Entry::Occupied(mut occupied) => {
                 let value = occupied.get_mut();
                 *value = value.saturating_sub(1);
+
                 if *value == 0 {
                     occupied.remove_entry();
                     true
@@ -152,32 +148,26 @@ impl Level {
                 // - Player disconnecting before all packets have been sent
                 // - Player moving so fast that the chunk leaves the render distance before it
                 // is loaded into memory
-                log::error!(
-                    "Marking a chunk as not watched, but was vacant! ({:?})",
-                    chunk
-                );
                 false
             }
         }
     }
 
-    pub fn should_pop_chunk(&self, chunk: &Vector2<i32>) -> bool {
-        if let Some(entry) = self.chunk_watchers.get(chunk) {
-            if entry.value().is_zero() {
-                self.chunk_watchers.remove(chunk);
-            }
-        }
-
-        self.chunk_watchers.get(chunk).is_none()
-    }
-
     pub fn clean_chunks(&self, chunks: &[Vector2<i32>]) {
         chunks.par_iter().for_each(|chunk_pos| {
             //log::debug!("Unloading {:?}", chunk_pos);
-            if let Some(data) = self.loaded_chunks.remove(chunk_pos) {
-                self.write_chunk(data);
-            };
+            self.clean_chunk(chunk_pos);
         });
+    }
+
+    pub fn clean_chunk(&self, chunk: &Vector2<i32>) {
+        if let Some(data) = self.loaded_chunks.remove(chunk) {
+            self.write_chunk(data);
+        }
+    }
+
+    pub fn is_chunk_watched(&self, chunk: &Vector2<i32>) -> bool {
+        self.chunk_watchers.get(chunk).is_some()
     }
 
     pub fn clean_memory(&self, chunks_to_check: &[Vector2<i32>]) {
@@ -226,63 +216,51 @@ impl Level {
         &self,
         chunks: &[Vector2<i32>],
         channel: mpsc::Sender<Arc<RwLock<ChunkData>>>,
-    ) -> ConcurrentChunkResult {
-        chunks
-            .iter()
-            .map(|at| {
-                let channel = channel.clone();
-                let loaded_chunks = self.loaded_chunks.clone();
-                let chunk_reader = self.chunk_reader.clone();
-                let save_file = self.save_file.clone();
-                let world_gen = self.world_gen.clone();
-                let chunk_pos = *at;
+    ) {
+        chunks.par_iter().for_each(|at| {
+            let channel = channel.clone();
+            let loaded_chunks = self.loaded_chunks.clone();
+            let chunk_reader = self.chunk_reader.clone();
+            let save_file = self.save_file.clone();
+            let world_gen = self.world_gen.clone();
+            let chunk_pos = *at;
 
-                let join_handle = tokio::spawn(async move {
-                    let chunk = loaded_chunks
-                        .get(&chunk_pos)
-                        .map(|entry| entry.value().clone())
-                        .unwrap_or_else(|| {
-                            let loaded_chunk = save_file
-                                .and_then(|save_file| {
-                                    match Self::load_chunk_from_save(
-                                        chunk_reader,
-                                        save_file,
+            let chunk = loaded_chunks
+                .get(&chunk_pos)
+                .map(|entry| entry.value().clone())
+                .unwrap_or_else(|| {
+                    let loaded_chunk = save_file
+                        .and_then(|save_file| {
+                            match Self::load_chunk_from_save(chunk_reader, save_file, chunk_pos) {
+                                Ok(chunk) => chunk,
+                                Err(err) => {
+                                    log::error!(
+                                        "Failed to read chunk (regenerating) {:?}: {:?}",
                                         chunk_pos,
-                                    ) {
-                                        Ok(chunk) => chunk,
-                                        Err(err) => {
-                                            log::error!(
-                                                "Failed to read chunk (regenerating) {:?}: {:?}",
-                                                chunk_pos,
-                                                err
-                                            );
-                                            None
-                                        }
-                                    }
-                                })
-                                .unwrap_or_else(|| {
-                                    Arc::new(RwLock::new(world_gen.generate_chunk(chunk_pos)))
-                                });
-
-                            if let Some(data) = loaded_chunks.get(&chunk_pos) {
-                                // Another thread populated in between the previous check and now
-                                // We did work, but this is basically like a cache miss, not much we
-                                // can do about it
-                                data.value().clone()
-                            } else {
-                                loaded_chunks.insert(chunk_pos, loaded_chunk.clone());
-                                loaded_chunk
+                                        err
+                                    );
+                                    None
+                                }
                             }
+                        })
+                        .unwrap_or_else(|| {
+                            Arc::new(RwLock::new(world_gen.generate_chunk(chunk_pos)))
                         });
 
-                    let _ = channel
-                        .send(chunk)
-                        .await
-                        .inspect_err(|err| log::error!("unable to send chunk to channel: {}", err));
+                    if let Some(data) = loaded_chunks.get(&chunk_pos) {
+                        // Another thread populated in between the previous check and now
+                        // We did work, but this is basically like a cache miss, not much we
+                        // can do about it
+                        data.value().clone()
+                    } else {
+                        loaded_chunks.insert(chunk_pos, loaded_chunk.clone());
+                        loaded_chunk
+                    }
                 });
 
-                (*at, join_handle)
-            })
-            .collect()
+            let _ = channel
+                .blocking_send(chunk)
+                .inspect_err(|err| log::error!("unable to send chunk to channel: {}", err));
+        });
     }
 }

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -1,6 +1,7 @@
 use connection_cache::{CachedBranding, CachedStatus};
 use key_store::KeyStore;
 use pumpkin_config::BASIC_CONFIG;
+use pumpkin_core::math::vector2::Vector2;
 use pumpkin_core::GameMode;
 use pumpkin_entity::EntityId;
 use pumpkin_inventory::drag_handler::DragHandler;
@@ -89,6 +90,14 @@ impl Server {
             ),
             DimensionType::Overworld,
         );
+
+        // Spawn chunks are never unloaded
+        for x in -1..=1 {
+            for z in -1..=1 {
+                world.level.mark_chunk_as_newly_watched(Vector2::new(x, z));
+            }
+        }
+
         Self {
             cached_registry: Registry::get_synced(),
             open_containers: RwLock::new(HashMap::new()),

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1,17 +1,11 @@
-use std::{
-    collections::{hash_map::Entry, HashMap, VecDeque},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 pub mod level_time;
 pub mod player_chunker;
 
 use crate::{
     command::client_cmd_suggestions,
-    entity::{
-        player::{ChunkHandleWrapper, Player},
-        Entity,
-    },
+    entity::{player::Player, Entity},
     error::PumpkinError,
     server::Server,
 };
@@ -45,22 +39,14 @@ use pumpkin_world::{
 use rand::{thread_rng, Rng};
 use scoreboard::Scoreboard;
 use thiserror::Error;
+use tokio::sync::{mpsc, RwLock};
 use tokio::sync::{mpsc::Receiver, Mutex};
-use tokio::{
-    sync::{mpsc, RwLock},
-    task::JoinHandle,
-};
 use worldborder::Worldborder;
 
 pub mod bossbar;
 pub mod custom_bossbar;
 pub mod scoreboard;
 pub mod worldborder;
-
-type ChunkReceiver = (
-    Vec<(Vector2<i32>, JoinHandle<()>)>,
-    Receiver<Arc<RwLock<ChunkData>>>,
-);
 
 #[derive(Debug, Error)]
 pub enum GetBlockError {
@@ -515,6 +501,10 @@ impl World {
         self.level.mark_chunks_as_not_watched(chunks)
     }
 
+    pub fn mark_chunks_as_watched(&self, chunks: &[Vector2<i32>]) {
+        self.level.mark_chunks_as_newly_watched(chunks);
+    }
+
     pub fn clean_chunks(&self, chunks: &[Vector2<i32>]) {
         self.level.clean_chunks(chunks);
     }
@@ -527,9 +517,8 @@ impl World {
         self.level.loaded_chunk_count()
     }
 
-    #[expect(clippy::too_many_lines)]
     /// IMPORTANT: Chunks have to be non-empty
-    fn spawn_world_chunks(&self, player: Arc<Player>, chunks: &[Vector2<i32>]) {
+    fn spawn_world_chunks(&self, player: Arc<Player>, chunks: Vec<Vector2<i32>>) {
         if player
             .client
             .closed
@@ -540,44 +529,12 @@ impl World {
         }
         #[cfg(debug_assertions)]
         let inst = std::time::Instant::now();
-        // Unique id of this chunk batch for later removal
-        let id = uuid::Uuid::new_v4();
 
-        let (pending, mut receiver) = self.receive_chunks(chunks);
-        {
-            let mut pending_chunks = player.pending_chunks.lock();
-
-            for chunk in chunks {
-                if pending_chunks.contains_key(chunk) {
-                    log::debug!(
-                        "Client id {} is requesting chunk {:?} but its already pending!",
-                        player.client.id,
-                        chunk
-                    );
-                }
-            }
-
-            for (chunk, handle) in pending {
-                let entry = pending_chunks.entry(chunk);
-                let wrapper = ChunkHandleWrapper::new(handle);
-                match entry {
-                    Entry::Occupied(mut entry) => {
-                        entry.get_mut().push_back(wrapper);
-                    }
-                    Entry::Vacant(entry) => {
-                        let mut queue = VecDeque::new();
-                        queue.push_back(wrapper);
-                        entry.insert(queue);
-                    }
-                };
-            }
-        }
-        let pending_chunks = player.pending_chunks.clone();
+        player.world().mark_chunks_as_watched(&chunks);
+        let mut receiver = self.receive_chunks(chunks);
         let level = self.level.clone();
-        let retained_player = player.clone();
-        let batch_id = id;
 
-        let handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             while let Some(chunk_data) = receiver.recv().await {
                 let chunk_data = chunk_data.read().await;
                 let packet = CChunkData(&chunk_data);
@@ -595,40 +552,13 @@ impl World {
                     );
                 }
 
-                {
-                    let mut pending_chunks = pending_chunks.lock();
-                    let handlers = pending_chunks
-                        .get_mut(&chunk_data.position)
-                        .expect("All chunks should be pending");
-                    let handler = handlers
-                        .pop_front()
-                        .expect("All chunks should have a handler");
-
-                    if handlers.is_empty() {
-                        pending_chunks.remove(&chunk_data.position);
-                    }
-
-                    // Chunk loading task was canceled after it was completed
-                    if handler.aborted() {
-                        // We never increment the watch value
-                        if level.should_pop_chunk(&chunk_data.position) {
-                            level.clean_chunks(&[chunk_data.position]);
-                        }
-                        // If ignored, dont send the packet
-                        let loaded_chunks = level.loaded_chunk_count();
-                        log::debug!(
-                            "Aborted chunk {:?} (post-process) {} cached",
-                            chunk_data.position,
-                            loaded_chunks
-                        );
-
-                        // We dont want to mark this chunk as watched or send it to the client
-                        continue;
-                    }
-
-                    // This must be locked with pending
-                    level.mark_chunk_as_newly_watched(chunk_data.position);
-                };
+                if !level.is_chunk_watched(&chunk_data.position) {
+                    log::debug!(
+                        "Received chunk {:?}, but it is no longer watched... cleaning",
+                        &chunk_data.position
+                    );
+                    level.clean_chunk(&chunk_data.position);
+                }
 
                 if !player
                     .client
@@ -639,22 +569,9 @@ impl World {
                 }
             }
 
-            {
-                let mut batch = player.pending_chunk_batch.lock();
-                batch.remove(&batch_id);
-            }
             #[cfg(debug_assertions)]
-            log::debug!(
-                "chunks sent after {}ms (batch {})",
-                inst.elapsed().as_millis(),
-                batch_id
-            );
+            log::debug!("chunks sent after {}ms ", inst.elapsed().as_millis(),);
         });
-
-        {
-            let mut batch_handles = retained_player.pending_chunk_batch.lock();
-            batch_handles.insert(id, handle);
-        }
     }
 
     /// Gets a Player by entity id
@@ -789,18 +706,32 @@ impl World {
     }
 
     // Stream the chunks (don't collect them and then do stuff with them)
-    pub fn receive_chunks(&self, chunks: &[Vector2<i32>]) -> ChunkReceiver {
+    pub fn receive_chunks(&self, chunks: Vec<Vector2<i32>>) -> Receiver<Arc<RwLock<ChunkData>>> {
         let (sender, receive) = mpsc::channel(chunks.len());
-        let pending_chunks = self.level.fetch_chunks(chunks, sender);
-        (pending_chunks, receive)
+        // Put this in another thread so we aren't blocking on it
+        let level = self.level.clone();
+        rayon::spawn(move || {
+            level.fetch_chunks(&chunks, sender);
+        });
+        receive
     }
 
-    pub async fn receive_chunk(&self, chunk: Vector2<i32>) -> Arc<RwLock<ChunkData>> {
-        let (_, mut receiver) = self.receive_chunks(&[chunk]);
-        receiver
+    pub async fn receive_chunk(&self, chunk_pos: Vector2<i32>) -> Arc<RwLock<ChunkData>> {
+        let mut receiver = self.receive_chunks(vec![chunk_pos]);
+        let chunk = receiver
             .recv()
             .await
-            .expect("Channel closed for unknown reason")
+            .expect("Channel closed for unknown reason");
+
+        if !self.level.is_chunk_watched(&chunk_pos) {
+            log::debug!(
+                "Received chunk {:?}, but it is not watched... cleaning",
+                chunk_pos
+            );
+            self.level.clean_chunk(&chunk_pos);
+        }
+
+        chunk
     }
 
     pub async fn break_block(&self, position: WorldPosition, cause: Option<&Player>) {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This PR fixes the "but no one was watching spam", removes the need to wait for chunks when removing a player and removes the concept of pending tasks from the player, adds perma-loaded spawn chunks, drastically speeds up loading screen time when joining, and leverages rayon rather than async to stream chunks.

<!-- A description of the tests performed to verify the changes -->
## Testing
Joined a world

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
