### PR TITLE
Fix: Client desync on container close

### DIFF
--- a/pumpkin-inventory/src/player/player_inventory.rs
+++ b/pumpkin-inventory/src/player/player_inventory.rs
@@ -10,7 +10,6 @@ use pumpkin_world::item::ItemStack;
 use std::any::Any;
 use std::array::from_fn;
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -300,7 +299,13 @@ impl PlayerInventory {
                 player
                     .enqueue_slot_set_packet(&CSetPlayerInventory::new(
                         (room_for_stack as i32).into(),
-                        &self.get_stack(room_for_stack as usize).await.lock().await.clone().into()
+                        &self
+                            .get_stack(room_for_stack as usize)
+                            .await
+                            .lock()
+                            .await
+                            .clone()
+                            .into(),
                     ))
                     .await;
             }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->
Messed up my fork's git history and didn't realise deleting the repo would close the PR :p

## Description
When a crafting table/other container screen is closed, the items are returned to the players inventory.

However, the client update packet is fed incorrect information.

`stack` is modified by `insert_stack()` to become the remaining items to distribute in the inventory / drop.

The server-side inventory slot data is now re-fetched before sending the slot set packet.

## Testing
Manually tested closing crafting tables and chests with different amounts of items in the cursor and crafting slots, hotbar instantly updated each time.

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
