### PR TITLE
Added default op level

### DIFF
--- a/pumpkin-config/src/commands.rs
+++ b/pumpkin-config/src/commands.rs
@@ -1,3 +1,4 @@
+use pumpkin_core::PermissionLvl;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
@@ -7,6 +8,8 @@ pub struct CommandsConfig {
     pub use_console: bool,
     /// Should be commands from players be logged in console?
     pub log_console: bool, // TODO: commands...
+    /// The op permission level of everyone that is not in the ops file
+    pub default_op_level: PermissionLvl,
 }
 
 impl Default for CommandsConfig {
@@ -14,6 +17,7 @@ impl Default for CommandsConfig {
         Self {
             use_console: true,
             log_console: true,
+            default_op_level: PermissionLvl::Zero,
         }
     }
 }

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -197,9 +197,10 @@ impl Player {
                 .ops
                 .iter()
                 .find(|op| op.uuid == gameprofile_clone.id)
-                .map_or(AtomicCell::new(PermissionLvl::Zero), |op| {
-                    AtomicCell::new(op.level)
-                }),
+                .map_or(
+                    AtomicCell::new(ADVANCED_CONFIG.commands.default_op_level),
+                    |op| AtomicCell::new(op.level),
+                ),
         }
     }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

<!-- A Detailed Description -->
## Description
Added default op level so server admins can set it for test servers.

<!-- A description of the tests performed to verify the changes -->
## Testing

Add `default_op_level=3` under `commands` section in `features.toml`

Can now do everything except stop server!


<!-- Please use Markdown Checkboxes. 
[ ] = not done
[x] = done
(or just click checkboxes to toggle them)
-->
## Checklist
Things need to be done before this Pull Request can be merged.

- [x] Code is well-formatted and adheres to project style guidelines: `cargo fmt`
- [x] Code does not produce any clippy warnings: `cargo clippy`
- [x] All unit tests pass: `cargo test`
- [x] I added new unit tests, so other people don't accidentally break my code by changing other parts of the codebase. [How?](https://doc.rust-lang.org/book/ch11-01-writing-tests.html)
