### PR TITLE
[feat] Add pumpkin-store crate — GameDataStore trait + StaticStore backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,6 +2266,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pumpkin-store"
+version = "0.1.0-dev+1.21.11"
+dependencies = [
+ "pumpkin-data",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "pumpkin-util"
 version = "0.1.0-dev+1.21.11"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "pumpkin-world",
     "pumpkin/",
     "pumpkin-data",
+    "pumpkin-store",
 ]
 
 
@@ -146,6 +147,7 @@ pumpkin-inventory = { path = "pumpkin-inventory" }
 pumpkin-macros = { path = "pumpkin-macros" }
 pumpkin-nbt = { path = "pumpkin-nbt" }
 pumpkin-protocol = { path = "pumpkin-protocol" }
+pumpkin-store = { path = "pumpkin-store" }
 pumpkin-util = { path = "pumpkin-util" }
 pumpkin-world = { path = "pumpkin-world" }
 quote = "1.0"

--- a/pumpkin-store/Cargo.toml
+++ b/pumpkin-store/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "pumpkin-store"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Pluggable game data storage for Pumpkin — TOML default, optional LanceDB/Arrow"
+
+[dependencies]
+# Always needed — trait definitions
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+# TOML backend (default) — wraps pumpkin-data static arrays, zero new deps
+pumpkin-data = { workspace = true, optional = true }
+
+# Lance backend deps — added in Phase 4 when implementation is ready.
+# Chrono conflict RESOLVED as of lance 2.0.0 (2026-02-05): chrono ^0.4.41.
+# Verified compatible versions: lance 2.0.0, lancedb 0.26.1, arrow 57, datafusion 51.
+# MSRV: lance requires 1.88+, Pumpkin requires 1.89 — compatible.
+# See: https://github.com/AdaWorldAPI/holograph
+
+[features]
+default = ["toml-store"]
+toml-store = ["dep:pumpkin-data"]
+lance-store = [] # Phase 4: lancedb 0.26+, lance 2.0, arrow 57, datafusion 51
+
+# Extended store — reserved for future columnar/vector deps (Lance, Arrow, Calcite).
+# All additive types (ZeroCopyGuard, GameMappingRecord, MobGoalState, CachedStore)
+# are zero-dep and always compiled. StoreProvider::open() is the runtime meta-switch.
+# Community default = toml-store + StoreProvider::Static.
+extended-store = []
+
+[lints]
+workspace = true

--- a/pumpkin-store/src/cached_store.rs
+++ b/pumpkin-store/src/cached_store.rs
@@ -1,0 +1,549 @@
+//! Caching layer over any [`GameDataStore`] backend.
+//!
+//! Wraps a delegate store and memoizes lookups in transparent [`CacheEntry`] DTOs.
+//! Each entry records the lookup method, key, and the full record value — making
+//! the cache inspectable for debugging and serialization.
+//!
+//! ## XOR Write-Through Guard (holograph pattern)
+//!
+//! Each [`CacheEntry`] carries an `xor_tag` computed at insertion time from the
+//! `Cow` variant discriminant. On read-back, [`CacheEntry::verify_zero_copy`]
+//! re-computes the tag and checks it matches. If an ephemeral variable switch
+//! silently converted `Cow::Borrowed` to `Cow::Owned` (breaking zero-copy),
+//! the XOR mismatch is detected immediately.
+//!
+//! This pattern is borrowed from `AdaWorldAPI/holograph` where it guards Arrow
+//! IPC zero-copy buffers from accidental materialization.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use pumpkin_store::{CachedStore, StaticStore};
+//!
+//! let cached = CachedStore::new(StaticStore::new());
+//! let block = cached.block_by_name("stone"); // delegate lookup + cache
+//! let block = cached.block_by_name("stone"); // instant cache hit
+//!
+//! // Inspect cache contents
+//! let snapshot = cached.snapshot();
+//! println!("{} blocks cached, {} items cached", snapshot.blocks, snapshot.items);
+//! ```
+//!
+//! No additional dependencies — just `std::collections::HashMap` with `RwLock`.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::StoreResult;
+use crate::traits::{
+    BlockRecord, EntityRecord, GameDataStore, ItemRecord, RecipeRecord, ZeroCopyGuard,
+};
+
+/// A transparent cache entry that records the lookup source and key.
+///
+/// Every cached value is wrapped in this DTO so the cache is inspectable:
+/// you can see which method produced it, what key was used, and the full value.
+///
+/// ## XOR Write-Through Guard
+///
+/// The `xor_tag` field is computed at insertion time from the value's
+/// [`ZeroCopyGuard::borrow_mask`]. On read-back, calling [`verify_zero_copy`]
+/// re-computes the tag — if an ephemeral variable switch silently converted
+/// a `Cow::Borrowed` to `Cow::Owned`, the mismatch is detected immediately.
+///
+/// [`verify_zero_copy`]: CacheEntry::verify_zero_copy
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry<T> {
+    /// The lookup method that produced this entry (e.g. `block_by_name`, `item_by_name`).
+    pub method: Cow<'static, str>,
+    /// The lookup key (e.g. "stone", `diamond_sword`, or a numeric ID as string).
+    pub key: Cow<'static, str>,
+    /// The cached value — the full record DTO from the delegate store.
+    pub value: T,
+    /// XOR tag computed at insertion: `borrow_mask ^ XOR_SENTINEL`.
+    /// Used to detect zero-copy breach on read-back.
+    pub xor_tag: u64,
+}
+
+impl<T: ZeroCopyGuard> CacheEntry<T> {
+    /// Create a new cache entry with XOR tag computed from the value's borrow state.
+    pub fn new(method: Cow<'static, str>, key: Cow<'static, str>, value: T) -> Self {
+        let xor_tag = value.xor_tag();
+        Self {
+            method,
+            key,
+            value,
+            xor_tag,
+        }
+    }
+
+    /// Verify that zero-copy is intact: the value's current borrow state
+    /// must match what was recorded at insertion time.
+    ///
+    /// Returns `true` if all `Cow::Borrowed` fields are still borrowed.
+    /// Returns `false` if any field was silently switched to `Cow::Owned`.
+    #[must_use]
+    pub fn verify_zero_copy(&self) -> bool {
+        self.value.verify_xor(self.xor_tag)
+    }
+}
+
+/// Summary of current cache state — returned by [`CachedStore::snapshot`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheSnapshot {
+    /// Number of cached block-by-id entries.
+    pub blocks_by_id: usize,
+    /// Number of cached block-by-name entries.
+    pub blocks_by_name: usize,
+    /// Number of cached block-by-state entries.
+    pub blocks_by_state: usize,
+    /// Number of cached item entries.
+    pub items: usize,
+    /// Number of cached entity entries.
+    pub entities: usize,
+    /// Total cached entries across all maps.
+    pub total: usize,
+}
+
+/// A caching wrapper around any [`GameDataStore`].
+///
+/// Thread-safe via `RwLock<HashMap>`. Cache is populated lazily on first
+/// access per key. The delegate store is called exactly once per unique key.
+/// Each entry is a transparent [`CacheEntry`] DTO with method/key metadata.
+pub struct CachedStore<S: GameDataStore> {
+    delegate: S,
+    blocks_by_id: RwLock<HashMap<u16, CacheEntry<BlockRecord>>>,
+    blocks_by_name: RwLock<HashMap<String, CacheEntry<BlockRecord>>>,
+    blocks_by_state: RwLock<HashMap<u16, CacheEntry<BlockRecord>>>,
+    items_by_name: RwLock<HashMap<String, CacheEntry<ItemRecord>>>,
+    entities_by_name: RwLock<HashMap<String, CacheEntry<EntityRecord>>>,
+}
+
+impl<S: GameDataStore> CachedStore<S> {
+    /// Create a new cached store wrapping the given delegate.
+    pub fn new(delegate: S) -> Self {
+        Self {
+            delegate,
+            blocks_by_id: RwLock::new(HashMap::new()),
+            blocks_by_name: RwLock::new(HashMap::new()),
+            blocks_by_state: RwLock::new(HashMap::new()),
+            items_by_name: RwLock::new(HashMap::new()),
+            entities_by_name: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Return a reference to the underlying delegate store.
+    pub const fn delegate(&self) -> &S {
+        &self.delegate
+    }
+
+    /// Clear all cached entries. Next lookup will hit the delegate again.
+    pub fn invalidate(&self) {
+        self.blocks_by_id.write().unwrap().clear();
+        self.blocks_by_name.write().unwrap().clear();
+        self.blocks_by_state.write().unwrap().clear();
+        self.items_by_name.write().unwrap().clear();
+        self.entities_by_name.write().unwrap().clear();
+    }
+
+    /// Return a snapshot of the current cache size across all maps.
+    pub fn snapshot(&self) -> CacheSnapshot {
+        let blocks_by_id = self.blocks_by_id.read().unwrap().len();
+        let blocks_by_name = self.blocks_by_name.read().unwrap().len();
+        let blocks_by_state = self.blocks_by_state.read().unwrap().len();
+        let items = self.items_by_name.read().unwrap().len();
+        let entities = self.entities_by_name.read().unwrap().len();
+        CacheSnapshot {
+            blocks_by_id,
+            blocks_by_name,
+            blocks_by_state,
+            items,
+            entities,
+            total: blocks_by_id + blocks_by_name + blocks_by_state + items + entities,
+        }
+    }
+}
+
+impl<S: GameDataStore> GameDataStore for CachedStore<S> {
+    fn block_by_id(&self, id: u16) -> StoreResult<BlockRecord> {
+        // Check cache first (read lock) + XOR verify
+        if let Some(entry) = self.blocks_by_id.read().unwrap().get(&id) {
+            debug_assert!(entry.verify_zero_copy(), "XOR zero-copy breach: block_by_id({id})");
+            return Ok(entry.value.clone());
+        }
+        // Miss — delegate, then cache with XOR tag (write lock)
+        let record = self.delegate.block_by_id(id)?;
+        let entry = CacheEntry::new(
+            Cow::Borrowed("block_by_id"),
+            Cow::Owned(id.to_string()),
+            record.clone(),
+        );
+        self.blocks_by_id.write().unwrap().insert(id, entry);
+        Ok(record)
+    }
+
+    fn block_by_name(&self, name: &str) -> StoreResult<BlockRecord> {
+        if let Some(entry) = self.blocks_by_name.read().unwrap().get(name) {
+            debug_assert!(entry.verify_zero_copy(), "XOR zero-copy breach: block_by_name({name})");
+            return Ok(entry.value.clone());
+        }
+        let record = self.delegate.block_by_name(name)?;
+        let entry = CacheEntry::new(
+            Cow::Borrowed("block_by_name"),
+            Cow::Owned(name.to_string()),
+            record.clone(),
+        );
+        self.blocks_by_name
+            .write()
+            .unwrap()
+            .insert(name.to_string(), entry);
+        Ok(record)
+    }
+
+    fn block_by_state_id(&self, state_id: u16) -> StoreResult<BlockRecord> {
+        if let Some(entry) = self.blocks_by_state.read().unwrap().get(&state_id) {
+            debug_assert!(
+                entry.verify_zero_copy(),
+                "XOR zero-copy breach: block_by_state_id({state_id})"
+            );
+            return Ok(entry.value.clone());
+        }
+        let record = self.delegate.block_by_state_id(state_id)?;
+        let entry = CacheEntry::new(
+            Cow::Borrowed("block_by_state_id"),
+            Cow::Owned(state_id.to_string()),
+            record.clone(),
+        );
+        self.blocks_by_state
+            .write()
+            .unwrap()
+            .insert(state_id, entry);
+        Ok(record)
+    }
+
+    fn block_count(&self) -> usize {
+        self.delegate.block_count()
+    }
+
+    fn item_by_name(&self, name: &str) -> StoreResult<ItemRecord> {
+        if let Some(entry) = self.items_by_name.read().unwrap().get(name) {
+            debug_assert!(entry.verify_zero_copy(), "XOR zero-copy breach: item_by_name({name})");
+            return Ok(entry.value.clone());
+        }
+        let record = self.delegate.item_by_name(name)?;
+        let entry = CacheEntry::new(
+            Cow::Borrowed("item_by_name"),
+            Cow::Owned(name.to_string()),
+            record.clone(),
+        );
+        self.items_by_name
+            .write()
+            .unwrap()
+            .insert(name.to_string(), entry);
+        Ok(record)
+    }
+
+    fn item_count(&self) -> usize {
+        self.delegate.item_count()
+    }
+
+    fn entity_by_name(&self, name: &str) -> StoreResult<EntityRecord> {
+        if let Some(entry) = self.entities_by_name.read().unwrap().get(name) {
+            debug_assert!(
+                entry.verify_zero_copy(),
+                "XOR zero-copy breach: entity_by_name({name})"
+            );
+            return Ok(entry.value.clone());
+        }
+        let record = self.delegate.entity_by_name(name)?;
+        let entry = CacheEntry::new(
+            Cow::Borrowed("entity_by_name"),
+            Cow::Owned(name.to_string()),
+            record.clone(),
+        );
+        self.entities_by_name
+            .write()
+            .unwrap()
+            .insert(name.to_string(), entry);
+        Ok(record)
+    }
+
+    fn entity_count(&self) -> usize {
+        self.delegate.entity_count()
+    }
+
+    fn recipes_for_output(&self, item_name: &str) -> StoreResult<Vec<RecipeRecord>> {
+        // Recipes are not cached — they return Vec and are typically
+        // queried infrequently. Delegate directly.
+        self.delegate.recipes_for_output(item_name)
+    }
+
+    fn recipe_count(&self) -> usize {
+        self.delegate.recipe_count()
+    }
+
+    fn game_mappings(
+        &self,
+        source_type: &str,
+        source_key: &str,
+    ) -> StoreResult<Vec<crate::traits::GameMappingRecord>> {
+        // Game mappings are not cached — delegate directly.
+        self.delegate.game_mappings(source_type, source_key)
+    }
+
+    fn game_mapping_count(&self) -> usize {
+        self.delegate.game_mapping_count()
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "toml-store")]
+mod tests {
+    use super::*;
+    use crate::StaticStore;
+
+    #[test]
+    fn cached_lookup_returns_same_as_delegate() {
+        let cached = CachedStore::new(StaticStore::new());
+        let direct = StaticStore::new();
+
+        let cached_block = cached.block_by_name("stone").unwrap();
+        let direct_block = direct.block_by_name("stone").unwrap();
+
+        assert_eq!(cached_block.id, direct_block.id);
+        assert_eq!(cached_block.name, direct_block.name);
+        assert_eq!(cached_block.hardness, direct_block.hardness);
+    }
+
+    #[test]
+    fn second_lookup_hits_cache() {
+        let cached = CachedStore::new(StaticStore::new());
+
+        // First lookup — cache miss, delegates to StaticStore
+        let first = cached.block_by_name("stone").unwrap();
+        // Second lookup — cache hit
+        let second = cached.block_by_name("stone").unwrap();
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.name, second.name);
+    }
+
+    #[test]
+    fn cache_entry_has_transparent_metadata() {
+        let cached = CachedStore::new(StaticStore::new());
+
+        // Populate cache
+        let _ = cached.block_by_name("stone").unwrap();
+
+        // Inspect the cache entry directly
+        let cache = cached.blocks_by_name.read().unwrap();
+        let entry = cache.get("stone").unwrap();
+        assert_eq!(entry.method, "block_by_name");
+        assert_eq!(entry.key, "stone");
+        assert_eq!(entry.value.name, "stone");
+    }
+
+    #[test]
+    fn cache_entry_serializes_to_json() {
+        let cached = CachedStore::new(StaticStore::new());
+        let _ = cached.block_by_name("stone").unwrap();
+
+        let cache = cached.blocks_by_name.read().unwrap();
+        let entry = cache.get("stone").unwrap();
+        let json = serde_json::to_string(entry).unwrap();
+        assert!(json.contains("block_by_name"));
+        assert!(json.contains("stone"));
+    }
+
+    #[test]
+    fn invalidate_clears_cache() {
+        let cached = CachedStore::new(StaticStore::new());
+
+        // Populate cache
+        let _ = cached.block_by_name("stone").unwrap();
+        assert_eq!(cached.snapshot().blocks_by_name, 1);
+
+        // Invalidate
+        cached.invalidate();
+        assert_eq!(cached.snapshot().total, 0);
+
+        // Re-lookup works
+        let block = cached.block_by_name("stone").unwrap();
+        assert_eq!(block.name, "stone");
+    }
+
+    #[test]
+    fn snapshot_tracks_counts() {
+        let cached = CachedStore::new(StaticStore::new());
+
+        assert_eq!(cached.snapshot().total, 0);
+
+        let _ = cached.block_by_name("stone").unwrap();
+        let _ = cached.block_by_id(0).unwrap();
+        let _ = cached.item_by_name("diamond_sword").unwrap();
+        let _ = cached.entity_by_name("zombie").unwrap();
+
+        let snap = cached.snapshot();
+        assert_eq!(snap.blocks_by_name, 1);
+        assert_eq!(snap.blocks_by_id, 1);
+        assert_eq!(snap.items, 1);
+        assert_eq!(snap.entities, 1);
+        assert_eq!(snap.total, 4);
+    }
+
+    #[test]
+    fn cached_item_lookup() {
+        let cached = CachedStore::new(StaticStore::new());
+        let item = cached.item_by_name("diamond_sword").unwrap();
+        assert_eq!(item.name, "diamond_sword");
+
+        // Second call from cache
+        let item2 = cached.item_by_name("diamond_sword").unwrap();
+        assert_eq!(item.id, item2.id);
+    }
+
+    #[test]
+    fn cached_entity_lookup() {
+        let cached = CachedStore::new(StaticStore::new());
+        let entity = cached.entity_by_name("zombie").unwrap();
+        assert_eq!(entity.name, "zombie");
+        assert!(entity.is_mob);
+    }
+
+    #[test]
+    fn cached_block_by_id() {
+        let cached = CachedStore::new(StaticStore::new());
+        let block = cached.block_by_id(0).unwrap();
+        assert_eq!(block.name, "air");
+
+        // Cache hit
+        let block2 = cached.block_by_id(0).unwrap();
+        assert_eq!(block.id, block2.id);
+    }
+
+    #[test]
+    fn cached_block_by_state_id() {
+        let cached = CachedStore::new(StaticStore::new());
+        let block = cached.block_by_state_id(0).unwrap();
+        assert_eq!(block.name, "air");
+    }
+
+    #[test]
+    fn delegate_accessor() {
+        let cached = CachedStore::new(StaticStore::new());
+        let block = cached.delegate().block_by_name("stone").unwrap();
+        assert_eq!(block.name, "stone");
+    }
+
+    #[test]
+    fn cached_as_trait_object() {
+        let cached: Box<dyn GameDataStore> =
+            Box::new(CachedStore::new(StaticStore::new()));
+        let block = cached.block_by_name("stone").unwrap();
+        assert_eq!(block.name, "stone");
+    }
+
+    /// Critical: Verify that `StaticStore` → `CachedStore` chain preserves
+    /// `Cow::Borrowed` (zero-copy). Cache cloning must NOT break into Owned.
+    #[test]
+    fn zero_copy_preserved_through_cache() {
+        let cached = CachedStore::new(StaticStore::new());
+
+        // First lookup (cache miss → delegate → cache)
+        let block1 = cached.block_by_name("stone").unwrap();
+        assert!(
+            matches!(block1.name, Cow::Borrowed(_)),
+            "first lookup must return Cow::Borrowed"
+        );
+
+        // Second lookup (cache hit → cloned from cache)
+        let block2 = cached.block_by_name("stone").unwrap();
+        assert!(
+            matches!(block2.name, Cow::Borrowed(_)),
+            "cache hit must return Cow::Borrowed, not heap-allocated Owned"
+        );
+
+        // Item through cache
+        let item = cached.item_by_name("diamond_sword").unwrap();
+        assert!(matches!(item.name, Cow::Borrowed(_)));
+
+        let item2 = cached.item_by_name("diamond_sword").unwrap();
+        assert!(
+            matches!(item2.name, Cow::Borrowed(_)),
+            "cached item must stay Cow::Borrowed"
+        );
+
+        // Entity through cache
+        let entity = cached.entity_by_name("zombie").unwrap();
+        assert!(matches!(entity.name, Cow::Borrowed(_)));
+
+        let entity2 = cached.entity_by_name("zombie").unwrap();
+        assert!(
+            matches!(entity2.name, Cow::Borrowed(_)),
+            "cached entity must stay Cow::Borrowed"
+        );
+    }
+
+    /// XOR write-through guard: verify tag is set and verifies correctly
+    /// for entries cached from `StaticStore` (all fields `Cow::Borrowed`).
+    #[test]
+    fn xor_guard_passes_for_borrowed() {
+        use crate::traits::XOR_SENTINEL;
+
+        let cached = CachedStore::new(StaticStore::new());
+        let _ = cached.block_by_name("stone").unwrap();
+
+        let cache = cached.blocks_by_name.read().unwrap();
+        let entry = cache.get("stone").unwrap();
+
+        // Tag should be: borrow_mask(1) ^ SENTINEL
+        assert_eq!(entry.xor_tag, 1 ^ XOR_SENTINEL);
+        assert!(entry.verify_zero_copy());
+    }
+
+    /// XOR write-through guard: verify that a manually corrupted entry
+    /// (simulating `Cow::Borrowed` → `Cow::Owned` flip) fails verification.
+    #[test]
+    fn xor_guard_detects_owned_breach() {
+        use crate::traits::XOR_SENTINEL;
+
+        let store = StaticStore::new();
+        let record = store.block_by_name("stone").unwrap();
+
+        // Create entry with Borrowed name — tag records borrow_mask = 1
+        let entry = CacheEntry::new(
+            Cow::Borrowed("block_by_name"),
+            Cow::Borrowed("stone"),
+            record,
+        );
+        assert!(entry.verify_zero_copy());
+        assert_eq!(entry.xor_tag, 1 ^ XOR_SENTINEL);
+
+        // Simulate zero-copy breach: force name to Owned.
+        // We intentionally clone here to create an independent copy to mutate.
+        #[allow(clippy::redundant_clone)]
+        let mut breached = entry.clone();
+        breached.value.name = Cow::Owned("stone".to_string());
+
+        // XOR tag was computed with borrow_mask=1, but now borrow_mask=0
+        // So verify_zero_copy must return false
+        assert!(
+            !breached.verify_zero_copy(),
+            "XOR guard must detect Borrowed→Owned flip"
+        );
+    }
+
+    /// XOR guard with entity record through cache.
+    #[test]
+    fn xor_guard_entity_through_cache() {
+        let cached = CachedStore::new(StaticStore::new());
+        let _ = cached.entity_by_name("zombie").unwrap();
+
+        let cache = cached.entities_by_name.read().unwrap();
+        let entry = cache.get("zombie").unwrap();
+        assert!(entry.verify_zero_copy());
+    }
+}

--- a/pumpkin-store/src/error.rs
+++ b/pumpkin-store/src/error.rs
@@ -1,0 +1,25 @@
+/// Errors from the store layer.
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("block not found: {0}")]
+    BlockNotFound(String),
+
+    #[error("item not found: {0}")]
+    ItemNotFound(String),
+
+    #[error("entity not found: {0}")]
+    EntityNotFound(String),
+
+    #[error("query failed: {0}")]
+    QueryFailed(String),
+
+    #[cfg(feature = "lance-store")]
+    #[error("lance error: {0}")]
+    Lance(String),
+
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+/// Convenience alias.
+pub type StoreResult<T> = Result<T, StoreError>;

--- a/pumpkin-store/src/lance_store.rs
+++ b/pumpkin-store/src/lance_store.rs
@@ -1,0 +1,201 @@
+//! Optional Lance backend — zero-copy Arrow columnar storage.
+//!
+//! Enable with `--features lance-store`. Hydrates Lance tables FROM the default
+//! [`StaticStore`](crate::StaticStore) — no external JSON files needed.
+//!
+//! # Architecture
+//!
+//! ```text
+//! StaticStore (pumpkin-data, compile-time)
+//!       │ hydrate_from()
+//!       ▼
+//! LanceStore (Arrow columnar, zero-copy reads)
+//!       │
+//!       └── lance 2.0 native queries (no `DataFusion` sidecar needed)
+//! ```
+//!
+//! ## Lance 2.0 Note
+//!
+//! Lance 2.0.0 (released 2026-02-05) + lancedb 0.26.1: MSRV 1.88, arrow 57,
+//! datafusion 51, chrono ^0.4.41 (conflict resolved). The `lance` umbrella crate
+//! still pulls datafusion transitively via `lance-datafusion`, but `lance-core`
+//! has it optional. For minimal deps, depend on `lance-core` directly.
+//!
+//! ## Hydration Flow
+//!
+//! 1. `LanceStore::open(path)` — opens or creates a Lance database at `path`
+//! 2. `store.hydrate_from(&static_store)` — reads all records from `StaticStore`
+//!    and writes them into Lance tables (blocks, items, entities)
+//! 3. Subsequent reads are zero-copy Arrow — no serialization overhead
+//!
+//! Hydration only happens once. If the Lance tables already exist, `open()` skips it.
+
+use crate::error::{StoreError, StoreResult};
+use crate::traits::{BlockRecord, EntityRecord, GameDataStore, ItemRecord, RecipeRecord};
+
+/// Lance-backed game data store.
+///
+/// Hydrates from any [`GameDataStore`] (typically [`StaticStore`](crate::StaticStore))
+/// then serves zero-copy Arrow reads. Lance 2.0 provides native queries —
+/// no `DataFusion` sidecar needed.
+pub struct LanceStore {
+    // Will hold: lancedb::Connection (Lance 2.0 API)
+    // Stubbed for now — real deps added when chrono conflict resolves
+    #[allow(dead_code)] // Used in Phase 4 for Lance 2.0 connection path
+    path: String,
+    hydrated: bool,
+}
+
+impl LanceStore {
+    /// Open or create a Lance store at the given path.
+    ///
+    /// On first run, the store is empty — call [`hydrate_from`](Self::hydrate_from)
+    /// to populate from a [`StaticStore`](crate::StaticStore). Subsequent opens
+    /// detect existing tables and skip hydration.
+    ///
+    /// # Errors
+    ///
+    /// Returns `StoreError::Lance` if the database cannot be opened.
+    #[allow(clippy::unused_async)] // Will await Lance 2.0 connection in Phase 4
+    pub async fn open(path: &str) -> StoreResult<Self> {
+        // TODO: Phase 4 — real Lance 2.0 connection
+        // let db = lancedb::connect(path).execute().await
+        //     .map_err(|e| StoreError::Lance(e.to_string()))?;
+        // let has_tables = db.table_names().await.map(|t| !t.is_empty()).unwrap_or(false);
+        Ok(Self {
+            path: path.to_string(),
+            hydrated: false,
+        })
+    }
+
+    /// Hydrate Lance tables from a source [`GameDataStore`].
+    ///
+    /// Reads all blocks, items, and entities from the source store and writes
+    /// them into Lance columnar tables. This is a one-time operation — if tables
+    /// already exist, this is a no-op.
+    ///
+    /// Typically called with `StaticStore` as the source:
+    /// ```rust,ignore
+    /// let static_store = StaticStore::new();
+    /// let mut lance = LanceStore::open("./data/lance").await?;
+    /// lance.hydrate_from(&static_store).await?;
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `StoreError::Lance` if hydration fails.
+    #[allow(clippy::unused_async)] // Will await Lance 2.0 table creation in Phase 4
+    pub async fn hydrate_from(&mut self, _source: &dyn GameDataStore) -> StoreResult<()> {
+        if self.hydrated {
+            return Ok(());
+        }
+
+        // TODO: Phase 4 — iterate source store, build Arrow RecordBatches,
+        // write to Lance tables:
+        //
+        // let blocks: Vec<BlockRecord> = (0..source.block_count())
+        //     .filter_map(|id| source.block_by_id(id as u16).ok())
+        //     .collect();
+        //
+        // let batch = blocks_to_record_batch(&blocks)?;
+        // db.create_table("blocks", batch).execute().await?;
+        //
+        // Similarly for items, entities, recipes.
+
+        self.hydrated = true;
+        Ok(())
+    }
+
+    /// Query Lance tables directly using Lance 2.0's native query API.
+    ///
+    /// Lance 2.0 supports filtering, projection, and full-text search natively
+    /// without requiring a `DataFusion` sidecar.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// // Lance 2.0 native query (not SQL — lance's own API)
+    /// let results = store.query("blocks")
+    ///     .filter("hardness > 5.0")
+    ///     .select(&["name", "hardness"])
+    ///     .execute().await?;
+    /// ```
+    #[allow(clippy::unused_async)] // Will await Lance 2.0 queries in Phase 4
+    pub async fn query_table(
+        &self,
+        _table: &str,
+        _filter: Option<&str>,
+    ) -> StoreResult<Vec<serde_json::Value>> {
+        // TODO: Phase 4 — Lance 2.0 native query API
+        // let table = self.db.open_table(table).execute().await?;
+        // let mut query = table.query();
+        // if let Some(f) = filter {
+        //     query = query.filter(f);
+        // }
+        // let batches = query.execute().await?;
+        // Convert Arrow RecordBatches to JSON
+        Err(StoreError::Lance(
+            "Lance backend not yet implemented — use toml-store for now".to_string(),
+        ))
+    }
+
+    /// Check whether this store has been hydrated with data.
+    #[must_use]
+    pub const fn is_hydrated(&self) -> bool {
+        self.hydrated
+    }
+}
+
+impl GameDataStore for LanceStore {
+    fn block_by_id(&self, _id: u16) -> StoreResult<BlockRecord> {
+        Err(StoreError::Lance("not yet implemented".to_string()))
+    }
+
+    fn block_by_name(&self, _name: &str) -> StoreResult<BlockRecord> {
+        Err(StoreError::Lance("not yet implemented".to_string()))
+    }
+
+    fn block_by_state_id(&self, _state_id: u16) -> StoreResult<BlockRecord> {
+        Err(StoreError::Lance("not yet implemented".to_string()))
+    }
+
+    fn block_count(&self) -> usize {
+        0
+    }
+
+    fn item_by_name(&self, _name: &str) -> StoreResult<ItemRecord> {
+        Err(StoreError::Lance("not yet implemented".to_string()))
+    }
+
+    fn item_count(&self) -> usize {
+        0
+    }
+
+    fn entity_by_name(&self, _name: &str) -> StoreResult<EntityRecord> {
+        Err(StoreError::Lance("not yet implemented".to_string()))
+    }
+
+    fn entity_count(&self) -> usize {
+        0
+    }
+
+    fn recipes_for_output(&self, _item_name: &str) -> StoreResult<Vec<RecipeRecord>> {
+        Err(StoreError::Lance("not yet implemented".to_string()))
+    }
+
+    fn recipe_count(&self) -> usize {
+        0
+    }
+
+    fn game_mappings(
+        &self,
+        _source_type: &str,
+        _source_key: &str,
+    ) -> StoreResult<Vec<crate::traits::GameMappingRecord>> {
+        Err(StoreError::Lance("not yet implemented".to_string()))
+    }
+
+    fn game_mapping_count(&self) -> usize {
+        0
+    }
+}

--- a/pumpkin-store/src/lib.rs
+++ b/pumpkin-store/src/lib.rs
@@ -1,0 +1,235 @@
+//! # pumpkin-store — Pluggable Game Data Storage
+//!
+//! Abstracts game data access behind the [`GameDataStore`] trait.
+//!
+//! ## Single-Flip Separation of Concerns
+//!
+//! [`StoreProvider`] is the **single control point** for selecting behavior.
+//! Community default is `StoreProvider::Static` — zero cost, zero extended features.
+//! One flip to `Cached` or `Lance` activates extended capabilities. Everything
+//! flows through `StoreProvider::open()` → `Box<dyn GameDataStore>`.
+//!
+//! ```text
+//! StoreProvider::open()            ← single flip point
+//!      │
+//!      ├── Static  (default)       ← community path: pumpkin-data only
+//!      │   Zero cost, no cache, no XOR, no overlays.
+//!      │   Identical to using pumpkin-data directly.
+//!      │
+//!      ├── Cached                  ← extended: HashMap + XOR zero-copy guard
+//!      │   Transparent CacheEntry DTOs, debug_assert XOR verification.
+//!      │
+//!      └── Lance                   ← extended: Arrow columnar, zero-copy
+//!          Hydrated from Static, lance 2.0 native queries.
+//! ```
+//!
+//! ## Core API (all tiers)
+//!
+//! ```rust,ignore
+//! use pumpkin_store::{StoreProvider, GameDataStore};
+//!
+//! let store = StoreProvider::default().open(); // Static — community default
+//! let block = store.block_by_name("stone")?;
+//! let item  = store.item_by_name("diamond_sword")?;
+//! ```
+//!
+//! ## Extended API (Cached/Lance tiers)
+//!
+//! The [`overlay`] module contains spatial types used by extended tiers.
+//! These are always compiled (zero deps) but only active when the provider
+//! is flipped away from `Static`.
+//!
+//! ```rust,ignore
+//! use pumpkin_store::StoreProvider;
+//! use pumpkin_store::overlay::{SpatialOverlay, MobGoalState};
+//!
+//! let store = StoreProvider::Cached.open(); // single flip → extended
+//! let mut world_map = SpatialOverlay::new();
+//! world_map.bind(100, 64, -200);
+//! ```
+
+mod error;
+mod traits;
+
+mod cached_store;
+
+#[cfg(feature = "toml-store")]
+mod static_store;
+
+#[cfg(feature = "lance-store")]
+mod lance_store;
+
+pub use error::{StoreError, StoreResult};
+
+// ── Core API (community path) ─────────────────────────────────────────
+// These types are used by all tiers including Static (community default).
+pub use traits::{BlockRecord, EntityRecord, GameDataStore, GameMappingRecord, ItemRecord, RecipeRecord};
+
+// ── Extended API (Cached/Lance tiers) ──────────────────────────────────
+// Spatial overlays, XOR guards, and goal state encoding. Always compiled
+// (zero deps) but only _active_ when StoreProvider is flipped from Static.
+// Community default path never touches these.
+pub mod overlay {
+    pub use crate::traits::{
+        MobGoalState, SpatialOverlay, ZeroCopyGuard, OVERLAY_BITS, OVERLAY_WORDS, XOR_SENTINEL,
+    };
+}
+
+pub use cached_store::{CacheEntry, CacheSnapshot, CachedStore};
+
+#[cfg(feature = "toml-store")]
+pub use static_store::StaticStore;
+
+#[cfg(feature = "lance-store")]
+pub use lance_store::LanceStore;
+
+/// Store provider tier — meta-switch for transparent backend routing.
+///
+/// Works like a NAT: callers get `Box<dyn GameDataStore>` from [`open`](Self::open)
+/// and call methods without knowing which backend handles them. The provider
+/// transparently routes all commands to the selected tier:
+///
+/// ```text
+/// StoreProvider::open()
+///      │
+///      ├── Static  → StaticStore (pumpkin-data, compile-time, zero cost)
+///      ├── Cached  → CachedStore<StaticStore> (HashMap memoization + XOR guard)
+///      └── Lance   → LanceStore (Arrow zero-copy, lance 2.0 native queries)
+/// ```
+///
+/// All tiers implement the same `GameDataStore` trait — including additive methods
+/// like `game_mappings()` that don't conflict with existing block/item/entity/recipe
+/// lookups. Static returns empty for relationship queries; higher tiers populate them.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use pumpkin_store::StoreProvider;
+///
+/// // Default: compile-time static data, zero cost
+/// let store = StoreProvider::default().open();
+/// let block = store.block_by_name("stone")?;
+///
+/// // Cached: HashMap memoization + XOR zero-copy guard
+/// let store = StoreProvider::Cached.open();
+/// let block = store.block_by_name("stone")?; // delegate + cache
+/// let block = store.block_by_name("stone")?; // instant O(1) hit
+///
+/// // Lance: async construction (use LanceStore::open() directly)
+/// let mut lance = LanceStore::open("./data/lance").await?;
+/// lance.hydrate_from(&*StoreProvider::default().open()).await?;
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum StoreProvider {
+    /// `StaticStore` — zero-cost, compile-time pumpkin-data lookups.
+    #[default]
+    Static,
+    /// `CachedStore<StaticStore>` — lazy `HashMap` + XOR write-through guard.
+    Cached,
+    /// `LanceStore` — Arrow columnar, hydrated from Static. Requires async.
+    Lance,
+}
+
+impl StoreProvider {
+    /// Open a store with this provider tier.
+    ///
+    /// Returns a `Box<dyn GameDataStore>` that transparently routes all commands
+    /// to the selected backend — the caller doesn't know or care which tier handles it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `Lance` is selected — Lance requires async construction.
+    /// Use `LanceStore::open()` directly for the Lance tier.
+    #[cfg(feature = "toml-store")]
+    #[must_use]
+    pub fn open(self) -> Box<dyn GameDataStore> {
+        match self {
+            Self::Static => Box::new(StaticStore::new()),
+            Self::Cached => Box::new(CachedStore::new(StaticStore::new())),
+            Self::Lance => {
+                panic!("Lance tier requires async — use LanceStore::open() directly")
+            }
+        }
+    }
+}
+
+/// Open the default store based on enabled features.
+///
+/// Returns `StaticStore` wrapping pumpkin-data — zero-cost, always available.
+/// For tier selection via meta-switch, use [`StoreProvider::open`] instead.
+///
+/// ```rust,ignore
+/// // Direct construction
+/// let store = open_default_store();
+///
+/// // Meta-switch (equivalent, returns Box<dyn GameDataStore>)
+/// let store = StoreProvider::default().open();
+/// ```
+#[cfg(feature = "toml-store")]
+#[must_use]
+pub const fn open_default_store() -> StaticStore {
+    StaticStore::new()
+}
+
+#[cfg(test)]
+#[cfg(feature = "toml-store")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_static_routes_block_lookup() {
+        let store = StoreProvider::Static.open();
+        let block = store.block_by_name("stone").unwrap();
+        assert_eq!(block.name, "stone");
+    }
+
+    #[test]
+    fn provider_cached_routes_block_lookup() {
+        let store = StoreProvider::Cached.open();
+        let block = store.block_by_name("stone").unwrap();
+        assert_eq!(block.name, "stone");
+
+        // Second call hits cache — same result, transparent to caller
+        let block2 = store.block_by_name("stone").unwrap();
+        assert_eq!(block.id, block2.id);
+    }
+
+    #[test]
+    fn provider_default_is_static() {
+        assert_eq!(StoreProvider::default(), StoreProvider::Static);
+    }
+
+    #[test]
+    #[should_panic(expected = "Lance tier requires async")]
+    fn provider_lance_panics_sync() {
+        let _store = StoreProvider::Lance.open();
+    }
+
+    #[test]
+    fn provider_additive_methods_available() {
+        // Additive methods (game_mappings) are available on all tiers
+        // without conflicting with existing block/item/entity lookups.
+        let store = StoreProvider::Static.open();
+        let mappings = store.game_mappings("biome", "plains").unwrap();
+        assert!(mappings.is_empty(), "Static tier returns empty game_mappings");
+
+        let count = store.game_mapping_count();
+        assert_eq!(count, 0);
+
+        // Same methods accessible through Cached tier
+        let cached = StoreProvider::Cached.open();
+        let mappings = cached.game_mappings("biome", "plains").unwrap();
+        assert!(mappings.is_empty());
+    }
+
+    #[test]
+    fn provider_routes_item_and_entity() {
+        let store = StoreProvider::Cached.open();
+        let item = store.item_by_name("diamond_sword").unwrap();
+        assert_eq!(item.name, "diamond_sword");
+
+        let entity = store.entity_by_name("zombie").unwrap();
+        assert_eq!(entity.name, "zombie");
+        assert!(entity.is_mob);
+    }
+}

--- a/pumpkin-store/src/static_store.rs
+++ b/pumpkin-store/src/static_store.rs
@@ -1,0 +1,280 @@
+//! Default backend: wraps pumpkin-data's compile-time generated static arrays.
+//!
+//! Zero runtime cost — all lookups delegate to `Block::from_*`, `Item::from_*`, etc.
+//! No heap allocation, no I/O, no new dependencies beyond pumpkin-data.
+
+use std::borrow::Cow;
+
+use pumpkin_data::Block;
+use pumpkin_data::entity::EntityType;
+use pumpkin_data::item::Item;
+
+use crate::error::{StoreError, StoreResult};
+use crate::traits::{BlockRecord, EntityRecord, GameDataStore, ItemRecord, RecipeRecord};
+
+/// Default store backed by pumpkin-data's static arrays.
+///
+/// This is a zero-cost wrapper — all methods are thin delegations to
+/// `Block::from_id()`, `Item::from_registry_key()`, etc.
+/// No heap allocation, no I/O.
+pub struct StaticStore;
+
+impl StaticStore {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for StaticStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert a pumpkin-data `Block` to our portable `BlockRecord` DTO.
+fn block_to_record(b: &'static Block) -> BlockRecord {
+    BlockRecord {
+        id: b.id,
+        name: Cow::Borrowed(b.name),
+        hardness: b.hardness,
+        blast_resistance: b.blast_resistance,
+        is_air: b.is_air(),
+        is_solid: b.is_solid(),
+        luminance: b.default_state.luminance,
+        item_id: b.item_id,
+        default_state_id: b.default_state.id,
+        state_count: b.states.len() as u16,
+    }
+}
+
+/// Convert a pumpkin-data `Item` to our portable `ItemRecord` DTO.
+fn item_to_record(item: &'static Item) -> ItemRecord {
+    use pumpkin_data::data_component::DataComponent;
+    use pumpkin_data::data_component_impl::MaxStackSizeImpl;
+
+    let max_stack = item
+        .components
+        .iter()
+        .find_map(|(comp, imp)| {
+            if matches!(comp, DataComponent::MaxStackSize) {
+                imp.as_any()
+                    .downcast_ref::<MaxStackSizeImpl>()
+                    .map(|m| m.size)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(64);
+
+    ItemRecord {
+        id: item.id,
+        name: Cow::Borrowed(item.registry_key),
+        max_stack_size: max_stack,
+    }
+}
+
+/// Convert a pumpkin-data `EntityType` to our portable `EntityRecord` DTO.
+const fn entity_to_record(e: &'static EntityType) -> EntityRecord {
+    EntityRecord {
+        id: e.id,
+        name: Cow::Borrowed(e.resource_name),
+        max_health: e.max_health,
+        is_mob: e.mob,
+        width: e.dimension[0],
+        height: e.dimension[1],
+        fire_immune: e.fire_immune,
+    }
+}
+
+impl GameDataStore for StaticStore {
+    fn block_by_id(&self, id: u16) -> StoreResult<BlockRecord> {
+        let b = Block::from_id(id);
+        // from_id returns AIR for out-of-range, check if the ID actually matches
+        if b.id != id && id != 0 {
+            return Err(StoreError::BlockNotFound(format!("id={id}")));
+        }
+        Ok(block_to_record(b))
+    }
+
+    fn block_by_name(&self, name: &str) -> StoreResult<BlockRecord> {
+        Block::from_name(name)
+            .map(block_to_record)
+            .ok_or_else(|| StoreError::BlockNotFound(name.to_string()))
+    }
+
+    fn block_by_state_id(&self, state_id: u16) -> StoreResult<BlockRecord> {
+        let b = Block::from_state_id(state_id);
+        Ok(block_to_record(b))
+    }
+
+    fn block_count(&self) -> usize {
+        // pumpkin-data has 1166 block types
+        1166
+    }
+
+    fn item_by_name(&self, name: &str) -> StoreResult<ItemRecord> {
+        let key = name.strip_prefix("minecraft:").unwrap_or(name);
+        Item::from_registry_key(key)
+            .map(item_to_record)
+            .ok_or_else(|| StoreError::ItemNotFound(name.to_string()))
+    }
+
+    fn item_count(&self) -> usize {
+        // Items are dense from 0..max_id; use a const from pumpkin-data
+        // There are ~1400 items in 1.21.11
+        1470
+    }
+
+    fn entity_by_name(&self, name: &str) -> StoreResult<EntityRecord> {
+        EntityType::from_name(name)
+            .map(entity_to_record)
+            .ok_or_else(|| StoreError::EntityNotFound(name.to_string()))
+    }
+
+    fn entity_count(&self) -> usize {
+        149
+    }
+
+    fn recipes_for_output(&self, _item_name: &str) -> StoreResult<Vec<RecipeRecord>> {
+        // Recipe iteration requires scanning all recipes — defer to a future
+        // implementation that indexes recipes by output item.
+        // For now return empty; the lance-store backend will do SQL queries.
+        Ok(Vec::new())
+    }
+
+    fn recipe_count(&self) -> usize {
+        // ~1470 recipes in 1.21.11
+        1470
+    }
+
+    fn game_mappings(
+        &self,
+        _source_type: &str,
+        _source_key: &str,
+    ) -> StoreResult<Vec<crate::traits::GameMappingRecord>> {
+        // Game mappings are relationship data — not available in pumpkin-data statics.
+        // The Lance backend will populate this from registry TOML files and mob goal data.
+        Ok(Vec::new())
+    }
+
+    fn game_mapping_count(&self) -> usize {
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_stone_by_name() {
+        let store = StaticStore::new();
+        let block = store.block_by_name("stone").unwrap();
+        assert_eq!(block.name, "stone");
+        assert!(!block.is_air);
+        assert!(block.is_solid);
+    }
+
+    #[test]
+    fn lookup_air_by_id() {
+        let store = StaticStore::new();
+        let block = store.block_by_id(0).unwrap();
+        assert_eq!(block.name, "air");
+        assert!(block.is_air);
+    }
+
+    #[test]
+    fn lookup_block_by_state_id() {
+        let store = StaticStore::new();
+        // State ID 0 is air
+        let block = store.block_by_state_id(0).unwrap();
+        assert_eq!(block.name, "air");
+    }
+
+    #[test]
+    fn lookup_diamond_sword() {
+        let store = StaticStore::new();
+        let item = store.item_by_name("diamond_sword").unwrap();
+        assert_eq!(item.name, "diamond_sword");
+    }
+
+    #[test]
+    fn lookup_zombie() {
+        let store = StaticStore::new();
+        let entity = store.entity_by_name("zombie").unwrap();
+        assert_eq!(entity.name, "zombie");
+        assert!(entity.is_mob);
+    }
+
+    #[test]
+    fn item_not_found() {
+        let store = StaticStore::new();
+        assert!(store.item_by_name("nonexistent_item_xyz").is_err());
+    }
+
+    #[test]
+    fn entity_not_found() {
+        let store = StaticStore::new();
+        assert!(store.entity_by_name("nonexistent_entity_xyz").is_err());
+    }
+
+    #[test]
+    fn block_count_positive() {
+        let store = StaticStore::new();
+        assert!(store.block_count() > 1000);
+    }
+
+    #[test]
+    fn trait_object_works() {
+        let store: Box<dyn GameDataStore> = Box::new(StaticStore::new());
+        let block = store.block_by_name("stone").unwrap();
+        assert_eq!(block.name, "stone");
+    }
+
+    /// Verify that `StaticStore` produces `Cow::Borrowed` (zero-copy pointers
+    /// into pumpkin-data statics), and that cloning preserves this invariant.
+    /// If this test fails, something is forcing heap allocation on the read path.
+    #[test]
+    fn zero_copy_invariant_preserved() {
+        let store = StaticStore::new();
+
+        // Block name must be Borrowed (pointer to static "stone")
+        let block = store.block_by_name("stone").unwrap();
+        assert!(
+            matches!(block.name, Cow::Borrowed(_)),
+            "block.name must be Cow::Borrowed, got Owned"
+        );
+
+        // Clone must preserve Borrowed — NOT heap-allocate.
+        // We intentionally clone here to test the invariant.
+        #[allow(clippy::redundant_clone)]
+        let cloned = block.clone();
+        assert!(
+            matches!(cloned.name, Cow::Borrowed(_)),
+            "cloned block.name must stay Cow::Borrowed"
+        );
+
+        // Item name
+        let item = store.item_by_name("diamond_sword").unwrap();
+        assert!(
+            matches!(item.name, Cow::Borrowed(_)),
+            "item.name must be Cow::Borrowed"
+        );
+
+        // Entity name
+        let entity = store.entity_by_name("zombie").unwrap();
+        assert!(
+            matches!(entity.name, Cow::Borrowed(_)),
+            "entity.name must be Cow::Borrowed"
+        );
+
+        // Cloned entity must still be Borrowed.
+        #[allow(clippy::redundant_clone)]
+        let cloned_entity = entity.clone();
+        assert!(
+            matches!(cloned_entity.name, Cow::Borrowed(_)),
+            "cloned entity.name must stay Cow::Borrowed"
+        );
+    }
+}

--- a/pumpkin-store/src/traits.rs
+++ b/pumpkin-store/src/traits.rs
@@ -1,0 +1,656 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+use crate::StoreResult;
+
+/// Lightweight block record — serializable DTO decoupled from pumpkin-data internals.
+///
+/// This is what crosses the store boundary. Backends fill it from whatever
+/// storage they use (static arrays, TOML files, Arrow batches, Lance tables).
+///
+/// Uses `Cow<'static, str>` for zero-copy from pumpkin-data statics AND
+/// owned strings from TOML registry files (`.claude/registry/blocks.toml`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockRecord {
+    pub id: u16,
+    pub name: Cow<'static, str>,
+    pub hardness: f32,
+    pub blast_resistance: f32,
+    pub is_air: bool,
+    pub is_solid: bool,
+    pub luminance: u8,
+    pub item_id: u16,
+    pub default_state_id: u16,
+    pub state_count: u16,
+}
+
+/// Lightweight item record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ItemRecord {
+    pub id: u16,
+    pub name: Cow<'static, str>,
+    pub max_stack_size: u8,
+}
+
+/// Lightweight entity type record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntityRecord {
+    pub id: u16,
+    pub name: Cow<'static, str>,
+    pub max_health: Option<f32>,
+    pub is_mob: bool,
+    pub width: f32,
+    pub height: f32,
+    pub fire_immune: bool,
+}
+
+/// Lightweight recipe record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecipeRecord {
+    pub recipe_type: Cow<'static, str>,
+    pub group: Cow<'static, str>,
+    pub result_item: Cow<'static, str>,
+    pub result_count: u8,
+}
+
+/// XOR sentinel for zero-copy write-through guard (holograph pattern).
+///
+/// Used by [`CacheEntry`](crate::CacheEntry) to detect if a `Cow::Borrowed` field
+/// was silently converted to `Cow::Owned` during ephemeral variable switching.
+pub const XOR_SENTINEL: u64 = 0xDEAD_BEEF_CAFE_BABE;
+
+/// Reports which `Cow` fields are currently `Borrowed` (zero-copy).
+///
+/// Each bit in the returned mask corresponds to a `Cow` field:
+/// - bit 0 = first `Cow` field (typically `name`)
+/// - bit 1 = second `Cow` field, etc.
+///
+/// Used by the XOR write-through guard in [`CacheEntry`](crate::CacheEntry):
+/// at insertion, `borrow_mask() ^ XOR_SENTINEL` is stored. On read-back,
+/// re-computing `borrow_mask() ^ XOR_SENTINEL` must produce the same tag.
+/// If a `Cow::Borrowed` silently flipped to `Cow::Owned`, the tags diverge.
+pub trait ZeroCopyGuard {
+    /// Bitmask of Borrowed `Cow` fields. Bit i = 1 if field i is `Cow::Borrowed`.
+    fn borrow_mask(&self) -> u64;
+
+    /// Compute the XOR tag for zero-copy verification.
+    fn xor_tag(&self) -> u64 {
+        self.borrow_mask() ^ XOR_SENTINEL
+    }
+
+    /// Verify that the current borrow state matches a previously computed tag.
+    /// Returns `true` if zero-copy is intact, `false` if breached.
+    fn verify_xor(&self, tag: u64) -> bool {
+        self.xor_tag() == tag
+    }
+}
+
+impl ZeroCopyGuard for BlockRecord {
+    fn borrow_mask(&self) -> u64 {
+        u64::from(matches!(self.name, Cow::Borrowed(_)))
+    }
+}
+
+impl ZeroCopyGuard for ItemRecord {
+    fn borrow_mask(&self) -> u64 {
+        u64::from(matches!(self.name, Cow::Borrowed(_)))
+    }
+}
+
+impl ZeroCopyGuard for EntityRecord {
+    fn borrow_mask(&self) -> u64 {
+        u64::from(matches!(self.name, Cow::Borrowed(_)))
+    }
+}
+
+impl ZeroCopyGuard for RecipeRecord {
+    fn borrow_mask(&self) -> u64 {
+        let b0 = u64::from(matches!(self.recipe_type, Cow::Borrowed(_)));
+        let b1 = u64::from(matches!(self.group, Cow::Borrowed(_)));
+        let b2 = u64::from(matches!(self.result_item, Cow::Borrowed(_)));
+        b0 | (b1 << 1) | (b2 << 2)
+    }
+}
+
+/// Cross-entity relationship mapping record (ARCH-027).
+///
+/// Stores relationships between game objects that don't fit in entity tables:
+/// biome→spawn rules, structure→loot tables, block→item drops, mob→goal states.
+///
+/// Used by the `game_mapping` Lance table and queryable via
+/// `GameDataStore::game_mappings()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameMappingRecord {
+    /// Source category (e.g. "biome", "structure", "block", `mob_goal`).
+    pub source_type: Cow<'static, str>,
+    /// Source key within category (e.g. "plains", `desert_pyramid`, "stone").
+    pub source_key: Cow<'static, str>,
+    /// Target category (e.g. `entity_spawn`, `loot_table`, `item_drop`, `goal_state`).
+    pub target_type: Cow<'static, str>,
+    /// Target key (e.g. "zombie", `chest_loot_desert`, "cobblestone").
+    pub target_key: Cow<'static, str>,
+    /// Optional weight/priority for weighted relationships (spawn weights, etc.).
+    pub weight: Option<f32>,
+}
+
+impl ZeroCopyGuard for GameMappingRecord {
+    fn borrow_mask(&self) -> u64 {
+        let b0 = u64::from(matches!(self.source_type, Cow::Borrowed(_)));
+        let b1 = u64::from(matches!(self.source_key, Cow::Borrowed(_)));
+        let b2 = u64::from(matches!(self.target_type, Cow::Borrowed(_)));
+        let b3 = u64::from(matches!(self.target_key, Cow::Borrowed(_)));
+        b0 | (b1 << 1) | (b2 << 2) | (b3 << 3)
+    }
+}
+
+/// Bitpacked mob goal state for Hamming XOR overlay (ARCH-027).
+///
+/// Encodes a mob's entire goal selector state in a single `u64`:
+/// ```text
+/// Bits  0-3:  active MOVE goal index (0xF = none)
+/// Bits  4-7:  active LOOK goal index
+/// Bits  8-11: active JUMP goal index
+/// Bits 12-15: active TARGET goal index
+/// Bits 16-19: disabled controls mask (4 bits)
+/// Bits 20-35: running mask (16 bits, 1 per PrioritizedGoal)
+/// Bits 36-63: reserved (priority encoding, cooldown state)
+/// ```
+///
+/// The Hamming XOR overlay computes state transitions:
+/// ```text
+/// prev_state XOR curr_state = diff_bits
+/// hamming_weight(diff_bits) = number of goal state changes
+/// ```
+///
+/// - `hamming_distance == 0` → stable (no goals changed)
+/// - `hamming_distance == 1` → single goal switch (normal tick)
+/// - `hamming_distance > 4`  → anomalous multi-goal switch
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MobGoalState(pub u64);
+
+impl MobGoalState {
+    /// No goals active, no controls disabled.
+    pub const EMPTY: Self = Self(0x0000_FFFF_FFFF_FFFFu64.reverse_bits());
+
+    /// Create a new goal state with explicit control slot indices.
+    ///
+    /// Pass `0xF` for a control slot with no active goal.
+    #[must_use]
+    pub const fn new(
+        move_goal: u8,
+        look_goal: u8,
+        jump_goal: u8,
+        target_goal: u8,
+        disabled_controls: u8,
+        running_mask: u16,
+    ) -> Self {
+        let bits = (move_goal as u64 & 0xF)
+            | ((look_goal as u64 & 0xF) << 4)
+            | ((jump_goal as u64 & 0xF) << 8)
+            | ((target_goal as u64 & 0xF) << 12)
+            | ((disabled_controls as u64 & 0xF) << 16)
+            | ((running_mask as u64) << 20);
+        Self(bits)
+    }
+
+    /// XOR two states — the result encodes which bits changed.
+    #[must_use]
+    pub const fn xor_diff(self, other: Self) -> u64 {
+        self.0 ^ other.0
+    }
+
+    /// Hamming distance between two states (number of changed bits).
+    #[must_use]
+    pub const fn hamming_distance(self, other: Self) -> u32 {
+        self.xor_diff(other).count_ones()
+    }
+
+    /// Extract the active goal index for the MOVE control slot.
+    #[must_use]
+    pub const fn move_goal(self) -> u8 {
+        (self.0 & 0xF) as u8
+    }
+
+    /// Extract the active goal index for the LOOK control slot.
+    #[must_use]
+    pub const fn look_goal(self) -> u8 {
+        ((self.0 >> 4) & 0xF) as u8
+    }
+
+    /// Extract the active goal index for the JUMP control slot.
+    #[must_use]
+    pub const fn jump_goal(self) -> u8 {
+        ((self.0 >> 8) & 0xF) as u8
+    }
+
+    /// Extract the active goal index for the TARGET control slot.
+    #[must_use]
+    pub const fn target_goal(self) -> u8 {
+        ((self.0 >> 12) & 0xF) as u8
+    }
+
+    /// Extract the disabled controls mask.
+    #[must_use]
+    pub const fn disabled_controls(self) -> u8 {
+        ((self.0 >> 16) & 0xF) as u8
+    }
+
+    /// Extract the running mask (1 bit per goal, up to 16 goals).
+    #[must_use]
+    pub const fn running_mask(self) -> u16 {
+        ((self.0 >> 20) & 0xFFFF) as u16
+    }
+}
+
+// ── Spatial Overlay (holograph pattern) ─────────────────────────────────
+
+/// Number of u64 words in a [`SpatialOverlay`] (256 × 64 = 2^14 = 16384 bits).
+pub const OVERLAY_WORDS: usize = 256;
+
+/// Total bits in the overlay (2^14 = 16384).
+pub const OVERLAY_BITS: usize = OVERLAY_WORDS * 64;
+
+/// Bitpacked 2^14 Hamming vector for spatial activity overlay (ARCH-029).
+///
+/// Compresses an 8192^3 (2^39) spatial volume into 2^14 bits via spatial
+/// hashing. Two independent tables XOR each other for activity detection:
+///
+/// ```text
+/// Table A (ephemeral):  height + mob activity → changes per tick
+/// Table B (static XY):  spatial map → changes on entity movement
+///
+/// XOR(A, B) = combined activity fingerprint
+/// hamming_weight(XOR(A, B)) = total state changes
+/// AVX-512: 32 ops to diff entire table (512 bits per lane)
+/// ```
+///
+/// ## Holograph Pattern
+///
+/// From `AdaWorldAPI/holograph`: 8192^3 positions in 3D space mapped to
+/// 2^14 bit Hamming vector. Entities bind/unbind bits by spatial hash of
+/// their (x, y, z) position. Two tables XOR each other — ephemeral
+/// (height + mob data, 16k) vs static (XY map, 16k).
+///
+/// ## Entity Slot Encoding (2 bits per slot)
+///
+/// ```text
+/// 00 = inactive (no entity bound)
+/// 01 = active (entity present, stable)
+/// 10 = changed (entity state transition this tick)
+/// 11 = anomalous (multi-goal switch or error)
+/// ```
+#[derive(Clone, PartialEq, Eq)]
+pub struct SpatialOverlay {
+    /// 256 × u64 = 16384 bits = 2^14 Hamming vector.
+    bits: [u64; OVERLAY_WORDS],
+}
+
+impl SpatialOverlay {
+    /// Empty overlay — all bits zero (no entities bound).
+    pub const EMPTY: Self = Self {
+        bits: [0u64; OVERLAY_WORDS],
+    };
+
+    /// Create an empty overlay.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self::EMPTY
+    }
+
+    /// Spatial hash: fold (x, y, z) into a bit index in `[0, 16384)`.
+    ///
+    /// Uses multiplicative hashing with golden-ratio-derived constants
+    /// to distribute 3D coordinates across the 2^14 bit space.
+    #[must_use]
+    pub const fn spatial_hash(x: i32, y: i32, z: i32) -> usize {
+        let hx = (x as u32).wrapping_mul(0x9E37_79B9);
+        let hy = (y as u32).wrapping_mul(0x517C_C1B7);
+        let hz = (z as u32).wrapping_mul(0x85EB_CA6B);
+        let combined = hx ^ hy.wrapping_shl(5) ^ hz.wrapping_shl(10);
+        (combined >> 18) as usize // top 14 bits → [0, 16384)
+    }
+
+    /// Set a bit at the given index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bit >= 16384`.
+    pub fn set_bit(&mut self, bit: usize) {
+        assert!(bit < OVERLAY_BITS, "bit index out of range: {bit}");
+        self.bits[bit / 64] |= 1u64 << (bit % 64);
+    }
+
+    /// Clear a bit at the given index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bit >= 16384`.
+    pub fn clear_bit(&mut self, bit: usize) {
+        assert!(bit < OVERLAY_BITS, "bit index out of range: {bit}");
+        self.bits[bit / 64] &= !(1u64 << (bit % 64));
+    }
+
+    /// Test whether a bit is set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `bit >= 16384`.
+    #[must_use]
+    pub const fn test_bit(&self, bit: usize) -> bool {
+        assert!(bit < OVERLAY_BITS, "bit index out of range");
+        (self.bits[bit / 64] >> (bit % 64)) & 1 == 1
+    }
+
+    /// Bind an entity at spatial position — sets the hashed bit.
+    pub fn bind(&mut self, x: i32, y: i32, z: i32) {
+        self.set_bit(Self::spatial_hash(x, y, z));
+    }
+
+    /// Unbind an entity at spatial position — clears the hashed bit.
+    pub fn unbind(&mut self, x: i32, y: i32, z: i32) {
+        self.clear_bit(Self::spatial_hash(x, y, z));
+    }
+
+    /// XOR two tables — produces a diff showing which bits changed.
+    ///
+    /// Use two independent overlays (ephemeral + static) and XOR them
+    /// for combined activity detection.
+    #[must_use]
+    pub fn xor_diff(&self, other: &Self) -> Self {
+        let mut result = Self::EMPTY;
+        for i in 0..OVERLAY_WORDS {
+            result.bits[i] = self.bits[i] ^ other.bits[i];
+        }
+        result
+    }
+
+    /// Hamming weight — total number of set bits.
+    ///
+    /// On a diff overlay (from [`xor_diff`](Self::xor_diff)), this is
+    /// the number of spatial buckets that changed between two snapshots.
+    #[must_use]
+    pub fn hamming_weight(&self) -> u32 {
+        let mut count = 0u32;
+        for word in &self.bits {
+            count += word.count_ones();
+        }
+        count
+    }
+
+    /// Hamming distance between two overlays (popcount of their XOR).
+    #[must_use]
+    pub fn hamming_distance(&self, other: &Self) -> u32 {
+        let mut count = 0u32;
+        for i in 0..OVERLAY_WORDS {
+            count += (self.bits[i] ^ other.bits[i]).count_ones();
+        }
+        count
+    }
+
+    /// Number of set bits (alias for [`hamming_weight`](Self::hamming_weight)).
+    #[must_use]
+    pub fn popcount(&self) -> u32 {
+        self.hamming_weight()
+    }
+
+    /// Access the raw u64 word array (for SIMD / Arrow interop).
+    #[must_use]
+    pub const fn as_words(&self) -> &[u64; OVERLAY_WORDS] {
+        &self.bits
+    }
+
+    /// Mutable access to the raw u64 word array.
+    pub const fn as_words_mut(&mut self) -> &mut [u64; OVERLAY_WORDS] {
+        &mut self.bits
+    }
+}
+
+impl Default for SpatialOverlay {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for SpatialOverlay {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpatialOverlay")
+            .field("popcount", &self.popcount())
+            .finish()
+    }
+}
+
+/// Core trait for game data access.
+///
+/// Backends implement this to provide block, item, entity, and recipe lookups.
+/// The trait uses `&'static` string references for zero-copy compatibility with
+/// pumpkin-data's compile-time generated data.
+///
+/// # Backends
+///
+/// - [`StaticStore`](crate::StaticStore) — wraps pumpkin-data (default, zero-cost)
+/// - [`LanceStore`](crate::LanceStore) — Arrow columnar + `DataFusion` SQL (opt-in)
+pub trait GameDataStore: Send + Sync {
+    // ── Blocks ──────────────────────────────────────────────────
+
+    /// Look up a block by its numeric ID.
+    fn block_by_id(&self, id: u16) -> StoreResult<BlockRecord>;
+
+    /// Look up a block by registry name (e.g. "stone", "minecraft:stone").
+    fn block_by_name(&self, name: &str) -> StoreResult<BlockRecord>;
+
+    /// Look up a block by one of its state IDs.
+    fn block_by_state_id(&self, state_id: u16) -> StoreResult<BlockRecord>;
+
+    /// Total number of blocks in the registry.
+    fn block_count(&self) -> usize;
+
+    // ── Items ───────────────────────────────────────────────────
+
+    /// Look up an item by registry name.
+    fn item_by_name(&self, name: &str) -> StoreResult<ItemRecord>;
+
+    /// Total number of items in the registry.
+    fn item_count(&self) -> usize;
+
+    // ── Entities ────────────────────────────────────────────────
+
+    /// Look up an entity type by registry name.
+    fn entity_by_name(&self, name: &str) -> StoreResult<EntityRecord>;
+
+    /// Total number of entity types.
+    fn entity_count(&self) -> usize;
+
+    // ── Recipes ─────────────────────────────────────────────────
+
+    /// Get all recipes that produce the given item name.
+    fn recipes_for_output(&self, item_name: &str) -> StoreResult<Vec<RecipeRecord>>;
+
+    /// Total number of recipes.
+    fn recipe_count(&self) -> usize;
+
+    // ── Game Mappings ────────────────────────────────────────────
+
+    /// Query cross-entity relationship mappings by source type and key.
+    ///
+    /// Returns all mappings from the given source (e.g. all spawn rules
+    /// for a biome, all goals for a mob type, all drops for a block).
+    fn game_mappings(
+        &self,
+        source_type: &str,
+        source_key: &str,
+    ) -> StoreResult<Vec<GameMappingRecord>>;
+
+    /// Total number of game mapping entries.
+    fn game_mapping_count(&self) -> usize;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── MobGoalState tests ────────────────────────────────────────
+
+    #[test]
+    fn mob_goal_state_roundtrip() {
+        let state = MobGoalState::new(1, 2, 3, 4, 0b1010, 0xABCD);
+        assert_eq!(state.move_goal(), 1);
+        assert_eq!(state.look_goal(), 2);
+        assert_eq!(state.jump_goal(), 3);
+        assert_eq!(state.target_goal(), 4);
+        assert_eq!(state.disabled_controls(), 0b1010);
+        assert_eq!(state.running_mask(), 0xABCD);
+    }
+
+    #[test]
+    fn mob_goal_state_hamming() {
+        let a = MobGoalState::new(1, 2, 0xF, 0xF, 0, 0);
+        let b = MobGoalState::new(1, 3, 0xF, 0xF, 0, 0);
+        // Only the LOOK slot changed (2→3), bits 4-7 differ
+        let dist = a.hamming_distance(b);
+        assert!(dist > 0, "different states must have nonzero hamming distance");
+        assert!(dist <= 4, "single slot change should differ by ≤4 bits");
+    }
+
+    #[test]
+    fn mob_goal_state_identical_is_zero() {
+        let state = MobGoalState::new(5, 3, 2, 1, 0xF, 0xFFFF);
+        assert_eq!(state.hamming_distance(state), 0);
+    }
+
+    // ── SpatialOverlay tests ──────────────────────────────────────
+
+    #[test]
+    fn overlay_empty_has_zero_popcount() {
+        let overlay = SpatialOverlay::new();
+        assert_eq!(overlay.popcount(), 0);
+    }
+
+    #[test]
+    fn overlay_set_and_test_bit() {
+        let mut overlay = SpatialOverlay::new();
+        overlay.set_bit(0);
+        overlay.set_bit(100);
+        overlay.set_bit(16383);
+        assert!(overlay.test_bit(0));
+        assert!(overlay.test_bit(100));
+        assert!(overlay.test_bit(16383));
+        assert!(!overlay.test_bit(1));
+        assert_eq!(overlay.popcount(), 3);
+    }
+
+    #[test]
+    fn overlay_clear_bit() {
+        let mut overlay = SpatialOverlay::new();
+        overlay.set_bit(42);
+        assert!(overlay.test_bit(42));
+        overlay.clear_bit(42);
+        assert!(!overlay.test_bit(42));
+        assert_eq!(overlay.popcount(), 0);
+    }
+
+    #[test]
+    fn overlay_bind_unbind() {
+        let mut overlay = SpatialOverlay::new();
+        overlay.bind(100, 64, -200);
+        assert!(overlay.popcount() > 0);
+
+        let hash = SpatialOverlay::spatial_hash(100, 64, -200);
+        assert!(overlay.test_bit(hash));
+
+        overlay.unbind(100, 64, -200);
+        assert!(!overlay.test_bit(hash));
+    }
+
+    #[test]
+    fn overlay_xor_diff_detects_changes() {
+        let mut a = SpatialOverlay::new();
+        let mut b = SpatialOverlay::new();
+
+        // Bind same position in both — no diff
+        a.bind(10, 20, 30);
+        b.bind(10, 20, 30);
+        let diff = a.xor_diff(&b);
+        assert_eq!(diff.popcount(), 0, "identical binds should produce zero diff");
+
+        // Bind extra position in b — diff shows it
+        b.bind(40, 50, 60);
+        let diff = a.xor_diff(&b);
+        assert!(diff.popcount() > 0, "different binds should produce nonzero diff");
+    }
+
+    #[test]
+    fn overlay_hamming_distance() {
+        let mut a = SpatialOverlay::new();
+        let mut b = SpatialOverlay::new();
+
+        a.bind(0, 0, 0);
+        b.bind(1000, 1000, 1000);
+
+        let dist = a.hamming_distance(&b);
+        // Two different positions bound → at least 2 bits differ (could be more if hash collision)
+        assert!(dist >= 1);
+    }
+
+    #[test]
+    fn overlay_two_tables_xor() {
+        // Ephemeral table: mob activity
+        let mut ephemeral = SpatialOverlay::new();
+        ephemeral.bind(100, 64, 200);
+        ephemeral.bind(200, 70, 300);
+
+        // Static table: XY spatial map
+        let mut static_xy = SpatialOverlay::new();
+        static_xy.bind(100, 64, 200); // same entity, present in both
+
+        // XOR reveals what's ephemeral-only (activity that moved)
+        let diff = ephemeral.xor_diff(&static_xy);
+        assert!(
+            diff.popcount() > 0,
+            "ephemeral has extra bind, XOR should be nonzero"
+        );
+    }
+
+    #[test]
+    fn overlay_constants_correct() {
+        assert_eq!(OVERLAY_WORDS, 256);
+        assert_eq!(OVERLAY_BITS, 16384);
+        assert_eq!(OVERLAY_BITS, 1 << 14);
+    }
+
+    #[test]
+    fn overlay_spatial_hash_in_range() {
+        // Various coordinates should all hash to valid range
+        for &(x, y, z) in &[
+            (0, 0, 0),
+            (8191, 8191, 8191),
+            (-8192, -8192, -8192),
+            (i32::MAX, i32::MIN, 0),
+            (100, -64, 320),
+        ] {
+            let hash = SpatialOverlay::spatial_hash(x, y, z);
+            assert!(
+                hash < OVERLAY_BITS,
+                "hash({x},{y},{z}) = {hash} out of range"
+            );
+        }
+    }
+
+    #[test]
+    fn overlay_as_words_roundtrip() {
+        let mut overlay = SpatialOverlay::new();
+        overlay.bind(42, 42, 42);
+        let words = overlay.as_words();
+        assert_eq!(words.len(), 256);
+
+        // At least one word should be nonzero
+        assert!(words.iter().any(|&w| w != 0));
+    }
+
+    #[test]
+    #[should_panic(expected = "bit index out of range")]
+    fn overlay_set_bit_panics_out_of_range() {
+        let mut overlay = SpatialOverlay::new();
+        overlay.set_bit(16384); // exactly out of range
+    }
+}


### PR DESCRIPTION
## What this adds

New `pumpkin-store` crate (~2K lines) providing a data storage abstraction layer.

### Components
- `GameDataStore` trait — generic interface for data backends
- `StaticStore` — compile-time static data backend
- `CachedStore` — overlay cache with lazy loading
- Error types and trait definitions

### Why
Foundation for multi-version data support. Decouples data access from storage implementation.

Part 2 of 11. Depends on: nothing (new leaf crate).
