### PR TITLE
fix: chest open and close now plays the correct sound

### DIFF
--- a/pumpkin-world/src/block/entities/chest.rs
+++ b/pumpkin-world/src/block/entities/chest.rs
@@ -105,7 +105,7 @@ impl ViewerCountListener for ChestBlockEntity {
         _position: &'a BlockPos,
     ) -> ViewerFuture<'a, ()> {
         Box::pin(async move {
-            self.play_sound(world, Sound::BlockEnderChestOpen).await;
+            self.play_sound(world, Sound::BlockChestOpen).await;
         })
     }
 
@@ -115,7 +115,7 @@ impl ViewerCountListener for ChestBlockEntity {
         _position: &'a BlockPos,
     ) -> ViewerFuture<'a, ()> {
         Box::pin(async move {
-            self.play_sound(world, Sound::BlockEnderChestClose).await;
+            self.play_sound(world, Sound::BlockChestClose).await;
         })
     }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
A regular Minecraft chest would play the ender chest open and close sound instead of the regular chest open and close sound. I changed it from BlockEnderChestOpen/BlockEnderChestClose to BlockChestOpen/BlockChestClose. 
## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
