### PR TITLE
Properly check chunks on respawn, render distance update, and validate render distance

### DIFF
--- a/pumpkin/src/client/client_packet.rs
+++ b/pumpkin/src/client/client_packet.rs
@@ -388,6 +388,12 @@ impl Client {
         client_information: SClientInformationConfig,
     ) {
         log::debug!("Handling client settings");
+        if client_information.view_distance <= 0 {
+            self.kick("Cannot have zero or negative view distance!")
+                .await;
+            return;
+        }
+
         if let (Some(main_hand), Some(chat_mode)) = (
             Hand::from_i32(client_information.main_hand.into()),
             ChatMode::from_i32(client_information.chat_mode.into()),

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -410,7 +410,7 @@ impl World {
         player.send_time(self).await;
 
         // Spawn in initial chunks
-        player_chunker::player_join(self, player.clone()).await;
+        player_chunker::player_join(&player).await;
 
         // if let Some(bossbars) = self..lock().await.get_player_bars(&player.gameprofile.id) {
         //     for bossbar in bossbars {
@@ -512,7 +512,7 @@ impl World {
         )
         .await;
 
-        player_chunker::player_join(self, player.clone()).await;
+        player_chunker::player_join(player).await;
         self.broadcast_packet_all(&entity_metadata_packet).await;
         // update commands
 
@@ -565,7 +565,6 @@ impl World {
             rel_x * rel_x + rel_z * rel_z
         });
 
-        player.world().mark_chunks_as_watched(&chunks);
         let mut receiver = self.receive_chunks(chunks);
         let level = self.level.clone();
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
This PR properly updates watched chunks on respawn and render distance updates. It also validates the render distance sent, kicking the player if it is negative.

<!-- A description of the tests performed to verify the changes -->
## Testing
Joined a world and:
- updated render distances
- died and respawned
then validated chunks would load/unload and leave the cache properly.

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`