### PR TITLE
fix: prevent player from getting kicked when doing jab attack with spear

### DIFF
--- a/pumpkin-protocol/src/java/server/play/player_action.rs
+++ b/pumpkin-protocol/src/java/server/play/player_action.rs
@@ -27,8 +27,10 @@ pub enum Status {
     /// I didn't make that up
     /// Indicates that the currently held item should have its state updated such as eating food, pulling back bows, using buckets, etc. Location is always set to 0/0/0, Face is always set to -Y. Sequence is always set to 0.
     ReleaseItemInUse,
-    /// Used to swap or assign an item to the second hand. Location is always set to 0/0/0, Face is always set to -Y. Sequence is always set to 0.  
+    /// Used to swap or assign an item to the second hand. Location is always set to 0/0/0, Face is always set to -Y. Sequence is always set to 0.
     SwapItem,
+    /// Sent when a player is holding a spear and performs a jab attack.
+    SpearJab,
 }
 
 pub struct InvalidStatus;
@@ -45,6 +47,7 @@ impl TryFrom<i32> for Status {
             4 => Ok(Self::DropItem),
             5 => Ok(Self::ReleaseItemInUse),
             6 => Ok(Self::SwapItem),
+            7 => Ok(Self::SpearJab),
             _ => Err(InvalidStatus),
         }
     }

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -1398,6 +1398,9 @@ impl JavaClient {
                 Status::SwapItem => {
                     player.swap_item().await;
                 }
+                Status::SpearJab => {
+                    log::debug!("todo");
+                }
             },
             Err(_) => self.kick(TextComponent::text("Invalid status")).await,
         }


### PR DESCRIPTION
## Description

This PR has been made to resolve [this issue](https://github.com/Pumpkin-MC/Pumpkin/issues/1320). 
This PR is adding a new action in the list of playerAction. This will avoid the server considering the spear jab as an unknown action. The spear jab attacked was not implemented in this PR. 

The SpearJab is assigned to actionStatus number 7. I couldn’t find much information about the list of actions, but from my testing, this action is only triggered by the jab with the spear. If it’s triggered by other behaviors, I’ll need to rename it.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
