### PR TITLE
Fixed Pumpkin website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 </div>
 
-[Pumpkin](https://snowiiii.github.io/Pumpkin/) is a Minecraft server built entirely in Rust, offering a fast, efficient,
+[Pumpkin](https://snowiiii.github.io/Pumpkin-Website/) is a Minecraft server built entirely in Rust, offering a fast, efficient,
 and customizable experience. It prioritizes performance and player enjoyment while adhering to the core mechanics of the game.
 
 ![image](https://github.com/user-attachments/assets/7e2e865e-b150-4675-a2d5-b52f9900378e)
@@ -87,7 +87,7 @@ Check out our [Github Project](https://github.com/users/Snowiiii/projects/12/vie
 
 ## How to run
 
-See our [Quick Start](https://snowiiii.github.io/Pumpkin/about/quick-start.html) Guide to get Pumpkin running
+See our [Quick Start](https://snowiiii.github.io/Pumpkin-Website/about/quick-start.html) Guide to get Pumpkin running
 
 ## Contributions
 
@@ -95,7 +95,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Docs
 
-The Documentation of Pumpkin can be found at https://snowiiii.github.io/Pumpkin/
+The Documentation of Pumpkin can be found at https://snowiiii.github.io/Pumpkin-Website/
 
 ## Communication
 


### PR DESCRIPTION
## Description

Changed the links in the README.md to link to the actual Pumpkin Website url (`https://snowiiii.github.io/Pumpkin/` -> `https://snowiiii.github.io/Pumpkin-Website/`)

## Testing

Click the links and they dont lead to a 404 page.

## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [ ] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
