### PR TITLE
Refactor Dockerfile cache mounts for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN rustup show active-toolchain || rustup toolchain install
 RUN rustup component add rustfmt
 
 # build release
-RUN --mount=type=cache,sharing=private,target=/pumpkin/target \
-    --mount=type=cache,target=/usr/local/cargo/git/db \
-    --mount=type=cache,target=/usr/local/cargo/registry/ \
+RUN --mount=type=cache,id=pumpkin-target,sharing=private,target=/pumpkin/target \
+    --mount=type=cache,id=cargo-git-db,target=/usr/local/cargo/git/db \
+    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
     cargo build --release && cp target/release/pumpkin ./pumpkin.release
 
 FROM alpine:3.23


### PR DESCRIPTION
Fixed this Error when trying to deploy it on a Plattform like Railway.  Cache mounts MUST be in the format --mount=type=cache,id=<cache-id>

<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
