### PR TITLE
feat: add git commit hash to /version command

### DIFF
--- a/pumpkin/build.rs
+++ b/pumpkin/build.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+
+fn main() {
+    // Get short hash (7 chars) for display
+    let short_output = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output();
+
+    let git_hash_short = match short_output {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        _ => "unknown".to_string(),
+    };
+
+    // Get full hash for hover text
+    let full_output = Command::new("git").args(["rev-parse", "HEAD"]).output();
+
+    let git_hash_full = match full_output {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        _ => "unknown".to_string(),
+    };
+
+    println!("cargo::rerun-if-changed=../.git/HEAD");
+    println!("cargo::rerun-if-changed=../.git/refs/heads/");
+    println!("cargo::rustc-env=GIT_HASH={git_hash_short}");
+    println!("cargo::rustc-env=GIT_HASH_FULL={git_hash_full}");
+}

--- a/pumpkin/src/command/commands/pumpkin.rs
+++ b/pumpkin/src/command/commands/pumpkin.rs
@@ -16,6 +16,8 @@ const DESCRIPTION: &str = "Display information about Pumpkin.";
 struct Executor;
 
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const GIT_HASH: &str = env!("GIT_HASH");
+const GIT_HASH_FULL: &str = env!("GIT_HASH_FULL");
 
 #[expect(clippy::too_many_lines)]
 impl CommandExecutor for Executor {
@@ -27,26 +29,24 @@ impl CommandExecutor for Executor {
     ) -> CommandResult<'a> {
         Box::pin(async move {
             let locale = sender.get_locale().await;
+            let version_string = format!("{CARGO_PKG_VERSION} (Commit: {GIT_HASH})");
             sender
                 .send_message(
                     TextComponent::custom(
                         "pumpkin",
                         "commands.pumpkin.version",
                         locale,
-                        vec![TextComponent::text(CARGO_PKG_VERSION)],
+                        vec![TextComponent::text(version_string.clone())],
                     )
-                    .hover_event(HoverEvent::show_text(TextComponent::custom(
-                        "pumpkin",
-                        "commands.pumpkin.version.hover",
-                        locale,
-                        vec![],
-                    )))
+                    .hover_event(HoverEvent::show_text(TextComponent::text(format!(
+                        "Commit: {GIT_HASH_FULL}\nClick to copy"
+                    ))))
                     .click_event(ClickEvent::CopyToClipboard {
                         value: Cow::from(
                             get_translation_text(
                                 "pumpkin:commands.pumpkin.version",
                                 locale,
-                                vec![TextComponent::text(CARGO_PKG_VERSION).0],
+                                vec![TextComponent::text(version_string).0],
                             )
                             .replace('\n', ""),
                         ),


### PR DESCRIPTION
## summary
- adds git commit hash to the `/version` command output
- displays 7-character short hash in the version string (e.g., `0.1.0 (Commit: ca77306)`)
- shows full 40-character hash on hover for easy copying

closes #1378