### PR TITLE
Feat /restart command (take 3) 

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -113,6 +113,12 @@ pub struct BasicConfiguration {
     pub white_list: bool,
     /// Whether to enforce the whitelist
     pub enforce_whitelist: bool,
+    /// Delay in milliseconds before restarting the server process.
+    pub restart_delay_ms: u64,
+    /// Message shown to players when the server stops.
+    pub server_stop_message: String,
+    /// Message shown to players when the server restarts.
+    pub server_restart_message: String,
 }
 
 impl Default for BasicConfiguration {
@@ -144,6 +150,9 @@ impl Default for BasicConfiguration {
             allow_chat_reports: false,
             white_list: false,
             enforce_whitelist: false,
+            restart_delay_ms: 200,
+            server_stop_message: "Server stopped".to_string(),
+            server_restart_message: "Server restarting".to_string(),
         }
     }
 }

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -38,6 +38,7 @@ mod playsound;
 mod plugin;
 mod plugins;
 mod pumpkin;
+mod restart;
 mod rotate;
 mod say;
 mod seed;
@@ -154,6 +155,7 @@ pub async fn default_dispatcher(
     );
     // Four
     dispatcher.register(stop::init_command_tree(), "minecraft:command.stop");
+    dispatcher.register(restart::init_command_tree(), "minecraft:command.restart");
 
     dispatcher
 }
@@ -537,6 +539,13 @@ fn register_level_4_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.stop",
             "Stops the server",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.restart",
+            "Restarts the server",
             PermissionDefault::Op(PermissionLvl::Four),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/restart.rs
+++ b/pumpkin/src/command/commands/restart.rs
@@ -1,0 +1,36 @@
+use pumpkin_util::text::TextComponent;
+use pumpkin_util::text::color::NamedColor;
+
+use crate::command::args::ConsumedArgs;
+use crate::command::tree::CommandTree;
+use crate::command::{CommandExecutor, CommandResult, CommandSender};
+use crate::request_restart;
+
+const NAMES: [&str; 1] = ["restart"];
+const DESCRIPTION: &str = "Restart the server.";
+
+struct Executor;
+
+impl CommandExecutor for Executor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        _server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            sender
+                .send_message(
+                    TextComponent::translate("commands.restart.restarting", [])
+                        .color_named(NamedColor::Red),
+                )
+                .await;
+            request_restart();
+            Ok(())
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).execute(Executor)
+}


### PR DESCRIPTION
## Description

Adds a built‑in /restart command that cleanly restarts the server. The command sets a restart flag, triggers a normal shutdown, and on Unix/macOS replaces the process with a fresh instance so the console stays attached, on Windows it spawns a new process for the console barely noticeable. it registers the command and permission at OP level 4 and adds a little bit of logging. 

Fairly useful for my case with my plugin development where im just rebuilding my plugin and replacing it and restarting the server :D

## This also adds 3 new things to the server config file.
- Server restart delay

- It lets you set your own message for server restart and server close. instead of showing the player server closed on a restart, it's set as default to server restarting when you do a restart and server closed when closing the server.

## Testing

cargo fmt --check
cargo clippy --all-targets --all-features
cargo clippy --release --all-targets --all-features

cargo build --release
Ran ./target/release/pumpkin
Executed /restart from console and in‑game; server shut down and restarted, console remained usable

Tested on both MacOs on an M1 Macbook and on Windows 11 with my pc.

### Sorry for the mess. I've got things figured out now this sort of thing wont happen again 