### PR TITLE
fix: server crash when placing liquids in survival

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1723,12 +1723,15 @@ impl JavaClient {
         }
         drop(held);
 
+        let item_for_use = {
+            let held = item_in_hand.lock().await;
+            held.item
+        };
+
         send_cancellable! {{
             event;
             'after: {
-                let held = item_in_hand.lock().await;
-                let item = held.item;
-                server.item_registry.on_use(item, player).await;
+                server.item_registry.on_use(item_for_use, player).await;
             }
         }}
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixed bug when placing liquids in survival would cause the server to crash due to a lock issue
https://github.com/Pumpkin-MC/Pumpkin/issues/1308

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
