### PR TITLE
Update permissions for /transfer

### DIFF
--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -65,7 +65,6 @@ pub async fn default_dispatcher() -> CommandDispatcher {
     dispatcher.register(pumpkin::init_command_tree(), "pumpkin:command.pumpkin");
     dispatcher.register(help::init_command_tree(), "minecraft:command.help");
     dispatcher.register(list::init_command_tree(), "minecraft:command.list");
-    dispatcher.register(transfer::init_command_tree(), "minecraft:command.transfer");
     dispatcher.register(me::init_command_tree(), "minecraft:command.me");
     dispatcher.register(msg::init_command_tree(), "minecraft:command.msg");
     // Two
@@ -128,6 +127,7 @@ pub async fn default_dispatcher() -> CommandDispatcher {
         whitelist::init_command_tree(),
         "minecraft:command.whitelist",
     );
+    dispatcher.register(transfer::init_command_tree(), "minecraft:command.transfer");
     // Four
     dispatcher.register(stop::init_command_tree(), "minecraft:command.stop");
 


### PR DESCRIPTION
## Description
Changes /transfer to require permission level 0 to permission level 3, matching vanilla. Closes #1036.