### PR TITLE
fix: incorrect favicon causes crashing during server ping

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -104,7 +104,7 @@ pub struct BasicConfiguration {
     /// Whether to use a server favicon
     pub use_favicon: bool,
     /// Path to server favicon
-    pub favicon_path: String,
+    pub favicon_path: Option<String>,
     /// The default level name
     pub default_level_name: String,
     /// Whether chat messages should be signed or not
@@ -139,7 +139,7 @@ impl Default for BasicConfiguration {
             force_gamemode: false,
             scrub_ips: true,
             use_favicon: true,
-            favicon_path: "icon.png".to_string(),
+            favicon_path: None,
             default_level_name: "world".to_string(),
             allow_chat_reports: false,
             white_list: false,
@@ -201,8 +201,12 @@ pub trait LoadConfiguration {
             merged_config
         } else {
             let content = Self::default();
+            let mut file_content = toml::to_string(&content).unwrap();
+            if !file_content.contains("favicon_path") {
+                file_content.push_str("# favicon_path = \"icon.png\"");
+            }
 
-            if let Err(err) = fs::write(&path, toml::to_string(&content).unwrap()) {
+            if let Err(err) = fs::write(&path, file_content) {
                 log::warn!(
                     "Couldn't write default config to {:?}. Reason: {}",
                     path.display(),

--- a/pumpkin/src/server/connection_cache.rs
+++ b/pumpkin/src/server/connection_cache.rs
@@ -17,6 +17,14 @@ fn load_icon_from_file<P: AsRef<Path>>(path: P) -> Result<String, Box<dyn error:
     let mut icon_file = File::open(path)?;
     let mut buf = Vec::new();
     icon_file.read_to_end(&mut buf)?;
+    if buf.len() >= 24 {
+        let width = u32::from_be_bytes([buf[16], buf[17], buf[18], buf[19]]);
+        let height = u32::from_be_bytes([buf[20], buf[21], buf[22], buf[23]]);
+
+        if width != 64 || height != 64 {
+            return Err("Invalid favicon dimensions (must be 64x64)".into());
+        }
+    }
     Ok(load_icon_from_bytes(&buf))
 }
 
@@ -116,28 +124,45 @@ impl CachedStatus {
 
     pub fn build_response(config: &BasicConfiguration) -> StatusResponse {
         let favicon = if config.use_favicon {
-            let icon_path = &config.favicon_path;
-            log::debug!("Attempting to load server favicon from '{icon_path}'");
-
-            match load_icon_from_file(icon_path) {
-                Ok(icon) => Some(icon),
-                Err(e) => {
-                    let error_message = e.downcast_ref::<std::io::Error>().map_or_else(
-                        || format!("other error: {e}; using default."),
-                        |io_err| {
-                            if io_err.kind() == std::io::ErrorKind::NotFound {
-                                "not found; using default.".to_string()
-                            } else {
-                                format!("I/O error: {io_err}; using default.")
-                            }
-                        },
-                    );
-                    log::warn!("Failed to load favicon from '{icon_path}': {error_message}");
+            config.favicon_path.as_ref().map_or_else(
+                || {
+                    log::debug!("Loading default icon");
 
                     // Attempt to load default icon
                     Some(load_icon_from_bytes(DEFAULT_ICON))
-                }
-            }
+                },
+                |icon_path| {
+                    if !std::path::Path::new(icon_path)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("png"))
+                    {
+                        log::warn!("Favicon is not a PNG-image, using default.");
+                        return Some(load_icon_from_bytes(DEFAULT_ICON));
+                    }
+                    log::debug!("Attempting to load server favicon from '{icon_path}'");
+
+                    match load_icon_from_file(icon_path) {
+                        Ok(icon) => Some(icon),
+                        Err(e) => {
+                            let error_message = e.downcast_ref::<std::io::Error>().map_or_else(
+                                || format!("other error: {e}; using default."),
+                                |io_err| {
+                                    if io_err.kind() == std::io::ErrorKind::NotFound {
+                                        "not found; using default.".to_string()
+                                    } else {
+                                        format!("I/O error: {io_err}; using default.")
+                                    }
+                                },
+                            );
+                            log::warn!(
+                                "Failed to load favicon from '{icon_path}': {error_message}"
+                            );
+
+                            Some(load_icon_from_bytes(DEFAULT_ICON))
+                        }
+                    }
+                },
+            )
         } else {
             log::info!("Favicon usage is disabled.");
             None


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

The [server list ping interface](https://minecraft.wiki/w/Java_Edition_protocol/Server_List_Ping) specifies the following for the favicon:

> The favicon field is optional. If specified, it should be a [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics) image that is [Base64](https://en.wikipedia.org/wiki/Base64) encoded (newlines (\n) are no longer supported since 1.13) and prepended with data:image/png;base64,. It should also be noted that the source image must be exactly 64x64 pixels, otherwise the Notchian client will not render the image.

But neither conditions is upheld currently. Change favicon_path to be `Option<String>` and ensure it's a PNG and 64x64; if not, fallback to the default favicon

## Testing

DIfferent sizes and formats of favicons have been tested, those not ending with .png or with a size of 64x64 fell back to the default favicon

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
