### PR TITLE
make command dispatcher mutable

### DIFF
--- a/pumpkin/src/command/args/arg_command.rs
+++ b/pumpkin/src/command/args/arg_command.rs
@@ -37,10 +37,10 @@ impl ArgumentConsumer for CommandTreeArgumentConsumer {
     ) -> Option<Arg<'a>> {
         let s = args.pop()?;
 
-        let dispatcher = &server.command_dispatcher;
-        return dispatcher
+        let dispatcher = server.command_dispatcher.read().await;
+        dispatcher
             .get_tree(s)
-            .map_or_else(|_| None, |tree| Some(Arg::CommandTree(tree)));
+            .map_or_else(|_| None, |tree| Some(Arg::CommandTree(tree)))
     }
 
     async fn suggest<'a>(
@@ -53,8 +53,8 @@ impl ArgumentConsumer for CommandTreeArgumentConsumer {
             return Ok(None);
         };
 
-        let suggestions = server
-            .command_dispatcher
+        let dispatcher = server.command_dispatcher.read().await;
+        let suggestions = dispatcher
             .commands
             .keys()
             .filter(|suggestion| suggestion.starts_with(input))

--- a/pumpkin/src/command/args/mod.rs
+++ b/pumpkin/src/command/args/mod.rs
@@ -83,7 +83,7 @@ pub(crate) enum Arg<'a> {
     Pos2D(Vector2<f64>),
     Rotation(f32, f32),
     GameMode(GameMode),
-    CommandTree(&'a CommandTree<'a>),
+    CommandTree(CommandTree<'a>),
     Item(&'a str),
     ResourceLocation(&'a str),
     Block(&'a str),

--- a/pumpkin/src/command/client_cmd_suggestions.rs
+++ b/pumpkin/src/command/client_cmd_suggestions.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use pumpkin_protocol::client::play::{CCommands, ProtoNode, ProtoNodeType};
+use tokio::sync::RwLock;
 
 use crate::entity::player::Player;
 
@@ -11,11 +12,12 @@ use super::{
 
 pub async fn send_c_commands_packet<'a>(
     player: &Arc<Player>,
-    dispatcher: &'a CommandDispatcher<'a>,
+    dispatcher: &RwLock<CommandDispatcher<'a>>,
 ) {
     let cmd_src = super::CommandSender::Player(player.clone());
     let mut first_level = Vec::new();
 
+    let dispatcher = dispatcher.read().await;
     for key in dispatcher.commands.keys() {
         let Ok(tree) = dispatcher.get_tree(key) else {
             continue;
@@ -72,8 +74,8 @@ impl<'a> ProtoNodeBuilder<'a> {
 
 fn nodes_to_proto_node_builders<'a>(
     cmd_src: &super::CommandSender,
-    nodes: &'a [Node<'a>],
-    children: &'a [usize],
+    nodes: &[Node<'a>],
+    children: &[usize],
 ) -> (bool, Vec<ProtoNodeBuilder<'a>>) {
     let mut child_nodes = Vec::new();
     let mut is_executable = false;

--- a/pumpkin/src/command/commands/cmd_help.rs
+++ b/pumpkin/src/command/commands/cmd_help.rs
@@ -121,8 +121,8 @@ impl CommandExecutor for BaseHelpExecutor {
             }
         };
 
-        let mut commands: Vec<&CommandTree> = server
-            .command_dispatcher
+        let dispatcher = server.command_dispatcher.read().await;
+        let mut commands: Vec<&CommandTree> = dispatcher
             .commands
             .values()
             .filter_map(|cmd| match cmd {

--- a/pumpkin/src/command/mod.rs
+++ b/pumpkin/src/command/mod.rs
@@ -107,7 +107,7 @@ impl<'a> CommandSender<'a> {
 }
 
 #[must_use]
-pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
+pub fn default_dispatcher<'a>() -> CommandDispatcher<'a> {
     let mut dispatcher = CommandDispatcher::default();
 
     dispatcher.register(cmd_pumpkin::init_command_tree());
@@ -129,7 +129,7 @@ pub fn default_dispatcher<'a>() -> Arc<CommandDispatcher<'a>> {
     dispatcher.register(cmd_transfer::init_command_tree());
     dispatcher.register(cmd_fill::init_command_tree());
 
-    Arc::new(dispatcher)
+    dispatcher
 }
 
 #[async_trait]

--- a/pumpkin/src/command/tree.rs
+++ b/pumpkin/src/command/tree.rs
@@ -5,12 +5,13 @@ use std::{collections::VecDeque, fmt::Debug};
 /// see [`crate::commands::tree_builder::argument`]
 pub type RawArgs<'a> = Vec<&'a str>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node<'a> {
     pub(crate) children: Vec<usize>,
     pub(crate) node_type: NodeType<'a>,
 }
 
+#[derive(Clone)]
 pub enum NodeType<'a> {
     ExecuteLeaf {
         executor: &'a dyn CommandExecutor,
@@ -50,7 +51,7 @@ pub enum Command<'a> {
     Alias(&'a str),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommandTree<'a> {
     pub(crate) nodes: Vec<Node<'a>>,
     pub(crate) children: Vec<usize>,

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -306,7 +306,7 @@ fn setup_console(server: Arc<Server>) {
                 .expect("Failed to read console line");
 
             if !out.is_empty() {
-                let dispatcher = server.command_dispatcher.clone();
+                let dispatcher = server.command_dispatcher.read().await;
                 dispatcher
                     .handle_command(&mut command::CommandSender::Console, &server, &out)
                     .await;

--- a/pumpkin/src/net/packet/play.rs
+++ b/pumpkin/src/net/packet/play.rs
@@ -286,7 +286,7 @@ impl Player {
         server: &Arc<Server>,
         command: SChatCommand,
     ) {
-        let dispatcher = server.command_dispatcher.clone();
+        let dispatcher = server.command_dispatcher.read().await;
         dispatcher
             .handle_command(
                 &mut CommandSender::Player(self.clone()),
@@ -877,10 +877,8 @@ impl Player {
             return;
         };
 
-        let suggestions = server
-            .command_dispatcher
-            .find_suggestions(&mut src, server, cmd)
-            .await;
+        let dispatcher = server.command_dispatcher.read().await;
+        let suggestions = dispatcher.find_suggestions(&mut src, server, cmd).await;
 
         let response = CCommandSuggestions::new(
             packet.id,

--- a/pumpkin/src/net/rcon/mod.rs
+++ b/pumpkin/src/net/rcon/mod.rs
@@ -104,7 +104,7 @@ impl RCONClient {
             ServerboundPacket::ExecCommand => {
                 if self.logged_in {
                     let output = tokio::sync::Mutex::new(Vec::new());
-                    let dispatcher = server.command_dispatcher.clone();
+                    let dispatcher = server.command_dispatcher.read().await;
                     dispatcher
                         .handle_command(
                             &mut crate::command::CommandSender::Rcon(&output),

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -47,7 +47,7 @@ pub struct Server {
     /// Saves server branding information.
     server_branding: CachedBranding,
     /// Saves and Dispatches commands to appropriate handlers.
-    pub command_dispatcher: Arc<CommandDispatcher<'static>>,
+    pub command_dispatcher: RwLock<CommandDispatcher<'static>>,
     /// Saves and calls blocks blocks
     pub block_manager: Arc<BlockManager>,
     /// Manages multiple worlds within the server.
@@ -79,7 +79,7 @@ impl Server {
         });
 
         // First register default command, after that plugins can put in their own
-        let command_dispatcher = default_dispatcher();
+        let command_dispatcher = RwLock::new(default_dispatcher());
 
         let world = World::load(
             Dimension::OverWorld.into_level(

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -229,7 +229,6 @@ impl World {
         player: Arc<Player>,
         server: &Server,
     ) {
-        let command_dispatcher = &server.command_dispatcher;
         let dimensions: Vec<Identifier> =
             server.dimensions.iter().map(DimensionType::name).collect();
 
@@ -270,8 +269,7 @@ impl World {
             .await;
         // permissions, i. e. the commands a player may use
         player.send_permission_lvl_update().await;
-        client_cmd_suggestions::send_c_commands_packet(&player, command_dispatcher).await;
-
+        client_cmd_suggestions::send_c_commands_packet(&player, &server.command_dispatcher).await;
         // teleport
         let mut position = Vector3::new(10.0, 120.0, 10.0);
         let yaw = 10.0;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Makes the command dispatcher mutable via tokio RWLock as a part of the Server struct

There is also a massive over usage of lifetimes in the command codebase that makes it overly constraining. This will not be addressed in this PR.

<!-- A description of the tests performed to verify the changes -->
## Testing
Opened the console and ran commands

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [x] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
