### PR TITLE
fix: warnings about the use of hashmap instead of btreemap

### DIFF
--- a/pumpkin-data/build/chunk_gen_settings.rs
+++ b/pumpkin-data/build/chunk_gen_settings.rs
@@ -1,17 +1,14 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
 use serde::Deserialize;
-use std::{
-    collections::{BTreeMap, HashMap},
-    fs,
-};
+use std::{collections::BTreeMap, fs};
 
 #[derive(Deserialize)]
 pub struct BlockStateCodecStruct {
     #[serde(rename = "Name")]
     pub name: String,
     #[serde(rename = "Properties")]
-    pub properties: Option<HashMap<String, String>>,
+    pub properties: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Deserialize)]

--- a/pumpkin-data/build/structures.rs
+++ b/pumpkin-data/build/structures.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::{ToTokens, format_ident, quote};
 use serde::Deserialize;
-use std::{collections::HashMap, fs};
+use std::{collections::BTreeMap, fs};
 
 #[derive(Deserialize)]
 pub struct StructureSetStruct {
@@ -245,11 +245,11 @@ pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=../assets/structures.json");
     println!("cargo:rerun-if-changed=../assets/structure_set.json");
 
-    let structures_json: HashMap<String, StructureStruct> =
+    let structures_json: BTreeMap<String, StructureStruct> =
         serde_json::from_str(&fs::read_to_string("../assets/structures.json").unwrap())
             .expect("Failed to parse structures.json");
 
-    let structure_sets_json: HashMap<String, StructureSetStruct> =
+    let structure_sets_json: BTreeMap<String, StructureSetStruct> =
         serde_json::from_str(&fs::read_to_string("../assets/structure_set.json").unwrap())
             .expect("Failed to parse structure_set.json");
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

## Testing

drop in replacement... its only a change of ordering

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
