### PR TITLE
Update signature dependency to version 3.0.0-rc.2

### DIFF
--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -84,7 +84,7 @@ dhat = { version = "0.3.3", optional = true }
 
 flate2 = "1.1.4"
 console-subscriber = { version = "0.4.1", optional = true }
-signature = "2.2.0"
+signature = "3.0.0-rc.2"
 [dev-dependencies]
 tempfile.workspace = true
 


### PR DESCRIPTION
## Description

RSA 0.10.0-rc.5 depends on signature 3.0.0-rc.2. I believe this is the root cause of plugin compilations failing. 

## Testing

I haven't tested, but I pulled it directly from RSA's 0.10.0-rc.5 update commit: https://github.com/RustCrypto/RSA/commit/472c98dd95c21cc123af77144bd2b65553ee8745
