### PR TITLE
feat(data): add is_solid and is_air helper methods to Block

### DIFF
--- a/pumpkin-data/src/blocks.rs
+++ b/pumpkin-data/src/blocks.rs
@@ -111,6 +111,16 @@ impl Block {
                 .any(|(key, value)| key == "waterlogged" && value == "true")
         })
     }
+
+    /// Returns whether this block is solid (based on default state)
+    pub fn is_solid(&self) -> bool {
+        self.default_state.is_solid()
+    }
+
+    /// Returns whether this block is air (based on default state)
+    pub fn is_air(&self) -> bool {
+        self.default_state.is_air()
+    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Description

Adds convenience helper methods to `Block` for checking block properties based on the default state:
- `is_solid()` - Returns whether the block's default state is solid
- `is_air()` - Returns whether the block's default state is air

These are simple delegations to the existing `BlockState` methods, providing a more ergonomic API when working with `Block` directly.

## Testing

Trivial change - delegates to existing `BlockState::is_solid()` and `BlockState::is_air()` methods.