### PR TITLE
fix: water flow not spreading correctly

### DIFF
--- a/pumpkin/src/block/fluid/water.rs
+++ b/pumpkin/src/block/fluid/water.rs
@@ -84,7 +84,7 @@ impl FlowingFluid for FlowingWater {
     }
 
     fn get_max_flow_distance(&self, _world: &World) -> i32 {
-        5
+        4
     }
 
     /// Determines if water can convert to source blocks based on game rules.


### PR DESCRIPTION
## summary
- fix `get_max_flow_distance` returning 5 instead of 4, causing incorrect flow direction selection
- fix `flow_to_sides` computing fluid level from source position (`level - 1`) instead of using `getUpdatedState` for each target position, which considers all neighbors
- fix falling fluid side-spread using `(8 - drop_off).min(8)` instead of unconditionally using level 7
- update `get_spread` to return computed fluid states alongside directions, matching vanilla's `getSpread()` return structure

fixes #1459