### PR TITLE
fix: block chest opening when solid block above

### DIFF
--- a/pumpkin-data/src/blocks.rs
+++ b/pumpkin-data/src/blocks.rs
@@ -114,7 +114,7 @@ impl Block {
 
     /// Returns whether this block is solid (based on default state)
     pub fn is_solid(&self) -> bool {
-        self.default_state.is_solid_block()
+        self.default_state.is_solid()
     }
 
     /// Returns whether this block is air (based on default state)

--- a/pumpkin/src/block/blocks/chests.rs
+++ b/pumpkin/src/block/blocks/chests.rs
@@ -326,8 +326,8 @@ async fn is_chest_blocked(world: &World, block_pos: &BlockPos) -> bool {
 }
 async fn has_block_on_top(world: &World, block_pos: &BlockPos) -> bool {
     let above_pos = block_pos.up();
-    let above_block = world.get_block(&above_pos).await;
-    above_block.is_solid()
+    let above_state = world.get_block_state(&above_pos).await;
+    above_state.is_solid_block()
 }
 trait ChestTypeExt {
     fn opposite(&self) -> ChestType;

--- a/pumpkin/src/block/blocks/ender_chest.rs
+++ b/pumpkin/src/block/blocks/ender_chest.rs
@@ -107,8 +107,8 @@ async fn is_chest_blocked(world: &World, block_pos: &BlockPos) -> bool {
 }
 async fn has_block_on_top(world: &World, block_pos: &BlockPos) -> bool {
     let above_pos = block_pos.up();
-    let above_block = world.get_block(&above_pos).await;
-    above_block.is_solid()
+    let above_state = world.get_block_state(&above_pos).await;
+    above_state.is_solid_block()
 }
 impl EnderChestBlock {
     pub const LID_ANIMATION_EVENT_TYPE: u8 = 1;


### PR DESCRIPTION
Fixes: #1429

## Description
This PR fixes an issue where standard chests and ender chests could be opened despite having a solid block placed directly above them.

## Changes:
* Added a has_block_on_top  and is_chest_blocked helper functions to check for solid blocks at pos.up().
* Implemented the check in normal_use for both chest.rs and ender_chest.rs.
* Added logic to check the neighboring block if a double chest is interacted with.

## Testing
Tested locally:
Placed a single chest, double chest, and ender chest.
Placed a solid block (e.g., stone) above them.
Tried to interact (right-click) - the inventory GUI no longer opens and the lid animation does not trigger.
Placed a non-solid block (e.g., stairs) above them - chests open correctly.