### PR TITLE
fix: fluid system incorrectly treating air as flowing water

### DIFF
--- a/pumpkin/src/block/fluid/flowing.rs
+++ b/pumpkin/src/block/fluid/flowing.rs
@@ -344,6 +344,14 @@ pub trait FlowingFluid: Send + Sync {
         Box::pin(async move {
             let block_state_id = world.get_block_state_id(block_pos).await;
 
+            let is_fluid_state_id = fluid
+                .states
+                .iter()
+                .any(|state| state.block_state_id == block_state_id);
+            if !is_fluid_state_id {
+                return;
+            }
+
             let props = FlowingFluidProperties::from_state_id(block_state_id, fluid);
             let drop_off = self.get_level_decrease_per_block(world);
 


### PR DESCRIPTION
## Description
The issue: https://github.com/Pumpkin-MC/Pumpkin/issues/1233
I think the problem is: 
When water dries up (the block turns to air):
[world.get_block_state_id(block_pos)](https://github.com/Pumpkin-MC/Pumpkin/blob/42c903493a09a4c8d7f4eddc2644464e3871c736/pumpkin/src/block/fluid/flowing.rs#L345) returns the block state ID of air
the [from_state_id ](https://github.com/Pumpkin-MC/Pumpkin/blob/42c903493a09a4c8d7f4eddc2644464e3871c736/pumpkin-data/build/fluid.rs#L236)iterates through all fluid states for a matching state.block_state_id, but the air's state ID cannot match any fluid state.
So, returns the default state: [Self::from_index(0)](https://github.com/Pumpkin-MC/Pumpkin/blob/42c903493a09a4c8d7f4eddc2644464e3871c736/pumpkin-data/build/fluid.rs#L211)
The default state has Falling set to true, which causes the level to be set to 7 by the code following flow_to_sides.
So it caused the issue: "After blocking the water source, flowing water still appeared repeatedly."

 I simply checked whether the block_state_id obtained from the location is a fluid state ID.

## Testing
After blocking the water source or cutting off the water flow with blocks, it will not cause the water to repeatedly appear and disappear.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
