### PR TITLE
Fix giving more than 255 items

### DIFF
--- a/pumpkin/src/command/commands/give.rs
+++ b/pumpkin/src/command/commands/give.rs
@@ -61,9 +61,9 @@ impl CommandExecutor for Executor {
         };
 
         for target in targets {
-            let max_stack = item.components.max_stack_size as i32;
+            let max_stack = i32::from(item.components.max_stack_size);
             let mut remaining = item_count;
-            
+
             while remaining > 0 {
                 let take = remaining.min(max_stack);
                 let mut stack = ItemStack::new(take as u8, item);


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Previously the number of items was restricted to 255. Now the correct number of items is added and excess items are dropped on the ground.

## Testing

Tested ingame.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
