### PR TITLE
Fix command dispatcher

### DIFF
--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -145,13 +145,13 @@ impl<'a> CommandDispatcher<'a> {
         let key = parts
             .next()
             .ok_or(GeneralCommandIssue("Empty Command".to_string()))?;
-        let mut raw_args: Vec<&str> = parts.rev().collect();
+        let raw_args: Vec<&str> = parts.rev().collect();
 
         let tree = self.get_tree(key)?;
 
         // try paths until fitting path is found
         for path in tree.iter_paths() {
-            if Self::try_is_fitting_path(src, server, &path, tree, &mut raw_args).await? {
+            if Self::try_is_fitting_path(src, server, &path, tree, &mut raw_args.clone()).await? {
                 return Ok(());
             }
         }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description

Fixes the issue where the command tree only worked with a single command path.

(👇`/time add` is working. but `/time set` and `/time query` is not working)
![image](https://github.com/user-attachments/assets/97fd3d21-6773-47ec-ba1c-c3d43ebf3304)
![image](https://github.com/user-attachments/assets/15cb9c50-c599-4ac8-94ff-4020fe617b47)


<!-- A description of the tests performed to verify the changes -->
## Testing

All of `/time add`, `/time set`, and `/time query` work.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
