### PR TITLE
fix:trait method signature mismatch for plugin_method

### DIFF
--- a/pumpkin-api-macros/src/lib.rs
+++ b/pumpkin-api-macros/src/lib.rs
@@ -14,14 +14,16 @@ pub fn plugin_method(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input_fn = parse_macro_input!(item as ItemFn);
     let fn_name = &input_fn.sig.ident;
     let fn_inputs = &input_fn.sig.inputs;
-    let fn_output = &input_fn.sig.output;
     let fn_body = &input_fn.block;
 
     let method = quote! {
-        #[allow(unused_mut)]
-        async fn #fn_name(#fn_inputs) #fn_output {
-            crate::GLOBAL_RUNTIME.block_on(async move {
-                #fn_body
+        fn #fn_name(#fn_inputs) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<(), String>> + Send>
+        > {
+            Box::pin(async move {
+                crate::GLOBAL_RUNTIME.block_on(async move {
+                    #fn_body
+                })
             })
         }
     }


### PR DESCRIPTION
Background

Pumpkin’s Plugin trait requires plugin methods (e.g., on_load) to return:
```rust
Pin<Box<dyn Future<Output = Result<(), String>> + Send>>
```

However, the current implementation of the #[plugin_method] macro rewrites methods into an async fn, which compiles into:
```rust
impl Future<Output = Result<(), String>>
```

This causes a type mismatch when implementing the Plugin trait, resulting in compilation error E0053.

❗ Problem

When using:
```rust
#[plugin_method]
async fn on_load(...) -> Result<(), String> { ... }
```

the generated method has signature:
```rust
fn on_load(...) -> impl Future<...>
```
but the trait expects:
```rust
fn on_load(...) -> Pin<Box<dyn Future<...> + Send>>
```

This mismatch triggers:

error[E0053]: method `on_load` has an incompatible type for trait

✅ Solution

Modify the plugin_method macro to wrap the async block into a boxed future, producing the correct return type expected by the Plugin trait.

Key Changes

Replace the generated async fn with a regular fn returning:

```rust
Pin<Box<dyn Future<Output = Result<(), String>> + Send>>
```

Wrap the original async body using:

```rust
Box::pin(async move {
    crate::GLOBAL_RUNTIME.block_on(async move { ... })
})
```
Preserve the user-written method body while ensuring type compatibility.

📄 Summary of Changes

Updated the expansion of #[plugin_method] to generate a boxed future instead of impl Future.

Ensured all plugin methods rewritten by the macro now fully satisfy the Pumpkin Plugin trait signatures.

No changes required from plugin authors—existing macro usage continues to work.

🔍 Impact

Fixes compilation failure for any method tagged with #[plugin_method].

Makes macro behavior trait-compliant.

No breaking API changes.