### PR TITLE
Added Basic Attack Modifiers

### DIFF
--- a/pumpkin-world/src/item/item_registry.rs
+++ b/pumpkin-world/src/item/item_registry.rs
@@ -33,9 +33,30 @@ pub struct ItemComponents {
     pub max_stack_size: u8,
     #[serde(rename = "minecraft:jukebox_playable")]
     pub jukebox_playable: Option<JukeboxPlayable>,
+    #[serde(rename = "minecraft:damage")]
+    pub damage: Option<u16>,
+    #[serde(rename = "minecraft:max_damage")]
+    pub max_damage: Option<u16>,
+    #[serde(rename = "minecraft:attribute_modifiers")]
+    pub attribute_modifiers: Option<AttributeModifiers>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct JukeboxPlayable {
     pub song: String,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct AttributeModifiers {
+    pub modifiers: Vec<Modifier>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Modifier {
+    #[serde(rename = "type")]
+    pub type_val: String,
+    pub id: String,
+    pub amount: f32,
+    pub operation: String,
+    pub slot: String,
 }

--- a/pumpkin-world/src/item/item_registry.rs
+++ b/pumpkin-world/src/item/item_registry.rs
@@ -56,7 +56,7 @@ pub struct Modifier {
     #[serde(rename = "type")]
     pub type_val: String,
     pub id: String,
-    pub amount: f32,
+    pub amount: f64,
     pub operation: String,
     pub slot: String,
 }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -8,7 +8,8 @@ use std::{
 
 use crossbeam::atomic::AtomicCell;
 use num_derive::{FromPrimitive, ToPrimitive};
-use pumpkin_config::ADVANCED_CONFIG;
+use num_traits::Pow;
+use pumpkin_config::{ADVANCED_CONFIG, BASIC_CONFIG};
 use pumpkin_core::{
     math::{
         boundingbox::{BoundingBox, BoundingBoxSize},
@@ -42,7 +43,10 @@ use pumpkin_protocol::{
     client::play::{CSetEntityMetadata, Metadata},
     server::play::{SClickContainer, SKeepAlive},
 };
-use pumpkin_world::{cylindrical_chunk_iterator::Cylindrical, item::ItemStack};
+use pumpkin_world::{
+    cylindrical_chunk_iterator::Cylindrical,
+    item::{item_registry::get_item_by_id, ItemStack},
+};
 use tokio::sync::{Mutex, Notify};
 
 use super::Entity;
@@ -228,14 +232,52 @@ impl Player {
         let attacker_entity = &self.living_entity.entity;
         let config = &ADVANCED_CONFIG.pvp;
 
-        let pos = victim_entity.pos.load();
+        let inventory = self.inventory().lock().await;
+        let item_slot = inventory.held_item();
 
-        let attack_cooldown_progress = self.get_attack_cooldown_progress(0.5);
+        let base_damage = 1.0;
+        let base_attack_speed = 4.0;
+
+        let mut damage_multiplier = 1.0;
+        let mut add_damage = 0.0;
+        let mut add_speed = 0.0;
+
+        // get attack damage
+        if let Some(item_stack) = item_slot {
+            if let Some(item) = get_item_by_id(item_stack.item_id) {
+                // TODO: this should be cached in memory
+                if let Some(modifiers) = &item.components.attribute_modifiers {
+                    for item_mod in &modifiers.modifiers {
+                        if item_mod.operation == "add_value" {
+                            if item_mod.id == "minecraft:base_attack_damage" {
+                                add_damage = item_mod.amount;
+                            }
+                            if item_mod.id == "minecraft:base_attack_speed" {
+                                add_speed = item_mod.amount;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        drop(inventory);
+
+        let attack_speed = base_attack_speed + add_speed;
+
+        let attack_cooldown_progress = self.get_attack_cooldown_progress(0.5, attack_speed);
         self.last_attacked_ticks
             .store(0, std::sync::atomic::Ordering::Relaxed);
 
-        // TODO: attack damage attribute and deal damage
-        let mut damage = 1.0;
+        // only reduce attack damage if in cooldown
+        // TODO: Enchantments are reduced same way just without the square
+        if attack_cooldown_progress < 1.0 {
+            damage_multiplier = 0.2_f32 + attack_cooldown_progress.pow(2) * 0.8_f32;
+        }
+        // modify added damage based on multiplier
+        let mut damage = base_damage + add_damage * damage_multiplier;
+
+        let pos = victim_entity.pos.load();
+
         if (config.protect_creative && victim.gamemode.load() == GameMode::Creative)
             || !victim.living_entity.check_damage(damage)
         {
@@ -327,16 +369,14 @@ impl Player {
         }
     }
 
-    pub fn get_attack_cooldown_progress(&self, base_time: f32) -> f32 {
+    pub fn get_attack_cooldown_progress(&self, base_time: f32, attack_speed: f32) -> f32 {
         #[allow(clippy::cast_precision_loss)]
         let x = self
             .last_attacked_ticks
             .load(std::sync::atomic::Ordering::Acquire) as f32
             + base_time;
-        // TODO attack speed attribute
-        let attack_speed = 4.0;
-        let progress_per_tick = 1.0 / attack_speed * 20.0;
 
+        let progress_per_tick = BASIC_CONFIG.tps / attack_speed;
         let progress = x / progress_per_tick;
         progress.clamp(0.0, 1.0)
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Added basic attack modifiers for all items (ex. swords, axes, maces):
- base_attack_damage - modifies the base attack damage
- base_attack_speed - modifies the attack speed and resulting damage mid way

<!-- A description of the tests performed to verify the changes -->
## Testing
Tested in offline mode
Counted health damage and compared to wiki

TODO:
- There may be calculated values which are incorrect. I read that MC goes 2 decimal places while Pumpkin uses f32.
- Each hit requires the comparison of many strings. This could be improved by parsing the strings at compile time into enums. 

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
