### PR TITLE
fix: stop elytra flight when switching to spectator mode

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -1965,6 +1965,14 @@ impl Player {
                     self.get_entity().set_on_fire(false).await;
                 }
 
+                // Stop elytra flight when switching to spectator mode
+                if gamemode == GameMode::Spectator {
+                    let entity = self.get_entity();
+                    if entity.fall_flying.load(Ordering::Relaxed) {
+                        entity.set_fall_flying(false).await;
+                    }
+                }
+
                 self.living_entity.entity.invulnerable.store(
                     matches!(gamemode, GameMode::Creative | GameMode::Spectator),
                     Ordering::Relaxed,


### PR DESCRIPTION
## summary
- stops elytra flight when player switches to spectator mode
- fixes #1349