### PR TITLE
feat(plugin): add API version compatibility check for native plugins

### DIFF
--- a/pumpkin-api-macros/src/lib.rs
+++ b/pumpkin-api-macros/src/lib.rs
@@ -66,6 +66,9 @@ pub fn plugin_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
             description: env!("CARGO_PKG_DESCRIPTION"),
         };
 
+        #[unsafe(no_mangle)]
+        pub static PUMPKIN_API_VERSION: u32 = pumpkin::plugin::PLUGIN_API_VERSION;
+
         #input_struct
 
         impl pumpkin::plugin::Plugin for #struct_ident {

--- a/pumpkin/src/plugin/loader/mod.rs
+++ b/pumpkin/src/plugin/loader/mod.rs
@@ -56,4 +56,17 @@ pub enum LoaderError {
 
     #[error("Invalid loader data")]
     InvalidLoaderData,
+
+    #[error(
+        "Plugin was built for an incompatible API version. Please rebuild it against this Pumpkin build."
+    )]
+    ApiVersionMissing,
+
+    #[error(
+        "Plugin API version mismatch (plugin {plugin_version}, server {server_version}). Please rebuild it against this Pumpkin build."
+    )]
+    ApiVersionMismatch {
+        plugin_version: u32,
+        server_version: u32,
+    },
 }

--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -18,6 +18,10 @@ pub use api::*;
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// Bump this whenever the public plugin API or any event layout changes in a way
+/// that makes old binary plugins incompatible.
+pub const PLUGIN_API_VERSION: u32 = 2;
+
 /// A trait for handling events dynamically.
 ///
 /// This trait allows for handling events of any type that implements the `Event` trait.


### PR DESCRIPTION
Added a plugin ABI gate so outdated binary plugins can’t take the server down. Specifically:
﻿
Introduced PLUGIN_API_VERSION and documented how to bump it when changing the public plugin ABI (pumpkin/src/plugin/mod.rs:21).
Updated the plugin derive macro to export the API version symbol alongside the metadata so loaders can inspect it (pumpkin-api-macros/src/lib.rs:62-80).
Extended the native loader with an explicit version check and descriptive loader errors; incompatible or missing symbols now cause a clean load failure before any plugin code runs (pumpkin/src/plugin/loader/native.rs:5-87, pumpkin/src/plugin/loader/mod.rs:40-71).
Tests: cargo check