### PR TITLE
fix: schedule fluid ticks to properly drain flowing liquids

### DIFF
--- a/pumpkin/src/block/fluid/water.rs
+++ b/pumpkin/src/block/fluid/water.rs
@@ -79,6 +79,10 @@ impl FlowingFluid for FlowingWater {
         1
     }
 
+    fn get_flow_speed(&self, _world: &World) -> u8 {
+        WATER_FLOW_SPEED
+    }
+
     fn get_max_flow_distance(&self, _world: &World) -> i32 {
         4
     }


### PR DESCRIPTION
## summary
- when fluid state changes during scheduled tick, schedule another tick to continue drainage
- matches vanilla behavior where each tick schedules the next until fully drained
- added `get_flow_speed` method to `FlowingFluid` trait for dimension-aware tick delays
- lava now uses correct tick rates (10 in nether, 30 elsewhere)

fixes #1371