### PR TITLE
fix: adjust explosion resistance calculation to account for fluid states

### DIFF
--- a/pumpkin/src/world/explosion.rs
+++ b/pumpkin/src/world/explosion.rs
@@ -58,7 +58,8 @@ impl Explosion {
                         // }
 
                         if !state.is_air() || !fluid_state.is_empty {
-                            let resistance = fluid_state.blast_resistance.max(block.blast_resistance);
+                            let resistance =
+                                fluid_state.blast_resistance.max(block.blast_resistance);
                             h -= resistance * 0.3;
                         }
 


### PR DESCRIPTION
## Description
Waterlogged blocks should not be destroyed in explosions

solves #1347

## Testing
Place water in watterloggable blocks then explode a TNT and check if it keeps in place
