### PR TITLE
Random default seed

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -1,7 +1,7 @@
 use fun::FunConfig;
 use logging::LoggingConfig;
 use pumpkin_util::world_seed::Seed;
-use pumpkin_util::{Difficulty, GameMode, PermissionLvl};
+use pumpkin_util::{Difficulty, GameMode, PermissionLvl, random};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use std::net::SocketAddr;
@@ -120,7 +120,7 @@ impl Default for BasicConfiguration {
             java_edition_address: "0.0.0.0:25565".parse().unwrap(),
             bedrock_edition: true,
             bedrock_edition_address: "0.0.0.0:19132".parse().unwrap(),
-            seed: Seed(0),
+            seed: Seed(random::get_seed()),
             max_players: 1000,
             view_distance: NonZeroU8::new(16).unwrap(),
             simulation_distance: NonZeroU8::new(10).unwrap(),


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
This PR changes the default seed to a random one, generated by `pumpkin_util::random::get_seed`. This change was done to match vanilla behavior.
## Testing
Testing was done manually.
Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
