### PR TITLE
Create configs in a folder

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -5,7 +5,7 @@ use query::QueryConfig;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use std::{
-    fs,
+    env, fs,
     net::{Ipv4Addr, SocketAddr},
     num::NonZeroU8,
     path::Path,
@@ -35,6 +35,8 @@ mod server_links;
 
 use proxy::ProxyConfig;
 use resource_pack::ResourcePackConfig;
+
+const CONFIG_ROOT_FOLDER: &str = "config/";
 
 pub static ADVANCED_CONFIG: LazyLock<AdvancedConfiguration> =
     LazyLock::new(AdvancedConfiguration::load);
@@ -126,26 +128,33 @@ trait LoadConfiguration {
     where
         Self: Sized + Default + Serialize + DeserializeOwned,
     {
-        let path = Self::get_path();
+        let exe_path = env::current_exe().unwrap();
+        let exe_dir = exe_path.parent().unwrap();
+        let config_dir = exe_dir.join(CONFIG_ROOT_FOLDER);
+        if !config_dir.exists() {
+            log::debug!("creating new config root folder");
+            fs::create_dir(&config_dir).expect("Failed to create Config root folder");
+        }
+        let path = config_dir.join(Self::get_path());
 
         let config = if path.exists() {
-            let file_content = fs::read_to_string(path)
-                .unwrap_or_else(|_| panic!("Couldn't read configuration file at {:?}", path));
+            let file_content = fs::read_to_string(&path)
+                .unwrap_or_else(|_| panic!("Couldn't read configuration file at {:?}", &path));
 
             toml::from_str(&file_content).unwrap_or_else(|err| {
                 panic!(
                     "Couldn't parse config at {:?}. Reason: {}. This is is proberbly caused by an Config update, Just delete the old Config and start Pumpkin again",
-                    path,
+                    &path,
                     err.message()
                 )
             })
         } else {
             let content = Self::default();
 
-            if let Err(err) = fs::write(path, toml::to_string(&content).unwrap()) {
+            if let Err(err) = fs::write(&path, toml::to_string(&content).unwrap()) {
                 warn!(
                     "Couldn't write default config to {:?}. Reason: {}. This is is proberbly caused by an Config update, Just delete the old Config and start Pumpkin again",
-                    path, err
+                    &path, err
                 );
             }
 

--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -128,8 +128,7 @@ trait LoadConfiguration {
     where
         Self: Sized + Default + Serialize + DeserializeOwned,
     {
-        let exe_path = env::current_exe().unwrap();
-        let exe_dir = exe_path.parent().unwrap();
+        let exe_dir = env::current_dir().unwrap();
         let config_dir = exe_dir.join(CONFIG_ROOT_FOLDER);
         if !config_dir.exists() {
             log::debug!("creating new config root folder");


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Creates configuration files in a separate folder which then can be in a read-only mode.
Addresses https://github.com/Snowiiii/Pumpkin/issues/377

<!-- A description of the tests performed to verify the changes -->
## Testing
- [x] Linux: Changed config values and saw that the server detected the new values

- [x] Docker

<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
