### PR TITLE
Parse seeds same as java

### DIFF
--- a/pumpkin-core/src/random/mod.rs
+++ b/pumpkin-core/src/random/mod.rs
@@ -1,9 +1,22 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use legacy_rand::{LegacyRand, LegacySplitter};
 use xoroshiro128::{Xoroshiro, XoroshiroSplitter};
 
 mod gaussian;
 pub mod legacy_rand;
 pub mod xoroshiro128;
+
+static SEED_UNIQUIFIER: AtomicU64 = AtomicU64::new(8682522807148012u64);
+
+pub fn get_seed() -> u64 {
+    SEED_UNIQUIFIER
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
+            Some(val.wrapping_mul(1181783497276652981u64))
+        })
+        // We always return Some, so there will always be an Ok result
+        .unwrap()
+}
 
 pub enum RandomGenerator {
     Xoroshiro(Xoroshiro),
@@ -195,7 +208,7 @@ fn hash_block_pos(x: i32, y: i32, z: i32) -> i64 {
     l >> 16
 }
 
-fn java_string_hash(string: &str) -> i32 {
+pub fn java_string_hash(string: &str) -> i32 {
     // All byte values of latin1 align with
     // the values of U+0000 - U+00FF making this code
     // equivalent to both java hash implementations

--- a/pumpkin-core/src/random/mod.rs
+++ b/pumpkin-core/src/random/mod.rs
@@ -1,4 +1,7 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time,
+};
 
 use legacy_rand::{LegacyRand, LegacySplitter};
 use xoroshiro128::{Xoroshiro, XoroshiroSplitter};
@@ -10,12 +13,21 @@ pub mod xoroshiro128;
 static SEED_UNIQUIFIER: AtomicU64 = AtomicU64::new(8682522807148012u64);
 
 pub fn get_seed() -> u64 {
-    SEED_UNIQUIFIER
+    let seed = SEED_UNIQUIFIER
         .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |val| {
             Some(val.wrapping_mul(1181783497276652981u64))
         })
         // We always return Some, so there will always be an Ok result
+        .unwrap();
+
+    let nanos = time::SystemTime::now()
+        .duration_since(time::SystemTime::UNIX_EPOCH)
         .unwrap()
+        .as_nanos();
+
+    let nano_upper = (nanos >> 8) as u64;
+    let nano_lower = nanos as u64;
+    seed ^ nano_upper ^ nano_lower
 }
 
 pub enum RandomGenerator {
@@ -199,7 +211,7 @@ pub trait RandomDeriverImpl {
     fn split_pos(&self, x: i32, y: i32, z: i32) -> impl RandomImpl;
 }
 
-fn hash_block_pos(x: i32, y: i32, z: i32) -> i64 {
+pub fn hash_block_pos(x: i32, y: i32, z: i32) -> i64 {
     let l = (x.wrapping_mul(3129871) as i64) ^ ((z as i64).wrapping_mul(116129781i64)) ^ (y as i64);
     let l = l
         .wrapping_mul(l)

--- a/pumpkin-world/src/level.rs
+++ b/pumpkin-world/src/level.rs
@@ -56,7 +56,7 @@ impl Level {
                 "World region folder does not exist, despite there being a root folder."
             );
             // TODO: read seed from level.dat
-            let seed = Seed(0);
+            let seed = get_or_create_seed();
             let world_gen = get_world_gen(seed).into(); // TODO Read Seed from config.
 
             Self {

--- a/pumpkin-world/src/world_gen/implementation/test.rs
+++ b/pumpkin-world/src/world_gen/implementation/test.rs
@@ -115,7 +115,7 @@ impl TerrainGenerator for TestTerrainGenerator {
         let entry = self.chunks.entry(*at);
         match entry {
             Entry::Vacant(entry) => {
-                let mut proto_chunk = ProtoChunk::new(*at, self.seed.0 as u64);
+                let mut proto_chunk = ProtoChunk::new(*at, self.seed.0);
                 //let inst = std::time::Instant::now();
                 //println!("Populating chunk: {:?}", at);
                 proto_chunk.populate_noise();

--- a/pumpkin-world/src/world_gen/seed.rs
+++ b/pumpkin-world/src/world_gen/seed.rs
@@ -1,15 +1,20 @@
-use std::hash::{DefaultHasher, Hash, Hasher};
+use pumpkin_core::random::{get_seed, java_string_hash, legacy_rand::LegacyRand, RandomImpl};
 
 #[derive(Clone, Copy)]
-pub struct Seed(pub i64);
+pub struct Seed(pub u64);
 
 impl From<&str> for Seed {
     fn from(value: &str) -> Self {
-        // TODO replace with a deterministic hasher (the same as vanilla?)
-        let mut hasher = DefaultHasher::new();
-        value.hash(&mut hasher);
+        let trimmed = value.trim();
+        let value = if !trimmed.is_empty() {
+            let i64_value = trimmed
+                .parse::<i64>()
+                .unwrap_or_else(|_| java_string_hash(trimmed) as i64);
+            Some(i64_value as u64)
+        } else {
+            None
+        };
 
-        // TODO use cast_signed once the feature is stabilized.
-        Self(hasher.finish() as i64)
+        Seed(value.unwrap_or_else(|| LegacyRand::from_seed(get_seed()).next_i64() as u64))
     }
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This PR implements parsing a seed from a string the same as Java.

<!-- A description of the tests performed to verify the changes -->
## Testing
N/A

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
