### PR TITLE
Stablize cylindrical chunks

### DIFF
--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -151,7 +151,7 @@ impl Level {
                 // - Player disconnecting before all packets have been sent
                 // - Player moving so fast that the chunk leaves the render distance before it
                 // is loaded into memory
-                false
+                true
             }
         }
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
To find different chunks we would iterate over the entire rectangular area the chunks covered. This fixes that. 

Fixes https://github.com/Snowiiii/Pumpkin/issues/379 and some edges cases where chunks are not removed from memory

<!-- A description of the tests performed to verify the changes -->
## Testing
Teleported far out and did not time out

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
