### PR TITLE
Fix order of explosion block handling that droping and explotion of blocks work

### DIFF
--- a/pumpkin/src/world/explosion.rs
+++ b/pumpkin/src/world/explosion.rs
@@ -80,14 +80,15 @@ impl Explosion {
 
             let block = world.get_block(&pos).await.unwrap();
             let pumpkin_block = server.block_registry.get_pumpkin_block(&block);
+
+            world.set_block_state(&pos, 0).await;
+
             if pumpkin_block.is_none_or(|s| s.should_drop_items_on_explosion()) {
                 drop_loot(world, &block, &pos, false, block_state.id).await;
             }
             if let Some(pumpkin_block) = pumpkin_block {
                 pumpkin_block.explode(&block, world, pos).await;
             }
-
-            world.set_block_state(&pos, 0).await;
         }
     }
 }

--- a/pumpkin/src/world/explosion.rs
+++ b/pumpkin/src/world/explosion.rs
@@ -77,7 +77,6 @@ impl Explosion {
             if block_state.air {
                 continue;
             }
-            world.set_block_state(&pos, 0).await;
 
             let block = world.get_block(&pos).await.unwrap();
             let pumpkin_block = server.block_registry.get_pumpkin_block(&block);
@@ -87,6 +86,8 @@ impl Explosion {
             if let Some(pumpkin_block) = pumpkin_block {
                 pumpkin_block.explode(&block, world, pos).await;
             }
+
+            world.set_block_state(&pos, 0).await;
         }
     }
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

In the explode function of a explosion the dropping of the loot and explode function of the block were executed after the block state was set to 0. This was the reason both methods had no impact. I changed this that the setting of the block_state will be done after. Now both the dropping of blocks and explosion of other TNT worked fine.

This PR fixes #595.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
