### PR TITLE
feat: add generate_single_chunk function for benchmarking

### DIFF
--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -74,10 +74,10 @@ harness = false
 #[[bench]]
 #name = "chunk_io"
 #harness = false
-#
-#[[bench]]
-#name = "chunk_gen"
-#harness = false
+
+[[bench]]
+name = "chunk_gen"
+harness = false
 
 [[bench]]
 name = "noise_router"

--- a/pumpkin-world/benches/chunk_gen.rs
+++ b/pumpkin-world/benches/chunk_gen.rs
@@ -1,64 +1,48 @@
-// use criterion::{Criterion, criterion_group, criterion_main};
-//
-// use pumpkin_data::BlockDirection;
-// use pumpkin_util::math::position::BlockPos;
-// use pumpkin_util::math::vector2::Vector2;
-// use std::sync::Arc;
-// use temp_dir::TempDir;
-//
-// use pumpkin_world::dimension::Dimension;
-// use pumpkin_world::generation::{Seed, get_world_gen};
-// use pumpkin_world::level::Level;
-// use pumpkin_world::world::{BlockAccessor, BlockRegistryExt};
-//
-// use rayon::prelude::*;
-//
-// struct BlockRegistry;
-//
-// impl BlockRegistryExt for BlockRegistry {
-//     fn can_place_at(
-//         &self,
-//         _block: &pumpkin_data::Block,
-//         _block_accessor: &dyn BlockAccessor,
-//         _block_pos: &BlockPos,
-//         _face: BlockDirection,
-//     ) -> bool {
-//         true
-//     }
-// }
-//
-// fn chunk_generation_seed(seed: i64) {
-//     let generator = get_world_gen(Seed(seed as u64), Dimension::Overworld);
-//     let temp_dir = TempDir::new().unwrap();
-//     let block_registry = Arc::new(BlockRegistry);
-//     let level = Arc::new(Level::from_root_folder(
-//         temp_dir.path().to_path_buf(),
-//         block_registry.clone(),
-//         seed,
-//         Dimension::Overworld,
-//     ));
-//
-//     // Prepare all positions to generate
-//     let positions: Vec<Vector2<i32>> = (0..100)
-//         .flat_map(|x| (0..10).map(move |y| Vector2::new(x, y)))
-//         .collect();
-//
-//     positions.par_iter().for_each(|position| {
-//         generator.generate_chunk(&level, block_registry.as_ref(), position);
-//     });
-// }
-//
-// fn bench_chunk_generation(c: &mut Criterion) {
-//     let seeds = [0];
-//     for seed in seeds {
-//         let name = format!("chunk generation seed {seed}");
-//         c.bench_function(&name, |b| b.iter(|| chunk_generation_seed(seed)));
-//     }
-// }
-//
-// criterion_group! {
-//     name = benches;
-//     config = Criterion::default().sample_size(10).measurement_time(std::time::Duration::from_secs(180));
-//     targets = bench_chunk_generation
-// }
-// criterion_main!(benches);
+use criterion::{Criterion, criterion_group, criterion_main};
+use pumpkin_data::dimension::Dimension;
+use pumpkin_util::world_seed::Seed;
+use pumpkin_world::biome::hash_seed;
+use pumpkin_world::chunk_system::{StagedChunkEnum, generate_single_chunk};
+use pumpkin_world::generation::get_world_gen;
+use pumpkin_world::world::BlockRegistryExt;
+use std::hint::black_box;
+use std::sync::Arc;
+
+fn bench_full_chunk_generation(c: &mut Criterion) {
+    let dimension = Dimension::OVERWORLD;
+    let seed = Seed(42);
+    let block_registry = Arc::new(BlockRegistry);
+    let world_gen = get_world_gen(seed, dimension);
+    let biome_mixer_seed = hash_seed(world_gen.random_config.seed);
+
+    c.bench_function("full_chunk_generation", |b| {
+        b.iter(|| {
+            let chunk = generate_single_chunk(
+                black_box(&dimension),
+                black_box(biome_mixer_seed),
+                black_box(&world_gen),
+                black_box(block_registry.as_ref()),
+                black_box(0),
+                black_box(0),
+                black_box(StagedChunkEnum::Full),
+            );
+            black_box(chunk);
+        });
+    });
+}
+
+struct BlockRegistry;
+impl BlockRegistryExt for BlockRegistry {
+    fn can_place_at(
+        &self,
+        _block: &pumpkin_data::Block,
+        _state: &pumpkin_data::BlockState,
+        _block_accessor: &dyn pumpkin_world::world::BlockAccessor,
+        _block_pos: &pumpkin_util::math::position::BlockPos,
+    ) -> bool {
+        true
+    }
+}
+
+criterion_group!(benches, bench_full_chunk_generation,);
+criterion_main!(benches);

--- a/pumpkin-world/src/chunk_system.rs
+++ b/pumpkin-world/src/chunk_system.rs
@@ -10,6 +10,7 @@ use crate::block::RawBlockState;
 use crate::chunk::io::LoadedData::Loaded;
 use crate::chunk::{ChunkData, ChunkHeightmapType, ChunkLight, ChunkSections};
 use crate::generation::biome_coords;
+use crate::generation::generator::VanillaGenerator;
 use pumpkin_data::block_properties::is_air;
 use pumpkin_data::chunk_gen_settings::GenerationSettings;
 use pumpkin_data::dimension::Dimension;
@@ -2186,4 +2187,65 @@ impl GenerationSchedule {
         }
         true
     }
+}
+
+pub fn generate_single_chunk(
+    dimension: &Dimension,
+    biome_mixer_seed: i64,
+    generator: &VanillaGenerator,
+    block_registry: &dyn BlockRegistryExt,
+    chunk_x: i32,
+    chunk_z: i32,
+    target_stage: StagedChunkEnum,
+) -> Chunk {
+    let settings = GenerationSettings::from_dimension(dimension);
+    let radius = target_stage.get_direct_radius();
+
+    let mut cache = Cache::new(chunk_x - radius, chunk_z - radius, radius * 2 + 1);
+
+    for dx in -radius..=radius {
+        for dz in -radius..=radius {
+            let new_x = chunk_x + dx;
+            let new_z = chunk_z + dz;
+
+            let proto_chunk = Box::new(ProtoChunk::new(
+                new_x,
+                new_z,
+                dimension,
+                generator.default_block,
+                biome_mixer_seed,
+            ));
+
+            cache.chunks.push(Chunk::Proto(proto_chunk));
+        }
+    }
+
+    let stages = [
+        StagedChunkEnum::StructureStart,
+        StagedChunkEnum::StructureReferences,
+        StagedChunkEnum::Biomes,
+        StagedChunkEnum::Noise,
+        StagedChunkEnum::Surface,
+        StagedChunkEnum::Features,
+        StagedChunkEnum::Full,
+    ];
+
+    for &stage in &stages {
+        if stage as u8 > target_stage as u8 {
+            break;
+        }
+
+        cache.advance(
+            stage,
+            block_registry,
+            settings,
+            &generator.random_config,
+            &generator.terrain_cache,
+            &generator.base_router,
+            *dimension,
+        );
+    }
+
+    let mid = ((cache.size * cache.size) >> 1) as usize;
+    cache.chunks.swap_remove(mid)
 }


### PR DESCRIPTION
## Description

Adds a function to generate a single chunk that allows for easy benchmarking of chunk generation.

## Testing

I've run `cargo bench`
