### PR TITLE
Add /restart command with safe restart flow

### DIFF
--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -38,6 +38,7 @@ mod playsound;
 mod plugin;
 mod plugins;
 mod pumpkin;
+mod restart;
 mod rotate;
 mod say;
 mod seed;
@@ -154,6 +155,7 @@ pub async fn default_dispatcher(
     );
     // Four
     dispatcher.register(stop::init_command_tree(), "minecraft:command.stop");
+    dispatcher.register(restart::init_command_tree(), "minecraft:command.restart");
 
     dispatcher
 }
@@ -537,6 +539,13 @@ fn register_level_4_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.stop",
             "Stops the server",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.restart",
+            "Restarts the server",
             PermissionDefault::Op(PermissionLvl::Four),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/restart.rs
+++ b/pumpkin/src/command/commands/restart.rs
@@ -1,0 +1,36 @@
+use pumpkin_util::text::TextComponent;
+use pumpkin_util::text::color::NamedColor;
+
+use crate::command::args::ConsumedArgs;
+use crate::command::tree::CommandTree;
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::request_restart;
+
+const NAMES: [&str; 1] = ["restart"];
+const DESCRIPTION: &str = "Restart the server.";
+
+struct Executor;
+
+impl CommandExecutor for Executor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            sender
+                .send_message(
+                    TextComponent::translate("commands.restart.restarting", [])
+                        .color_named(NamedColor::Red),
+                )
+                .await;
+            request_restart();
+            Ok(())
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).execute(Executor)
+}

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -143,11 +143,17 @@ pub fn init_logger(advanced_config: &AdvancedConfiguration) {
 }
 
 pub static SHOULD_STOP: AtomicBool = AtomicBool::new(false);
+pub static RESTART_REQUESTED: AtomicBool = AtomicBool::new(false);
 pub static STOP_INTERRUPT: LazyLock<CancellationToken> = LazyLock::new(CancellationToken::new);
 
 pub fn stop_server() {
     SHOULD_STOP.store(true, Ordering::Relaxed);
     STOP_INTERRUPT.cancel();
+}
+
+pub fn request_restart() {
+    RESTART_REQUESTED.store(true, Ordering::Relaxed);
+    stop_server();
 }
 
 fn resolve_some<T: Future, D, F: FnOnce(D) -> T>(


### PR DESCRIPTION
## Description

Adds a built‑in /restart command that cleanly restarts the server. The command sets a restart flag, triggers a normal shutdown, and on Unix/macOS replaces the process with a fresh instance so the console stays attached. Also registers the command and permission at OP level 4.

## Testing

cargo build --release
Ran ./target/release/pumpkin
Executed /restart from console and in‑game; server shut down and restarted, console remained usable

