### PR TITLE
fix: implement broken behavior for piston block to break the head

### DIFF
--- a/pumpkin/src/block/blocks/piston/piston.rs
+++ b/pumpkin/src/block/blocks/piston/piston.rs
@@ -16,7 +16,7 @@ use pumpkin_world::{
 
 use crate::{
     block::{
-        BlockBehaviour, BlockFuture, BlockMetadata, OnNeighborUpdateArgs, OnPlaceArgs,
+        BlockBehaviour, BlockFuture, BlockMetadata, BrokenArgs, OnNeighborUpdateArgs, OnPlaceArgs,
         OnSyncedBlockEventArgs, PlacedArgs, blocks::redstone::is_emitting_redstone_power,
     },
     world::World,
@@ -87,6 +87,21 @@ impl BlockBehaviour for PistonBlock {
             props.extended = false;
             props.facing = args.player.living_entity.entity.get_facing().opposite();
             props.to_state_id(args.block)
+        })
+    }
+
+    fn broken<'a>(&'a self, args: BrokenArgs<'a>) -> BlockFuture<'a, ()> {
+        Box::pin(async move {
+            let props = PistonProps::from_state_id(args.state.id, args.block);
+            let pos = args
+                .position
+                .offset(props.facing.to_block_direction().to_offset());
+            let (block_to_check, _) = args.world.get_block_and_state_id(&pos).await;
+            if &Block::PISTON_HEAD == block_to_check || &Block::MOVING_PISTON == block_to_check {
+                args.world
+                    .break_block(&pos, None, BlockFlags::SKIP_DROPS)
+                    .await;
+            }
         })
     }
 


### PR DESCRIPTION
## Description
Adds the broken behaviour to the piston so it breaks the moving/head part

fixes #1271

## Testing
When you break a piston base then it break the movable piece.
