### PR TITLE
fix: add out of bounds checking for some commands

### DIFF
--- a/pumpkin-util/src/math/vector3.rs
+++ b/pumpkin-util/src/math/vector3.rs
@@ -338,6 +338,28 @@ impl<T: Math + Copy + Into<f64>> Vector3<T> {
 }
 
 impl<T: Math + Copy + Into<f64>> Vector3<T> {
+    pub fn floor_to_i32(&self) -> Vector3<i32> {
+        let x: f64 = self.x.into();
+        let y: f64 = self.y.into();
+        let z: f64 = self.z.into();
+        Vector3 {
+            x: x.floor() as i32,
+            y: y.floor() as i32,
+            z: z.floor() as i32,
+        }
+    }
+
+    pub fn floor_to_vec2_i32(&self) -> Vector2<i32> {
+        let x: f64 = self.x.into();
+        let z: f64 = self.z.into();
+        Vector2 {
+            x: x.floor() as i32,
+            y: z.floor() as i32,
+        }
+    }
+}
+
+impl<T: Math + Copy + Into<f64>> Vector3<T> {
     pub fn to_block_pos(&self) -> BlockPos {
         BlockPos(self.to_i32())
     }

--- a/pumpkin/src/command/commands/fill.rs
+++ b/pumpkin/src/command/commands/fill.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::command::args::block::{
     BlockArgumentConsumer, BlockPredicate, BlockPredicateArgumentConsumer,
 };
@@ -6,6 +8,7 @@ use crate::command::args::{ConsumedArgs, FindArg};
 use crate::command::tree::CommandTree;
 use crate::command::tree::builder::{argument, literal};
 use crate::command::{CommandError, CommandExecutor, CommandResult, CommandSender};
+use crate::world::World;
 
 use pumpkin_data::Block;
 use pumpkin_util::math::position::BlockPos;
@@ -48,12 +51,214 @@ fn not_in_filter(filter: &BlockPredicate, old_block: &Block) -> bool {
     }
 }
 
-#[expect(clippy::too_many_lines)]
+enum FillerResult {
+    DidNotPlaceBlock = 0,
+    PlacedBlock = 1,
+    PlacedBlockWithoutUpdate = 2,
+}
+
+struct Context {
+    block_state_id: u16,
+    option_filter: Option<BlockPredicate>,
+    world: Arc<World>,
+    placed_blocks: i32,
+    to_update: Vec<BlockPos>,
+
+    start_x: i32,
+    start_y: i32,
+    start_z: i32,
+    end_x: i32,
+    end_y: i32,
+    end_z: i32,
+}
+
+impl Context {
+    /// Checks whether the block position is at the edge of the region stored by this context.
+    #[inline]
+    const fn is_edge(&self, block_position: BlockPos) -> bool {
+        let pos = block_position.0;
+        pos.x == self.start_x
+            || pos.x == self.end_x
+            || pos.y == self.start_y
+            || pos.y == self.end_y
+            || pos.z == self.start_z
+            || pos.z == self.end_z
+    }
+}
+
+trait Filler {
+    async fn execute_for_pos(context: &Context, block_position: BlockPos) -> FillerResult;
+
+    async fn execute_for_region(context: &mut Context) {
+        for x in context.start_x..=context.end_x {
+            for y in context.start_y..=context.end_y {
+                for z in context.start_z..=context.end_z {
+                    let block_position = BlockPos(Vector3::new(x, y, z));
+                    let filler_result = Self::execute_for_pos(context, block_position).await;
+                    match filler_result {
+                        FillerResult::PlacedBlock => {
+                            context.placed_blocks += 1;
+                            context.to_update.push(block_position);
+                        }
+                        FillerResult::PlacedBlockWithoutUpdate => {
+                            context.placed_blocks += 1;
+                        }
+                        FillerResult::DidNotPlaceBlock => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct DestroyFiller;
+impl Filler for DestroyFiller {
+    async fn execute_for_pos(context: &Context, block_position: BlockPos) -> FillerResult {
+        if let Some(filter) = &context.option_filter
+            && not_in_filter(filter, context.world.get_block(&block_position).await)
+        {
+            return FillerResult::DidNotPlaceBlock;
+        }
+        context
+            .world
+            .break_block(
+                &block_position,
+                None,
+                BlockFlags::SKIP_DROPS | BlockFlags::FORCE_STATE,
+            )
+            .await;
+        context
+            .world
+            .set_block_state(
+                &block_position,
+                context.block_state_id,
+                BlockFlags::FORCE_STATE,
+            )
+            .await;
+        FillerResult::PlacedBlock
+    }
+}
+
+struct HollowFiller;
+impl Filler for HollowFiller {
+    async fn execute_for_pos(context: &Context, block_position: BlockPos) -> FillerResult {
+        if let Some(filter) = &context.option_filter
+            && not_in_filter(filter, context.world.get_block(&block_position).await)
+        {
+            return FillerResult::DidNotPlaceBlock;
+        }
+        if context.is_edge(block_position) {
+            context
+                .world
+                .set_block_state(
+                    &block_position,
+                    context.block_state_id,
+                    BlockFlags::FORCE_STATE,
+                )
+                .await;
+        } else {
+            context
+                .world
+                .set_block_state(&block_position, 0, BlockFlags::FORCE_STATE)
+                .await;
+        }
+        FillerResult::PlacedBlock
+    }
+}
+
+struct KeepFiller;
+impl Filler for KeepFiller {
+    async fn execute_for_pos(context: &Context, block_position: BlockPos) -> FillerResult {
+        let old_state = context.world.get_block_state(&block_position).await;
+        if old_state.is_air() {
+            if let Some(filter) = &context.option_filter
+                && not_in_filter(filter, context.world.get_block(&block_position).await)
+            {
+                return FillerResult::DidNotPlaceBlock;
+            }
+            context
+                .world
+                .set_block_state(
+                    &block_position,
+                    context.block_state_id,
+                    BlockFlags::FORCE_STATE,
+                )
+                .await;
+            FillerResult::PlacedBlock
+        } else {
+            FillerResult::DidNotPlaceBlock
+        }
+    }
+}
+
+struct OutlineFiller;
+impl Filler for OutlineFiller {
+    async fn execute_for_pos(context: &Context, block_position: BlockPos) -> FillerResult {
+        if !context.is_edge(block_position) {
+            return FillerResult::DidNotPlaceBlock;
+        }
+        if let Some(filter) = &context.option_filter
+            && not_in_filter(filter, context.world.get_block(&block_position).await)
+        {
+            return FillerResult::DidNotPlaceBlock;
+        }
+        context
+            .world
+            .set_block_state(
+                &block_position,
+                context.block_state_id,
+                BlockFlags::FORCE_STATE,
+            )
+            .await;
+        FillerResult::PlacedBlock
+    }
+}
+
+struct ReplaceFiller;
+impl Filler for ReplaceFiller {
+    async fn execute_for_pos(context: &Context, block_position: BlockPos) -> FillerResult {
+        if let Some(filter) = &context.option_filter
+            && not_in_filter(filter, context.world.get_block(&block_position).await)
+        {
+            return FillerResult::DidNotPlaceBlock;
+        }
+        context
+            .world
+            .set_block_state(
+                &block_position,
+                context.block_state_id,
+                BlockFlags::FORCE_STATE,
+            )
+            .await;
+        FillerResult::PlacedBlock
+    }
+}
+
+struct StrictFiller;
+impl Filler for StrictFiller {
+    async fn execute_for_pos(context: &Context, block_position: BlockPos) -> FillerResult {
+        if let Some(filter) = &context.option_filter
+            && not_in_filter(filter, context.world.get_block(&block_position).await)
+        {
+            return FillerResult::DidNotPlaceBlock;
+        }
+        context
+            .world
+            .set_block_state(
+                &block_position,
+                context.block_state_id,
+                BlockFlags::SKIP_BLOCK_ADDED_CALLBACK,
+            )
+            .await;
+        FillerResult::PlacedBlockWithoutUpdate
+    }
+}
+
 impl CommandExecutor for Executor {
     fn execute<'a>(
         &'a self,
         sender: &'a CommandSender,
-        _server: &'a crate::server::Server,
+        server: &'a crate::server::Server,
         args: &'a ConsumedArgs<'a>,
     ) -> CommandResult<'a> {
         Box::pin(async move {
@@ -61,207 +266,74 @@ impl CommandExecutor for Executor {
             let block_state_id = block.default_state.id;
             let from = BlockPosArgumentConsumer::find_arg(args, ARG_FROM)?;
             let to = BlockPosArgumentConsumer::find_arg(args, ARG_TO)?;
-            let option_filter = BlockPredicateArgumentConsumer::find_arg(args, ARG_FILTER)?;
             let mode = self.0;
 
-            let start_x = from.0.x.min(to.0.x);
-            let start_y = from.0.y.min(to.0.y);
-            let start_z = from.0.z.min(to.0.z);
+            let mut context = Context {
+                block_state_id,
+                option_filter: BlockPredicateArgumentConsumer::find_arg(args, ARG_FILTER)?,
+                world: sender.world().ok_or(CommandError::InvalidRequirement)?,
+                placed_blocks: 0,
+                to_update: Vec::new(),
 
-            let end_x = from.0.x.max(to.0.x);
-            let end_y = from.0.y.max(to.0.y);
-            let end_z = from.0.z.max(to.0.z);
-            // TODO: check isInWorldBounds and throw argument.pos.outofbounds
+                start_x: from.0.x.min(to.0.x),
+                start_y: from.0.y.min(to.0.y),
+                start_z: from.0.z.min(to.0.z),
 
-            let world = sender.world().ok_or(CommandError::InvalidRequirement)?;
-            let mut placed_blocks = 0;
-            let mut to_update = Vec::new();
-            match mode {
-                Mode::Destroy => {
-                    for x in start_x..=end_x {
-                        for y in start_y..=end_y {
-                            for z in start_z..=end_z {
-                                let block_position = BlockPos(Vector3::new(x, y, z));
-                                if let Some(filter) = &option_filter
-                                    && not_in_filter(filter, world.get_block(&block_position).await)
-                                {
-                                    continue;
-                                }
-                                world
-                                    .break_block(
-                                        &block_position,
-                                        None,
-                                        BlockFlags::SKIP_DROPS | BlockFlags::FORCE_STATE,
-                                    )
-                                    .await;
-                                world
-                                    .set_block_state(
-                                        &block_position,
-                                        block_state_id,
-                                        BlockFlags::FORCE_STATE,
-                                    )
-                                    .await;
-                                placed_blocks += 1;
-                                to_update.push(block_position);
-                            }
-                        }
-                    }
-                }
-                Mode::Replace => {
-                    for x in start_x..=end_x {
-                        for y in start_y..=end_y {
-                            for z in start_z..=end_z {
-                                let block_position = BlockPos(Vector3::new(x, y, z));
-                                if let Some(filter) = &option_filter
-                                    && not_in_filter(filter, world.get_block(&block_position).await)
-                                {
-                                    continue;
-                                }
-                                world
-                                    .set_block_state(
-                                        &block_position,
-                                        block_state_id,
-                                        BlockFlags::FORCE_STATE,
-                                    )
-                                    .await;
-                                placed_blocks += 1;
-                                to_update.push(block_position);
-                            }
-                        }
-                    }
-                }
-                Mode::Keep => {
-                    for x in start_x..=end_x {
-                        for y in start_y..=end_y {
-                            for z in start_z..=end_z {
-                                let block_position = BlockPos(Vector3::new(x, y, z));
-                                let old_state = world.get_block_state(&block_position).await;
-                                if old_state.is_air() {
-                                    if let Some(filter) = &option_filter
-                                        && not_in_filter(
-                                            filter,
-                                            world.get_block(&block_position).await,
-                                        )
-                                    {
-                                        continue;
-                                    }
-                                    world
-                                        .set_block_state(
-                                            &block_position,
-                                            block_state_id,
-                                            BlockFlags::FORCE_STATE,
-                                        )
-                                        .await;
-                                    placed_blocks += 1;
-                                    to_update.push(block_position);
-                                }
-                            }
-                        }
-                    }
-                }
-                Mode::Hollow => {
-                    for x in start_x..=end_x {
-                        for y in start_y..=end_y {
-                            for z in start_z..=end_z {
-                                let block_position = BlockPos(Vector3::new(x, y, z));
-                                let is_edge = x == start_x
-                                    || x == end_x
-                                    || y == start_y
-                                    || y == end_y
-                                    || z == start_z
-                                    || z == end_z;
-                                if let Some(filter) = &option_filter
-                                    && not_in_filter(filter, world.get_block(&block_position).await)
-                                {
-                                    continue;
-                                }
-                                if is_edge {
-                                    world
-                                        .set_block_state(
-                                            &block_position,
-                                            block_state_id,
-                                            BlockFlags::FORCE_STATE,
-                                        )
-                                        .await;
-                                } else {
-                                    world
-                                        .set_block_state(
-                                            &block_position,
-                                            0,
-                                            BlockFlags::FORCE_STATE,
-                                        )
-                                        .await;
-                                }
-                                placed_blocks += 1;
-                                to_update.push(block_position);
-                            }
-                        }
-                    }
-                }
-                Mode::Outline => {
-                    for x in start_x..=end_x {
-                        for y in start_y..=end_y {
-                            for z in start_z..=end_z {
-                                let block_position = BlockPos(Vector3::new(x, y, z));
-                                let is_edge = x == start_x
-                                    || x == end_x
-                                    || y == start_y
-                                    || y == end_y
-                                    || z == start_z
-                                    || z == end_z;
-                                if !is_edge {
-                                    continue;
-                                }
-                                if let Some(filter) = &option_filter
-                                    && not_in_filter(filter, world.get_block(&block_position).await)
-                                {
-                                    continue;
-                                }
-                                world
-                                    .set_block_state(
-                                        &block_position,
-                                        block_state_id,
-                                        BlockFlags::FORCE_STATE,
-                                    )
-                                    .await;
-                                placed_blocks += 1;
-                                to_update.push(block_position);
-                            }
-                        }
-                    }
-                }
-                Mode::Strict => {
-                    for x in start_x..=end_x {
-                        for y in start_y..=end_y {
-                            for z in start_z..=end_z {
-                                let block_position = BlockPos(Vector3::new(x, y, z));
-                                if let Some(filter) = &option_filter
-                                    && not_in_filter(filter, world.get_block(&block_position).await)
-                                {
-                                    continue;
-                                }
-                                world
-                                    .set_block_state(
-                                        &block_position,
-                                        block_state_id,
-                                        BlockFlags::SKIP_BLOCK_ADDED_CALLBACK,
-                                    )
-                                    .await;
-                                placed_blocks += 1;
-                            }
-                        }
-                    }
-                }
+                end_x: from.0.x.max(to.0.x),
+                end_y: from.0.y.max(to.0.y),
+                end_z: from.0.z.max(to.0.z),
+            };
+
+            if !context.world.is_in_build_limit(from) || !context.world.is_in_build_limit(to) {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    "argument.pos.outofbounds",
+                    [],
+                )));
             }
 
-            for i in to_update {
-                world.update_neighbors(&i, None).await;
+            let max_block_modifications = {
+                let level_info = server.level_info.load();
+                level_info.game_rules.max_block_modifications
+            };
+
+            let total_blocks = (context.end_x - context.start_x + 1) as i64
+                * (context.end_y - context.start_y + 1) as i64
+                * (context.end_z - context.start_z + 1) as i64;
+
+            if total_blocks > max_block_modifications {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    "commands.fill.toobig",
+                    [
+                        TextComponent::text(max_block_modifications.to_string()),
+                        TextComponent::text(total_blocks.to_string()),
+                    ],
+                )));
+            }
+
+            match mode {
+                Mode::Destroy => DestroyFiller::execute_for_region(&mut context).await,
+                Mode::Replace => ReplaceFiller::execute_for_region(&mut context).await,
+                Mode::Keep => KeepFiller::execute_for_region(&mut context).await,
+                Mode::Hollow => HollowFiller::execute_for_region(&mut context).await,
+                Mode::Outline => OutlineFiller::execute_for_region(&mut context).await,
+                Mode::Strict => StrictFiller::execute_for_region(&mut context).await,
+            }
+
+            for i in context.to_update {
+                context.world.update_neighbors(&i, None).await;
+            }
+
+            if context.placed_blocks == 0 {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    "commands.fill.failed",
+                    [],
+                )));
             }
 
             sender
                 .send_message(TextComponent::translate(
                     "commands.fill.success",
-                    [TextComponent::text(placed_blocks.to_string())],
+                    [TextComponent::text(context.placed_blocks.to_string())],
                 ))
                 .await;
 

--- a/pumpkin/src/command/commands/teleport.rs
+++ b/pumpkin/src/command/commands/teleport.rs
@@ -1,3 +1,4 @@
+use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector3::Vector3;
 use pumpkin_util::text::TextComponent;
 
@@ -65,9 +66,9 @@ impl CommandExecutor for EntitiesToEntityExecutor {
 
             let destination = EntityArgumentConsumer::find_arg(args, ARG_DESTINATION)?;
             let pos = destination.get_entity().pos.load();
-            if !World::is_valid(pos) {
+            if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "argument.pos.outofbounds",
+                    "commands.teleport.invalidPosition",
                     [],
                 )));
             }
@@ -100,9 +101,9 @@ impl CommandExecutor for EntitiesToPosFacingPosExecutor {
             let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
 
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
-            if !World::is_valid(pos) {
+            if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "argument.pos.outofbounds",
+                    "commands.teleport.invalidPosition",
                     [],
                 )));
             }
@@ -142,9 +143,9 @@ impl CommandExecutor for EntitiesToPosFacingEntityExecutor {
             let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
 
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
-            if !World::is_valid(pos) {
+            if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "argument.pos.outofbounds",
+                    "commands.teleport.invalidPosition",
                     [],
                 )));
             }
@@ -182,9 +183,9 @@ impl CommandExecutor for EntitiesToPosWithRotationExecutor {
             let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
 
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
-            if !World::is_valid(pos) {
+            if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "argument.pos.outofbounds",
+                    "commands.teleport.invalidPosition",
                     [],
                 )));
             }
@@ -219,9 +220,9 @@ impl CommandExecutor for EntitiesToPosExecutor {
             let targets = EntitiesArgumentConsumer::find_arg(args, ARG_TARGETS)?;
 
             let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
-            if !World::is_valid(pos) {
+            if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                 return Err(CommandError::CommandFailed(TextComponent::translate(
-                    "argument.pos.outofbounds",
+                    "commands.teleport.invalidPosition",
                     [],
                 )));
             }
@@ -265,9 +266,9 @@ impl CommandExecutor for SelfToEntityExecutor {
                 CommandSender::Player(player) => {
                     let yaw = player.living_entity.entity.yaw.load();
                     let pitch = player.living_entity.entity.pitch.load();
-                    if !World::is_valid(pos) {
+                    if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                         return Err(CommandError::CommandFailed(TextComponent::translate(
-                            "argument.pos.outofbounds",
+                            "commands.teleport.invalidPosition",
                             [],
                         )));
                     }
@@ -302,9 +303,9 @@ impl CommandExecutor for SelfToPosExecutor {
                     let pos = Position3DArgumentConsumer::find_arg(args, ARG_LOCATION)?;
                     let yaw = player.living_entity.entity.yaw.load();
                     let pitch = player.living_entity.entity.pitch.load();
-                    if !World::is_valid(pos) {
+                    if !World::is_valid(BlockPos(pos.floor_to_i32())) {
                         return Err(CommandError::CommandFailed(TextComponent::translate(
-                            "argument.pos.outofbounds",
+                            "commands.teleport.invalidPosition",
                             [],
                         )));
                     }

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -3054,17 +3054,33 @@ impl World {
             .await;
     }
     #[must_use]
-    pub fn is_valid(dest: Vector3<f64>) -> bool {
-        Self::is_valid_horizontally(dest) && Self::is_valid_vertically(dest.y)
+    pub fn is_valid(dest: BlockPos) -> bool {
+        Self::is_valid_horizontally(dest) && Self::is_valid_vertically(dest.0.y)
     }
     #[must_use]
-    pub fn is_valid_horizontally(dest: Vector3<f64>) -> bool {
-        (-30_000_000.0..=30_000_000.0).contains(&dest.x)
-            && (-30_000_000.0..=30_000_000.0).contains(&dest.z)
+    pub fn is_valid_horizontally(dest: BlockPos) -> bool {
+        // Note: 30_000_000 is not valid, but -30_000_000 is.
+        (-30_000_000..30_000_000).contains(&dest.0.x)
+            && (-30_000_000..30_000_000).contains(&dest.0.z)
     }
     #[must_use]
-    pub fn is_valid_vertically(y: f64) -> bool {
-        (-20_000_000.0..=20_000_000.0).contains(&y)
+    pub fn is_valid_vertically(y: i32) -> bool {
+        // Note: 20_000_000 is not valid, but -20_000_000 is.
+        (-20_000_000..20_000_000).contains(&y)
+    }
+    #[must_use]
+    pub fn is_in_build_limit(&self, dest: BlockPos) -> bool {
+        self.is_in_height_limit(dest.0.y) && Self::is_valid_horizontally(dest)
+    }
+    #[must_use]
+    pub fn is_in_height_limit(&self, y: i32) -> bool {
+        (self.get_bottom_y()..=self.get_top_y()).contains(&y)
+    }
+    pub const fn get_bottom_y(&self) -> i32 {
+        self.dimension.min_y
+    }
+    pub const fn get_top_y(&self) -> i32 {
+        self.dimension.min_y + self.dimension.height - 1
     }
     /// Gets a `Block` from the block registry. Returns `Block::AIR` if the block was not found.
     pub async fn get_block(&self, position: &BlockPos) -> &'static Block {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

Previously, `/fill` and `/setblock` commands did not have out-of-bounds checking. This PR adds the checking, and also
- each mode in the `/fill` command has its own `Filler` which now removes the need for copy-pasting the same 3D loop. it has two methods, `execute_for_region` to do the 3D loop for each block in it and the other `execute_for_pos` for one block
- `Context` is passed in both methods, which stores information about the command parameters, the world, placed blocks and the `Vec` of `BlockPos` to update (from the previous implementation)
- moved edge checking to its own `const` inlined function in `Context`
- added checking in the `/fill` command if too many blocks were attempted to be filled (gamerule max_block_modifications)
- moved some error feedback into an `Err` result for red color
- added functions in `World` to return the minimum y and maximum y (differs for each `Dimension`), helper methods related to them and removed floating-point ones (replaced with `i32`)
- in the java protocol, removed hardcoded y limits of the world and replaced them with ones dependent on the `World`
- adds `strict` mode (1.21.5) for `/setblock`
- added a way to floor a Vector3 for the out-of-bounds checking change in the `/tp` command

## Testing
- commands can be run to check results