### PR TITLE
fix: make TargetSelector new function public

### DIFF
--- a/pumpkin/src/command/args/entities.rs
+++ b/pumpkin/src/command/args/entities.rs
@@ -130,7 +130,8 @@ pub struct TargetSelector {
 
 impl TargetSelector {
     /// Creates a new target selector with the specified type and default conditions.
-    fn new(selector_type: EntitySelectorType) -> Self {
+    #[must_use]
+    pub fn new(selector_type: EntitySelectorType) -> Self {
         let mut filter = Vec::new();
         match selector_type {
             EntitySelectorType::Source => filter.push(EntityFilter::Limit(1)),


### PR DESCRIPTION
## Description

This just makes the new function in TargetSelector public, since it seems like it should be. I would also like to use it to get entities with PatchBukkit.

## Testing

Testing isn't really required for this since I'm just making the function public.