### PR TITLE
fix: armor stands now break instantly in creative mode

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -675,8 +675,8 @@ impl Player {
                 damage as f32,
                 DamageType::PLAYER_ATTACK,
                 None,
-                Some(&self.living_entity.entity),
-                Some(&self.living_entity.entity),
+                Some(self),
+                Some(self),
             )
             .await
         {


### PR DESCRIPTION
## Summary
- pass `Player` instead of `Entity` as damage source so `get_player()` works
- creative mode: spawn break particles, play sound, remove without drops
- add `spawn_break_particles` method (TODO: use oak plank block particles, requires block state data in particle system)

Fixes #1281