### PR TITLE
Implemented the item counting in /clear

### DIFF
--- a/pumpkin/src/command/commands/clear.rs
+++ b/pumpkin/src/command/commands/clear.rs
@@ -23,14 +23,14 @@ const ARG_TARGET: &str = "target";
 async fn clear_player(target: &Player) -> u64 {
     let inventory = target.inventory();
     let mut count: u64 = 0;
-    for slot in inventory.main_inventory.iter() {
+    for slot in &inventory.main_inventory {
         let mut slot_lock = slot.lock().await;
         count += u64::from(slot_lock.item_count);
         *slot_lock = ItemStack::EMPTY;
     }
 
     let entity_equipment_lock = inventory.entity_equipment.lock().await;
-    for (_, slot) in entity_equipment_lock.equipment.iter() {
+    for slot in entity_equipment_lock.equipment.values() {
         let mut slot_lock = slot.lock().await;
         if slot_lock.is_empty() {
             continue;


### PR DESCRIPTION
## Description

The `clear_player` function used to call `inventory.clear()`. Now it counts the stack's content before clearing it. The player's armor is turned into ghost items due to these slots not being updated.

## Testing

The code was tested in-game and is working.