### PR TITLE
Fix a deadlock

### DIFF
--- a/pumpkin-world/src/chunk_system.rs
+++ b/pumpkin-world/src/chunk_system.rs
@@ -2086,16 +2086,15 @@ impl GenerationSchedule {
 
             if self.queue.is_empty() {
                 // debug!("the queue is empty. thread sleep");
-                'out: while self.running_task_count > 0 {
+                while self.running_task_count > 0 && self.queue.is_empty() {
                     let (pos, data) = self.recv_chunk.recv().expect("recv_chunk stop");
                     self.receive_chunk(pos, data);
-                    if !self.queue.is_empty() || self.resort_work(self.send_level.get()) {
-                        break 'out;
-                    }
+                    self.resort_work(self.send_level.get());
                 }
                 if self.queue.is_empty() {
                     // debug!("no work to do. thread sleep");
-                    debug_assert!(self.running_task_count > 0 || self.debug_check());
+                    debug_assert!(self.debug_check());
+                    debug_assert_eq!(self.running_task_count, 0);
                     self.resort_work(self.send_level.wait_and_get(&level));
                 }
             }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

It is really a hard work.

I think there is possibility that `self.queue.is_empty()` is true after `self.resort_work`. Then incorrectly goto `self.send_level.wait_and_get` and deadlock

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
