### PR TITLE
[feat] Anvil region file format + SNBT parser for pumpkin-nbt

### DIFF
--- a/pumpkin-nbt/src/anvil.rs
+++ b/pumpkin-nbt/src/anvil.rs
@@ -1,0 +1,1059 @@
+//! Anvil region file format support.
+//!
+//! This module provides low-level reading and writing of Minecraft's Anvil
+//! region file format (`.mca` files). A region file stores up to 1024 chunks
+//! (32x32) using a sector-based allocation scheme.
+//!
+//! # Region File Layout
+//!
+//! ```text
+//! Offset   Size   Description
+//! 0        4096   Location table (1024 entries × 4 bytes)
+//! 4096     4096   Timestamp table (1024 entries × 4 bytes)
+//! 8192+    ...    Chunk data sectors (4096 bytes each)
+//! ```
+//!
+//! Each location entry encodes the sector offset (upper 24 bits) and
+//! sector count (lower 8 bits). Chunk data is preceded by a 5-byte header:
+//! 4 bytes for the data length (including compression byte) and 1 byte for
+//! the compression method.
+//!
+//! # Compression Methods
+//!
+//! | ID | Method      |
+//! |----|-------------|
+//! | 1  | `GZip`      |
+//! | 2  | `ZLib`      |
+//! | 3  | Uncompressed|
+//!
+//! # Example
+//!
+//! ```no_run
+//! use pumpkin_nbt::anvil::RegionFile;
+//!
+//! // Open a region file
+//! let data = std::fs::read("r.0.0.mca").unwrap();
+//! let region = RegionFile::from_bytes(&data).unwrap();
+//!
+//! // Read chunk at local coordinates (0, 0)
+//! if let Some(chunk_data) = region.read_chunk(0, 0).unwrap() {
+//!     // chunk_data is decompressed NBT bytes
+//!     println!("Chunk has {} bytes", chunk_data.len());
+//! }
+//! ```
+
+use std::io::{self, Read, Write};
+
+use flate2::Compression;
+use flate2::read::{GzDecoder, ZlibDecoder};
+use flate2::write::{GzEncoder, ZlibEncoder};
+
+/// Number of chunks per region side (32×32 = 1024 chunks per region).
+pub const REGION_SIZE: usize = 32;
+
+/// Total number of chunk slots in a region file.
+pub const CHUNK_COUNT: usize = REGION_SIZE * REGION_SIZE;
+
+/// Size of a single sector in bytes (4 KiB).
+pub const SECTOR_BYTES: usize = 4096;
+
+/// Number of header sectors (location table + timestamp table).
+pub const HEADER_SECTORS: usize = 2;
+
+/// Byte offset where chunk data sectors begin.
+pub const DATA_OFFSET: usize = HEADER_SECTORS * SECTOR_BYTES;
+
+/// Compression methods used in Anvil region files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CompressionMethod {
+    /// `GZip` compression (ID 1).
+    GZip = 1,
+    /// ZLib/Deflate compression (ID 2). This is the default used by vanilla.
+    ZLib = 2,
+    /// No compression (ID 3).
+    None = 3,
+}
+
+impl CompressionMethod {
+    /// Parse a compression method from its byte ID.
+    pub const fn from_id(id: u8) -> Result<Self, AnvilError> {
+        match id {
+            1 => Ok(Self::GZip),
+            2 => Ok(Self::ZLib),
+            3 => Ok(Self::None),
+            _ => Err(AnvilError::UnknownCompression(id)),
+        }
+    }
+}
+
+/// Errors that can occur during Anvil region file operations.
+#[derive(Debug)]
+pub enum AnvilError {
+    /// The region file data is too small to contain the header tables.
+    FileTooSmall(usize),
+    /// Chunk coordinates are out of bounds (must be 0..31).
+    ChunkOutOfBounds(u8, u8),
+    /// The sector offset points outside the file.
+    SectorOutOfBounds {
+        chunk_x: u8,
+        chunk_z: u8,
+        offset: u32,
+        file_len: usize,
+    },
+    /// The chunk data header specifies a length larger than the allocated sectors.
+    ChunkDataTooLarge {
+        chunk_x: u8,
+        chunk_z: u8,
+        data_len: u32,
+        available: usize,
+    },
+    /// An unknown compression method ID was encountered.
+    UnknownCompression(u8),
+    /// An I/O error occurred during decompression or other operations.
+    Io(io::Error),
+    /// The chunk data length in the header is zero or invalid.
+    InvalidDataLength(u32),
+}
+
+impl std::fmt::Display for AnvilError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::FileTooSmall(size) => {
+                write!(
+                    f,
+                    "Region file too small: {size} bytes (minimum {DATA_OFFSET})"
+                )
+            }
+            Self::ChunkOutOfBounds(x, z) => {
+                write!(
+                    f,
+                    "Chunk coordinates out of bounds: ({x}, {z}), must be 0..31"
+                )
+            }
+            Self::SectorOutOfBounds {
+                chunk_x,
+                chunk_z,
+                offset,
+                file_len,
+            } => write!(
+                f,
+                "Sector offset {offset} for chunk ({chunk_x}, {chunk_z}) points past file end ({file_len} bytes)"
+            ),
+            Self::ChunkDataTooLarge {
+                chunk_x,
+                chunk_z,
+                data_len,
+                available,
+            } => write!(
+                f,
+                "Chunk ({chunk_x}, {chunk_z}) data length {data_len} exceeds available sector space {available}"
+            ),
+            Self::UnknownCompression(id) => {
+                write!(f, "Unknown compression method: {id}")
+            }
+            Self::Io(err) => write!(f, "I/O error: {err}"),
+            Self::InvalidDataLength(len) => {
+                write!(f, "Invalid chunk data length: {len}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AnvilError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for AnvilError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}
+
+/// Location table entry for a single chunk within a region file.
+///
+/// Encodes the starting sector (offset from file start, in 4 KiB sectors)
+/// and the number of sectors allocated for the chunk data.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ChunkLocation {
+    /// Sector offset from the beginning of the file. A value of 0 means the
+    /// chunk is not present.
+    pub offset: u32,
+    /// Number of 4 KiB sectors allocated for the chunk.
+    pub sector_count: u8,
+}
+
+impl ChunkLocation {
+    /// Returns `true` if this chunk slot is empty (offset and sector count are both 0).
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.offset == 0 && self.sector_count == 0
+    }
+
+    /// Decode a location entry from 4 big-endian bytes.
+    const fn from_bytes(bytes: [u8; 4]) -> Self {
+        let offset = ((bytes[0] as u32) << 16) | ((bytes[1] as u32) << 8) | (bytes[2] as u32);
+        let sector_count = bytes[3];
+        Self {
+            offset,
+            sector_count,
+        }
+    }
+
+    /// Encode this location entry as 4 big-endian bytes.
+    const fn to_bytes(self) -> [u8; 4] {
+        [
+            ((self.offset >> 16) & 0xFF) as u8,
+            ((self.offset >> 8) & 0xFF) as u8,
+            (self.offset & 0xFF) as u8,
+            self.sector_count,
+        ]
+    }
+}
+
+/// A parsed Anvil region file.
+///
+/// Provides random access to individual chunk data by local coordinates
+/// (0..31, 0..31). Chunk data is stored compressed and is decompressed
+/// on read.
+pub struct RegionFile {
+    /// Location table: 1024 entries mapping chunk positions to sector offsets.
+    pub locations: [ChunkLocation; CHUNK_COUNT],
+    /// Timestamp table: 1024 Unix timestamps (seconds since epoch).
+    pub timestamps: [u32; CHUNK_COUNT],
+    /// Raw file data (including headers). Chunk sectors are read from this.
+    data: Vec<u8>,
+}
+
+impl RegionFile {
+    /// Parse a region file from a byte slice.
+    ///
+    /// The input must contain at least the 8 KiB header (location + timestamp
+    /// tables). Chunk data sectors follow the header.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, AnvilError> {
+        if bytes.len() < DATA_OFFSET {
+            return Err(AnvilError::FileTooSmall(bytes.len()));
+        }
+
+        let mut locations = [ChunkLocation::default(); CHUNK_COUNT];
+        let mut timestamps = [0u32; CHUNK_COUNT];
+
+        // Parse location table (first 4096 bytes)
+        for (i, location) in locations.iter_mut().enumerate() {
+            let base = i * 4;
+            let entry_bytes = [
+                bytes[base],
+                bytes[base + 1],
+                bytes[base + 2],
+                bytes[base + 3],
+            ];
+            *location = ChunkLocation::from_bytes(entry_bytes);
+        }
+
+        // Parse timestamp table (second 4096 bytes)
+        for (i, timestamp) in timestamps.iter_mut().enumerate() {
+            let base = SECTOR_BYTES + i * 4;
+            *timestamp = u32::from_be_bytes([
+                bytes[base],
+                bytes[base + 1],
+                bytes[base + 2],
+                bytes[base + 3],
+            ]);
+        }
+
+        Ok(Self {
+            locations,
+            timestamps,
+            data: bytes.to_vec(),
+        })
+    }
+
+    /// Create a new empty region file with no chunks.
+    #[must_use]
+    pub fn new() -> Self {
+        let mut data = vec![0u8; DATA_OFFSET];
+        // The header is already zeroed, meaning all chunks are absent.
+        // Ensure data is exactly 8192 bytes (2 sectors for headers).
+        data.resize(DATA_OFFSET, 0);
+
+        Self {
+            locations: [ChunkLocation::default(); CHUNK_COUNT],
+            timestamps: [0u32; CHUNK_COUNT],
+            data,
+        }
+    }
+
+    /// Compute the index into the location/timestamp tables for the given
+    /// local chunk coordinates.
+    const fn chunk_index(x: u8, z: u8) -> Result<usize, AnvilError> {
+        if x >= REGION_SIZE as u8 || z >= REGION_SIZE as u8 {
+            return Err(AnvilError::ChunkOutOfBounds(x, z));
+        }
+        Ok((x as usize) + (z as usize) * REGION_SIZE)
+    }
+
+    /// Convert world-space chunk coordinates to region-local coordinates.
+    ///
+    /// World chunk (cx, cz) maps to region (cx >> 5, cz >> 5), and local
+    /// coordinates are (cx & 31, cz & 31).
+    #[must_use]
+    pub const fn world_to_local(chunk_x: i32, chunk_z: i32) -> (u8, u8) {
+        ((chunk_x & 31) as u8, (chunk_z & 31) as u8)
+    }
+
+    /// Convert world-space chunk coordinates to the region file coordinates.
+    ///
+    /// Returns (`region_x`, `region_z`) suitable for constructing the filename
+    /// `r.{region_x}.{region_z}.mca`.
+    #[must_use]
+    pub const fn chunk_to_region(chunk_x: i32, chunk_z: i32) -> (i32, i32) {
+        (chunk_x >> 5, chunk_z >> 5)
+    }
+
+    /// Check whether a chunk exists at the given local coordinates.
+    pub fn has_chunk(&self, x: u8, z: u8) -> Result<bool, AnvilError> {
+        let idx = Self::chunk_index(x, z)?;
+        Ok(!self.locations[idx].is_empty())
+    }
+
+    /// Get the timestamp for a chunk at the given local coordinates.
+    ///
+    /// Returns 0 if the chunk has never been saved.
+    pub fn get_timestamp(&self, x: u8, z: u8) -> Result<u32, AnvilError> {
+        let idx = Self::chunk_index(x, z)?;
+        Ok(self.timestamps[idx])
+    }
+
+    /// Read and decompress chunk data at the given local coordinates.
+    ///
+    /// Returns `None` if the chunk slot is empty. The returned bytes are
+    /// the decompressed NBT data (ready to be parsed with `Nbt::read` or
+    /// the serde deserializer).
+    pub fn read_chunk(&self, x: u8, z: u8) -> Result<Option<Vec<u8>>, AnvilError> {
+        let idx = Self::chunk_index(x, z)?;
+        let loc = self.locations[idx];
+
+        if loc.is_empty() {
+            return Ok(None);
+        }
+
+        let byte_offset = loc.offset as usize * SECTOR_BYTES;
+        let max_bytes = loc.sector_count as usize * SECTOR_BYTES;
+
+        // Validate the offset is within the file
+        if byte_offset + max_bytes > self.data.len() {
+            return Err(AnvilError::SectorOutOfBounds {
+                chunk_x: x,
+                chunk_z: z,
+                offset: loc.offset,
+                file_len: self.data.len(),
+            });
+        }
+
+        let sector_data = &self.data[byte_offset..byte_offset + max_bytes];
+
+        // Read chunk header: 4 bytes length + 1 byte compression
+        if sector_data.len() < 5 {
+            return Err(AnvilError::InvalidDataLength(0));
+        }
+
+        let data_len = u32::from_be_bytes([
+            sector_data[0],
+            sector_data[1],
+            sector_data[2],
+            sector_data[3],
+        ]);
+
+        if data_len < 1 {
+            return Err(AnvilError::InvalidDataLength(data_len));
+        }
+
+        // data_len includes the compression byte
+        let total_data = data_len as usize;
+        if total_data + 4 > sector_data.len() {
+            return Err(AnvilError::ChunkDataTooLarge {
+                chunk_x: x,
+                chunk_z: z,
+                data_len,
+                available: sector_data.len() - 4,
+            });
+        }
+
+        let compression = CompressionMethod::from_id(sector_data[4])?;
+        let compressed = &sector_data[5..4 + total_data];
+
+        decompress(compressed, compression)
+            .map(Some)
+            .map_err(AnvilError::Io)
+    }
+
+    /// Write (compressed) chunk data at the given local coordinates.
+    ///
+    /// The `nbt_data` should be the raw NBT bytes (not compressed). This method
+    /// compresses them with the specified method and rebuilds the region file
+    /// with updated sector allocation.
+    ///
+    /// The `timestamp` is the Unix timestamp (seconds since epoch) for the chunk.
+    pub fn write_chunk(
+        &mut self,
+        x: u8,
+        z: u8,
+        nbt_data: &[u8],
+        compression: CompressionMethod,
+        timestamp: u32,
+    ) -> Result<(), AnvilError> {
+        let idx = Self::chunk_index(x, z)?;
+
+        let compressed = compress(nbt_data, compression)?;
+
+        // Chunk header: 4 bytes length + 1 byte compression + compressed data
+        // length field includes the compression byte
+        let data_len = compressed.len() as u32 + 1;
+        let total_with_header = 4 + data_len as usize;
+
+        // Calculate sectors needed (round up to SECTOR_BYTES)
+        let sectors_needed = total_with_header.div_ceil(SECTOR_BYTES);
+        if sectors_needed > 255 {
+            return Err(AnvilError::ChunkDataTooLarge {
+                chunk_x: x,
+                chunk_z: z,
+                data_len,
+                available: 255 * SECTOR_BYTES,
+            });
+        }
+
+        // Build the chunk sector data (padded to sector boundary)
+        let padded_len = sectors_needed * SECTOR_BYTES;
+        let mut chunk_sector = vec![0u8; padded_len];
+
+        // Write header
+        let len_bytes = data_len.to_be_bytes();
+        chunk_sector[0..4].copy_from_slice(&len_bytes);
+        chunk_sector[4] = compression as u8;
+        chunk_sector[5..5 + compressed.len()].copy_from_slice(&compressed);
+
+        // Rebuild the file: collect all existing chunk sectors, replace/add the target chunk
+        let mut chunks: Vec<(usize, Vec<u8>)> = Vec::new(); // (index, sector_data)
+        for i in 0..CHUNK_COUNT {
+            if i == idx {
+                // Will be replaced
+                continue;
+            }
+            let loc = self.locations[i];
+            if loc.is_empty() {
+                continue;
+            }
+            let start = loc.offset as usize * SECTOR_BYTES;
+            let end = start + loc.sector_count as usize * SECTOR_BYTES;
+            if end <= self.data.len() {
+                chunks.push((i, self.data[start..end].to_vec()));
+            }
+        }
+
+        // Add the new/updated chunk
+        chunks.push((idx, chunk_sector));
+
+        // Sort by index for deterministic output
+        chunks.sort_by_key(|(i, _)| *i);
+
+        // Rebuild the file
+        let mut new_data = vec![0u8; DATA_OFFSET]; // Start with empty headers
+        let mut new_locations = [ChunkLocation::default(); CHUNK_COUNT];
+        let mut new_timestamps = self.timestamps;
+
+        let mut current_sector = HEADER_SECTORS as u32;
+
+        for (i, sector_data) in &chunks {
+            let sector_count = (sector_data.len() / SECTOR_BYTES) as u8;
+            new_locations[*i] = ChunkLocation {
+                offset: current_sector,
+                sector_count,
+            };
+            new_data.extend_from_slice(sector_data);
+            current_sector += sector_count as u32;
+        }
+
+        // Update timestamp for the written chunk
+        new_timestamps[idx] = timestamp;
+
+        // Write location table into header
+        for (i, loc) in new_locations.iter().enumerate() {
+            let bytes = loc.to_bytes();
+            let base = i * 4;
+            new_data[base..base + 4].copy_from_slice(&bytes);
+        }
+
+        // Write timestamp table into header
+        for (i, ts) in new_timestamps.iter().enumerate() {
+            let bytes = ts.to_be_bytes();
+            let base = SECTOR_BYTES + i * 4;
+            new_data[base..base + 4].copy_from_slice(&bytes);
+        }
+
+        self.data = new_data;
+        self.locations = new_locations;
+        self.timestamps = new_timestamps;
+
+        Ok(())
+    }
+
+    /// Remove a chunk from the region file.
+    ///
+    /// Clears the location and timestamp entries. The sector data is not
+    /// immediately reclaimed but will be omitted on the next `write_chunk`
+    /// or `to_bytes` call if the file is rebuilt.
+    pub fn remove_chunk(&mut self, x: u8, z: u8) -> Result<(), AnvilError> {
+        let idx = Self::chunk_index(x, z)?;
+        self.locations[idx] = ChunkLocation::default();
+        self.timestamps[idx] = 0;
+        Ok(())
+    }
+
+    /// Serialize the region file to bytes.
+    ///
+    /// Returns the complete file contents suitable for writing to disk.
+    #[must_use]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+
+    /// Write the region file to a writer.
+    pub fn write_to<W: Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        writer.write_all(&self.data)
+    }
+
+    /// Count the number of chunks present in this region file.
+    #[must_use]
+    pub fn chunk_count(&self) -> usize {
+        self.locations.iter().filter(|loc| !loc.is_empty()).count()
+    }
+
+    /// Iterate over all present chunks, yielding (`local_x`, `local_z`) pairs.
+    pub fn present_chunks(&self) -> impl Iterator<Item = (u8, u8)> + '_ {
+        self.locations.iter().enumerate().filter_map(|(i, loc)| {
+            if loc.is_empty() {
+                None
+            } else {
+                let x = (i % REGION_SIZE) as u8;
+                let z = (i / REGION_SIZE) as u8;
+                Some((x, z))
+            }
+        })
+    }
+}
+
+impl Default for RegionFile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Decompress data using the specified compression method.
+fn decompress(data: &[u8], method: CompressionMethod) -> Result<Vec<u8>, io::Error> {
+    match method {
+        CompressionMethod::GZip => {
+            let mut decoder = GzDecoder::new(data);
+            let mut output = Vec::new();
+            decoder.read_to_end(&mut output)?;
+            Ok(output)
+        }
+        CompressionMethod::ZLib => {
+            let mut decoder = ZlibDecoder::new(data);
+            let mut output = Vec::new();
+            decoder.read_to_end(&mut output)?;
+            Ok(output)
+        }
+        CompressionMethod::None => Ok(data.to_vec()),
+    }
+}
+
+/// Compress data using the specified compression method.
+fn compress(data: &[u8], method: CompressionMethod) -> Result<Vec<u8>, AnvilError> {
+    match method {
+        CompressionMethod::GZip => {
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(data)?;
+            Ok(encoder.finish()?)
+        }
+        CompressionMethod::ZLib => {
+            let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+            encoder.write_all(data)?;
+            Ok(encoder.finish()?)
+        }
+        CompressionMethod::None => Ok(data.to_vec()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_region_file_is_empty() {
+        let region = RegionFile::new();
+        assert_eq!(region.chunk_count(), 0);
+        assert_eq!(region.to_bytes().len(), DATA_OFFSET);
+    }
+
+    #[test]
+    fn chunk_index_bounds() {
+        assert!(RegionFile::chunk_index(0, 0).is_ok());
+        assert!(RegionFile::chunk_index(31, 31).is_ok());
+        assert!(RegionFile::chunk_index(32, 0).is_err());
+        assert!(RegionFile::chunk_index(0, 32).is_err());
+    }
+
+    #[test]
+    fn world_to_local_conversion() {
+        assert_eq!(RegionFile::world_to_local(0, 0), (0, 0));
+        assert_eq!(RegionFile::world_to_local(31, 31), (31, 31));
+        assert_eq!(RegionFile::world_to_local(32, 32), (0, 0));
+        assert_eq!(RegionFile::world_to_local(-1, -1), (31, 31));
+        assert_eq!(RegionFile::world_to_local(33, 65), (1, 1));
+    }
+
+    #[test]
+    fn chunk_to_region_conversion() {
+        assert_eq!(RegionFile::chunk_to_region(0, 0), (0, 0));
+        assert_eq!(RegionFile::chunk_to_region(31, 31), (0, 0));
+        assert_eq!(RegionFile::chunk_to_region(32, 32), (1, 1));
+        assert_eq!(RegionFile::chunk_to_region(-1, -1), (-1, -1));
+        assert_eq!(RegionFile::chunk_to_region(-32, -32), (-1, -1));
+        assert_eq!(RegionFile::chunk_to_region(-33, -33), (-2, -2));
+    }
+
+    #[test]
+    fn location_entry_roundtrip() {
+        let loc = ChunkLocation {
+            offset: 12345,
+            sector_count: 3,
+        };
+        let bytes = loc.to_bytes();
+        let decoded = ChunkLocation::from_bytes(bytes);
+        assert_eq!(decoded.offset, loc.offset);
+        assert_eq!(decoded.sector_count, loc.sector_count);
+    }
+
+    #[test]
+    fn location_entry_empty() {
+        let loc = ChunkLocation::default();
+        assert!(loc.is_empty());
+
+        let loc = ChunkLocation {
+            offset: 1,
+            sector_count: 0,
+        };
+        assert!(!loc.is_empty());
+    }
+
+    #[test]
+    fn write_and_read_chunk_zlib() {
+        let mut region = RegionFile::new();
+        let nbt_data = b"Hello, this is some test NBT data for chunk storage!";
+
+        region
+            .write_chunk(0, 0, nbt_data, CompressionMethod::ZLib, 1000)
+            .unwrap();
+
+        assert!(region.has_chunk(0, 0).unwrap());
+        assert!(!region.has_chunk(1, 0).unwrap());
+        assert_eq!(region.get_timestamp(0, 0).unwrap(), 1000);
+        assert_eq!(region.chunk_count(), 1);
+
+        let read_data = region.read_chunk(0, 0).unwrap().unwrap();
+        assert_eq!(read_data, nbt_data);
+    }
+
+    #[test]
+    fn write_and_read_chunk_gzip() {
+        let mut region = RegionFile::new();
+        let nbt_data = b"GZip compressed chunk test data";
+
+        region
+            .write_chunk(5, 10, nbt_data, CompressionMethod::GZip, 2000)
+            .unwrap();
+
+        let read_data = region.read_chunk(5, 10).unwrap().unwrap();
+        assert_eq!(read_data, nbt_data);
+    }
+
+    #[test]
+    fn write_and_read_chunk_uncompressed() {
+        let mut region = RegionFile::new();
+        let nbt_data = b"Uncompressed chunk data";
+
+        region
+            .write_chunk(31, 31, nbt_data, CompressionMethod::None, 3000)
+            .unwrap();
+
+        let read_data = region.read_chunk(31, 31).unwrap().unwrap();
+        assert_eq!(read_data, nbt_data);
+    }
+
+    #[test]
+    fn read_empty_chunk_returns_none() {
+        let region = RegionFile::new();
+        assert_eq!(region.read_chunk(0, 0).unwrap(), None);
+    }
+
+    #[test]
+    fn multiple_chunks() {
+        let mut region = RegionFile::new();
+
+        for i in 0..10u8 {
+            let data = format!("chunk data {i}");
+            region
+                .write_chunk(
+                    i,
+                    0,
+                    data.as_bytes(),
+                    CompressionMethod::ZLib,
+                    i as u32 * 100,
+                )
+                .unwrap();
+        }
+
+        assert_eq!(region.chunk_count(), 10);
+
+        for i in 0..10u8 {
+            let expected = format!("chunk data {i}");
+            let read_data = region.read_chunk(i, 0).unwrap().unwrap();
+            assert_eq!(read_data, expected.as_bytes());
+            assert_eq!(region.get_timestamp(i, 0).unwrap(), i as u32 * 100);
+        }
+    }
+
+    #[test]
+    fn overwrite_chunk() {
+        let mut region = RegionFile::new();
+
+        region
+            .write_chunk(5, 5, b"first", CompressionMethod::ZLib, 100)
+            .unwrap();
+        region
+            .write_chunk(5, 5, b"second version", CompressionMethod::ZLib, 200)
+            .unwrap();
+
+        let data = region.read_chunk(5, 5).unwrap().unwrap();
+        assert_eq!(data, b"second version");
+        assert_eq!(region.get_timestamp(5, 5).unwrap(), 200);
+        assert_eq!(region.chunk_count(), 1);
+    }
+
+    #[test]
+    fn remove_chunk() {
+        let mut region = RegionFile::new();
+
+        region
+            .write_chunk(3, 3, b"data", CompressionMethod::ZLib, 100)
+            .unwrap();
+        assert_eq!(region.chunk_count(), 1);
+
+        region.remove_chunk(3, 3).unwrap();
+        assert!(!region.has_chunk(3, 3).unwrap());
+        assert_eq!(region.chunk_count(), 0);
+    }
+
+    #[test]
+    fn present_chunks_iterator() {
+        let mut region = RegionFile::new();
+
+        region
+            .write_chunk(0, 0, b"a", CompressionMethod::None, 0)
+            .unwrap();
+        region
+            .write_chunk(5, 10, b"b", CompressionMethod::None, 0)
+            .unwrap();
+        region
+            .write_chunk(31, 31, b"c", CompressionMethod::None, 0)
+            .unwrap();
+
+        let present: Vec<(u8, u8)> = region.present_chunks().collect();
+        assert_eq!(present.len(), 3);
+        assert!(present.contains(&(0, 0)));
+        assert!(present.contains(&(5, 10)));
+        assert!(present.contains(&(31, 31)));
+    }
+
+    #[test]
+    fn serialize_and_reparse() {
+        let mut region = RegionFile::new();
+
+        region
+            .write_chunk(0, 0, b"chunk 0,0", CompressionMethod::ZLib, 100)
+            .unwrap();
+        region
+            .write_chunk(15, 15, b"chunk 15,15", CompressionMethod::GZip, 200)
+            .unwrap();
+        region
+            .write_chunk(31, 0, b"chunk 31,0", CompressionMethod::None, 300)
+            .unwrap();
+
+        let bytes = region.to_bytes();
+        let reparsed = RegionFile::from_bytes(&bytes).unwrap();
+
+        assert_eq!(reparsed.chunk_count(), 3);
+        assert_eq!(reparsed.read_chunk(0, 0).unwrap().unwrap(), b"chunk 0,0");
+        assert_eq!(
+            reparsed.read_chunk(15, 15).unwrap().unwrap(),
+            b"chunk 15,15"
+        );
+        assert_eq!(reparsed.read_chunk(31, 0).unwrap().unwrap(), b"chunk 31,0");
+        assert_eq!(reparsed.get_timestamp(0, 0).unwrap(), 100);
+        assert_eq!(reparsed.get_timestamp(15, 15).unwrap(), 200);
+        assert_eq!(reparsed.get_timestamp(31, 0).unwrap(), 300);
+    }
+
+    #[test]
+    fn file_too_small_error() {
+        let result = RegionFile::from_bytes(&[0u8; 100]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn compression_method_roundtrip() {
+        assert_eq!(
+            CompressionMethod::from_id(1).unwrap(),
+            CompressionMethod::GZip
+        );
+        assert_eq!(
+            CompressionMethod::from_id(2).unwrap(),
+            CompressionMethod::ZLib
+        );
+        assert_eq!(
+            CompressionMethod::from_id(3).unwrap(),
+            CompressionMethod::None
+        );
+        assert!(CompressionMethod::from_id(0).is_err());
+        assert!(CompressionMethod::from_id(4).is_err());
+    }
+
+    #[test]
+    fn large_chunk_data() {
+        let mut region = RegionFile::new();
+        // Write a chunk with significant data (100KB)
+        let large_data = vec![42u8; 100_000];
+
+        region
+            .write_chunk(0, 0, &large_data, CompressionMethod::ZLib, 999)
+            .unwrap();
+
+        let read_data = region.read_chunk(0, 0).unwrap().unwrap();
+        assert_eq!(read_data, large_data);
+    }
+
+    // --- Edge case and hardening tests ---
+
+    #[test]
+    fn header_only_file() {
+        // A valid file with just the 8KB header and no chunk data
+        let data = vec![0u8; DATA_OFFSET];
+        let region = RegionFile::from_bytes(&data).unwrap();
+        assert_eq!(region.chunk_count(), 0);
+        for x in 0..32u8 {
+            for z in 0..32u8 {
+                assert!(!region.has_chunk(x, z).unwrap());
+            }
+        }
+    }
+
+    #[test]
+    fn corrupted_location_pointing_past_file() {
+        let mut data = vec![0u8; DATA_OFFSET];
+        // Set chunk (0,0) location to sector offset 100, count 1
+        // but the file only has 2 sectors (header)
+        data[0] = 0;
+        data[1] = 0;
+        data[2] = 100; // offset = 100
+        data[3] = 1; // sector_count = 1
+
+        let region = RegionFile::from_bytes(&data).unwrap();
+        assert!(region.has_chunk(0, 0).unwrap());
+        let result = region.read_chunk(0, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn zero_data_length_in_sector() {
+        let mut data = vec![0u8; DATA_OFFSET + SECTOR_BYTES];
+        // Location: sector 2, count 1
+        data[0] = 0;
+        data[1] = 0;
+        data[2] = 2;
+        data[3] = 1;
+        // Chunk header at sector 2: data_len = 0 (already zeroed)
+
+        let region = RegionFile::from_bytes(&data).unwrap();
+        let result = region.read_chunk(0, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn data_length_exceeds_sector_allocation() {
+        let mut data = vec![0u8; DATA_OFFSET + SECTOR_BYTES];
+        data[0] = 0;
+        data[1] = 0;
+        data[2] = 2;
+        data[3] = 1; // 1 sector = 4096 bytes
+        // Chunk header: data_len = 5000 (exceeds single sector)
+        let len_bytes = 5000u32.to_be_bytes();
+        let base = DATA_OFFSET;
+        data[base..base + 4].copy_from_slice(&len_bytes);
+
+        let region = RegionFile::from_bytes(&data).unwrap();
+        let result = region.read_chunk(0, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_compression_in_chunk() {
+        let mut data = vec![0u8; DATA_OFFSET + SECTOR_BYTES];
+        data[0] = 0;
+        data[1] = 0;
+        data[2] = 2;
+        data[3] = 1;
+        let base = DATA_OFFSET;
+        data[base + 3] = 2; // length = 2
+        data[base + 4] = 99; // unknown compression method
+        data[base + 5] = 0;
+
+        let region = RegionFile::from_bytes(&data).unwrap();
+        let result = region.read_chunk(0, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn all_1024_chunks() {
+        let mut region = RegionFile::new();
+        for z in 0..32u8 {
+            for x in 0..32u8 {
+                let data = format!("({x},{z})");
+                region
+                    .write_chunk(x, z, data.as_bytes(), CompressionMethod::ZLib, 0)
+                    .unwrap();
+            }
+        }
+        assert_eq!(region.chunk_count(), 1024);
+
+        for z in 0..32u8 {
+            for x in 0..32u8 {
+                let expected = format!("({x},{z})");
+                let read = region.read_chunk(x, z).unwrap().unwrap();
+                assert_eq!(read, expected.as_bytes());
+            }
+        }
+
+        let bytes = region.to_bytes();
+        let reparsed = RegionFile::from_bytes(&bytes).unwrap();
+        assert_eq!(reparsed.chunk_count(), 1024);
+
+        assert_eq!(reparsed.read_chunk(0, 0).unwrap().unwrap(), b"(0,0)");
+        assert_eq!(
+            reparsed.read_chunk(31, 31).unwrap().unwrap(),
+            b"(31,31)"
+        );
+    }
+
+    #[test]
+    fn write_remove_rewrite() {
+        let mut region = RegionFile::new();
+
+        region
+            .write_chunk(0, 0, b"original", CompressionMethod::ZLib, 100)
+            .unwrap();
+        region
+            .write_chunk(1, 0, b"second", CompressionMethod::ZLib, 200)
+            .unwrap();
+        assert_eq!(region.chunk_count(), 2);
+
+        region.remove_chunk(0, 0).unwrap();
+        assert_eq!(region.chunk_count(), 1);
+
+        region
+            .write_chunk(0, 0, b"replaced", CompressionMethod::ZLib, 300)
+            .unwrap();
+        assert_eq!(region.chunk_count(), 2);
+        assert_eq!(region.read_chunk(0, 0).unwrap().unwrap(), b"replaced");
+        assert_eq!(region.read_chunk(1, 0).unwrap().unwrap(), b"second");
+    }
+
+    #[test]
+    fn timestamp_updates_correctly() {
+        let mut region = RegionFile::new();
+
+        region
+            .write_chunk(5, 5, b"data1", CompressionMethod::ZLib, 1000)
+            .unwrap();
+        assert_eq!(region.get_timestamp(5, 5).unwrap(), 1000);
+
+        region
+            .write_chunk(5, 5, b"data2", CompressionMethod::ZLib, 2000)
+            .unwrap();
+        assert_eq!(region.get_timestamp(5, 5).unwrap(), 2000);
+
+        let bytes = region.to_bytes();
+        let reparsed = RegionFile::from_bytes(&bytes).unwrap();
+        assert_eq!(reparsed.get_timestamp(5, 5).unwrap(), 2000);
+    }
+
+    #[test]
+    fn max_sector_offset() {
+        let loc = ChunkLocation {
+            offset: 0xFF_FFFF,
+            sector_count: 255,
+        };
+        let bytes = loc.to_bytes();
+        let decoded = ChunkLocation::from_bytes(bytes);
+        assert_eq!(decoded.offset, 0xFF_FFFF);
+        assert_eq!(decoded.sector_count, 255);
+    }
+
+    #[test]
+    fn write_to_writer() {
+        let mut region = RegionFile::new();
+        region
+            .write_chunk(0, 0, b"test", CompressionMethod::None, 0)
+            .unwrap();
+
+        let mut buf = Vec::new();
+        region.write_to(&mut buf).unwrap();
+        assert_eq!(buf, region.to_bytes());
+    }
+
+    #[test]
+    fn file_one_byte_too_small() {
+        let data = vec![0u8; DATA_OFFSET - 1];
+        assert!(RegionFile::from_bytes(&data).is_err());
+    }
+
+    #[test]
+    fn nbt_integration() {
+        // Test with actual NBT data
+        use crate::Nbt;
+        use crate::compound::NbtCompound;
+        use crate::tag::NbtTag;
+
+        let mut compound = NbtCompound::new();
+        compound.put_int("DataVersion", 4671);
+        compound.put_int("xPos", 0);
+        compound.put_int("zPos", 0);
+        compound.put_string("Status", "full".to_string());
+        compound.put("Sections", NbtTag::List(vec![]));
+
+        let nbt = Nbt::new(String::new(), compound);
+        let nbt_bytes = nbt.write();
+
+        let mut region = RegionFile::new();
+        region
+            .write_chunk(0, 0, &nbt_bytes, CompressionMethod::ZLib, 1234)
+            .unwrap();
+
+        let read_bytes = region.read_chunk(0, 0).unwrap().unwrap();
+        assert_eq!(read_bytes, nbt_bytes.as_ref());
+    }
+}

--- a/pumpkin-nbt/src/player_data.rs
+++ b/pumpkin-nbt/src/player_data.rs
@@ -1,0 +1,504 @@
+//! Player data NBT helpers.
+//!
+//! Provides utility functions for encoding and decoding Minecraft player data
+//! between Rust types and NBT format. These helpers match the vanilla Minecraft
+//! player data file format (`.dat` files in the `playerdata/` directory).
+//!
+//! # UUID Encoding
+//!
+//! Minecraft stores UUIDs as `IntArray` with 4 elements (most-significant
+//! first), not as strings.
+//!
+//! ```
+//! use pumpkin_nbt::player_data::{uuid_to_int_array, uuid_from_int_array};
+//!
+//! let uuid = 0x12345678_9abcdef0_12345678_9abcdef0u128;
+//! let arr = uuid_to_int_array(uuid);
+//! assert_eq!(uuid_from_int_array(&arr), Some(uuid));
+//! ```
+//!
+//! # Position and Rotation
+//!
+//! Position is stored as a `List` of 3 `Double` values `[x, y, z]`.
+//! Rotation is stored as a `List` of 2 `Float` values `[yaw, pitch]`.
+//! Motion/velocity uses the same 3-double format as position.
+
+use crate::compound::NbtCompound;
+use crate::tag::NbtTag;
+
+/// Encode a UUID as an `IntArray` of 4 i32 values (most-significant first).
+///
+/// This matches Minecraft's NBT UUID encoding: the 128-bit UUID is split
+/// into four 32-bit signed integers in big-endian order.
+#[must_use]
+pub const fn uuid_to_int_array(uuid: u128) -> [i32; 4] {
+    [
+        ((uuid >> 96) & 0xFFFF_FFFF) as i32,
+        ((uuid >> 64) & 0xFFFF_FFFF) as i32,
+        ((uuid >> 32) & 0xFFFF_FFFF) as i32,
+        (uuid & 0xFFFF_FFFF) as i32,
+    ]
+}
+
+/// Decode a UUID from an `IntArray` of 4 i32 values.
+///
+/// Returns `None` if the slice does not contain exactly 4 elements.
+#[must_use]
+pub fn uuid_from_int_array(arr: &[i32]) -> Option<u128> {
+    if arr.len() != 4 {
+        return None;
+    }
+    let a = (arr[0] as u32) as u128;
+    let b = (arr[1] as u32) as u128;
+    let c = (arr[2] as u32) as u128;
+    let d = (arr[3] as u32) as u128;
+    Some((a << 96) | (b << 64) | (c << 32) | d)
+}
+
+/// Encode a UUID into an [`NbtTag::IntArray`].
+#[must_use]
+pub fn uuid_to_nbt(uuid: u128) -> NbtTag {
+    let arr = uuid_to_int_array(uuid);
+    NbtTag::IntArray(arr.to_vec())
+}
+
+/// Decode a UUID from an [`NbtTag::IntArray`].
+///
+/// Returns `None` if the tag is not an `IntArray` or does not contain
+/// exactly 4 elements.
+#[must_use]
+pub fn uuid_from_nbt(tag: &NbtTag) -> Option<u128> {
+    tag.extract_int_array().and_then(uuid_from_int_array)
+}
+
+/// Encode a 3D position as an [`NbtTag::List`] of 3 `Double` values.
+///
+/// Matches Minecraft's `Pos` tag format: `[x, y, z]`.
+#[must_use]
+pub fn position_to_nbt(x: f64, y: f64, z: f64) -> NbtTag {
+    NbtTag::List(vec![NbtTag::Double(x), NbtTag::Double(y), NbtTag::Double(z)])
+}
+
+/// Decode a 3D position from an [`NbtTag::List`] of 3 `Double` values.
+///
+/// Returns `None` if the tag is not a `List` of exactly 3 `Double` elements.
+#[must_use]
+pub fn position_from_nbt(tag: &NbtTag) -> Option<(f64, f64, f64)> {
+    let list = tag.extract_list()?;
+    if list.len() != 3 {
+        return None;
+    }
+    let x = list[0].extract_double()?;
+    let y = list[1].extract_double()?;
+    let z = list[2].extract_double()?;
+    Some((x, y, z))
+}
+
+/// Encode a rotation as an [`NbtTag::List`] of 2 `Float` values.
+///
+/// Matches Minecraft's `Rotation` tag format: `[yaw, pitch]`.
+#[must_use]
+pub fn rotation_to_nbt(yaw: f32, pitch: f32) -> NbtTag {
+    NbtTag::List(vec![NbtTag::Float(yaw), NbtTag::Float(pitch)])
+}
+
+/// Decode a rotation from an [`NbtTag::List`] of 2 `Float` values.
+///
+/// Returns `None` if the tag is not a `List` of exactly 2 `Float` elements.
+#[must_use]
+pub fn rotation_from_nbt(tag: &NbtTag) -> Option<(f32, f32)> {
+    let list = tag.extract_list()?;
+    if list.len() != 2 {
+        return None;
+    }
+    let yaw = list[0].extract_float()?;
+    let pitch = list[1].extract_float()?;
+    Some((yaw, pitch))
+}
+
+/// Encode a 3D velocity/motion as an [`NbtTag::List`] of 3 `Double` values.
+///
+/// Matches Minecraft's `Motion` tag format: `[dx, dy, dz]`.
+#[must_use]
+pub fn motion_to_nbt(dx: f64, dy: f64, dz: f64) -> NbtTag {
+    position_to_nbt(dx, dy, dz)
+}
+
+/// Decode a 3D velocity/motion from an [`NbtTag::List`] of 3 `Double` values.
+///
+/// Returns `None` if the tag is not a `List` of exactly 3 `Double` elements.
+#[must_use]
+pub fn motion_from_nbt(tag: &NbtTag) -> Option<(f64, f64, f64)> {
+    position_from_nbt(tag)
+}
+
+/// Standard entity fields matching vanilla Minecraft's NBT format.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EntityBase {
+    pub uuid: u128,
+    pub pos: (f64, f64, f64),
+    pub motion: (f64, f64, f64),
+    pub rotation: (f32, f32),
+    pub on_ground: bool,
+    pub fire_ticks: i16,
+}
+
+impl EntityBase {
+    /// Write this entity's fields into an [`NbtCompound`].
+    pub fn write_to(&self, compound: &mut NbtCompound) {
+        compound.put("UUID", uuid_to_nbt(self.uuid));
+        compound.put("Pos", position_to_nbt(self.pos.0, self.pos.1, self.pos.2));
+        compound.put(
+            "Motion",
+            motion_to_nbt(self.motion.0, self.motion.1, self.motion.2),
+        );
+        compound.put(
+            "Rotation",
+            rotation_to_nbt(self.rotation.0, self.rotation.1),
+        );
+        compound.put_bool("OnGround", self.on_ground);
+        compound.put_short("Fire", self.fire_ticks);
+    }
+
+    /// Read entity fields from an [`NbtCompound`].
+    ///
+    /// Returns `None` if any required field is missing or has the wrong type.
+    #[must_use]
+    pub fn read_from(compound: &NbtCompound) -> Option<Self> {
+        Some(Self {
+            uuid: compound.get("UUID").and_then(uuid_from_nbt)?,
+            pos: compound.get("Pos").and_then(position_from_nbt)?,
+            motion: compound.get("Motion").and_then(motion_from_nbt)?,
+            rotation: compound.get("Rotation").and_then(rotation_from_nbt)?,
+            on_ground: compound.get_bool("OnGround")?,
+            fire_ticks: compound.get_short("Fire")?,
+        })
+    }
+}
+
+/// Player abilities matching vanilla Minecraft's NBT format.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayerAbilities {
+    pub invulnerable: bool,
+    pub flying: bool,
+    pub may_fly: bool,
+    pub instabuild: bool,
+    pub may_build: bool,
+    pub fly_speed: f32,
+    pub walk_speed: f32,
+}
+
+impl PlayerAbilities {
+    /// Write abilities as an `abilities` sub-compound into the given compound.
+    pub fn write_to(&self, compound: &mut NbtCompound) {
+        let mut abilities = NbtCompound::new();
+        abilities.put_bool("invulnerable", self.invulnerable);
+        abilities.put_bool("flying", self.flying);
+        abilities.put_bool("mayfly", self.may_fly);
+        abilities.put_bool("instabuild", self.instabuild);
+        abilities.put_bool("mayBuild", self.may_build);
+        abilities.put_float("flySpeed", self.fly_speed);
+        abilities.put_float("walkSpeed", self.walk_speed);
+        compound.put_component("abilities", abilities);
+    }
+
+    /// Read abilities from the `abilities` sub-compound.
+    ///
+    /// Returns `None` if the compound is missing or incomplete.
+    #[must_use]
+    pub fn read_from(compound: &NbtCompound) -> Option<Self> {
+        let abilities = compound.get_compound("abilities")?;
+        Some(Self {
+            invulnerable: abilities.get_bool("invulnerable")?,
+            flying: abilities.get_bool("flying")?,
+            may_fly: abilities.get_bool("mayfly")?,
+            instabuild: abilities.get_bool("instabuild")?,
+            may_build: abilities.get_bool("mayBuild")?,
+            fly_speed: abilities.get_float("flySpeed")?,
+            walk_speed: abilities.get_float("walkSpeed")?,
+        })
+    }
+}
+
+/// Encode a game mode as a byte value for NBT storage.
+///
+/// Matches Minecraft's `playerGameType` encoding:
+/// - 0 = Survival
+/// - 1 = Creative
+/// - 2 = Adventure
+/// - 3 = Spectator
+#[must_use]
+pub const fn game_mode_to_byte(mode: u8) -> i8 {
+    mode as i8
+}
+
+/// Decode a game mode from a byte value.
+///
+/// Returns `None` if the value is not a valid game mode (0-3).
+#[must_use]
+pub const fn game_mode_from_byte(byte: i8) -> Option<u8> {
+    match byte {
+        0..=3 => Some(byte as u8),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_roundtrip() {
+        let uuid = 0x12345678_9ABCDEF0_12345678_9ABCDEF0u128;
+        let arr = uuid_to_int_array(uuid);
+        assert_eq!(uuid_from_int_array(&arr), Some(uuid));
+    }
+
+    #[test]
+    fn uuid_zero() {
+        let arr = uuid_to_int_array(0);
+        assert_eq!(arr, [0, 0, 0, 0]);
+        assert_eq!(uuid_from_int_array(&arr), Some(0));
+    }
+
+    #[test]
+    fn uuid_max() {
+        let uuid = u128::MAX;
+        let arr = uuid_to_int_array(uuid);
+        assert_eq!(arr, [-1, -1, -1, -1]); // all 0xFFFFFFFF as i32
+        assert_eq!(uuid_from_int_array(&arr), Some(uuid));
+    }
+
+    #[test]
+    fn uuid_wrong_length() {
+        assert_eq!(uuid_from_int_array(&[1, 2, 3]), None);
+        assert_eq!(uuid_from_int_array(&[1, 2, 3, 4, 5]), None);
+        assert_eq!(uuid_from_int_array(&[]), None);
+    }
+
+    #[test]
+    fn uuid_nbt_roundtrip() {
+        let uuid = 0xDEADBEEF_CAFEBABE_12345678_87654321u128;
+        let tag = uuid_to_nbt(uuid);
+        assert_eq!(uuid_from_nbt(&tag), Some(uuid));
+    }
+
+    #[test]
+    fn uuid_nbt_wrong_type() {
+        assert_eq!(uuid_from_nbt(&NbtTag::Int(42)), None);
+        assert_eq!(uuid_from_nbt(&NbtTag::String("test".into())), None);
+    }
+
+    #[test]
+    fn position_roundtrip() {
+        let tag = position_to_nbt(1.5, 64.0, -3.25);
+        assert_eq!(position_from_nbt(&tag), Some((1.5, 64.0, -3.25)));
+    }
+
+    #[test]
+    fn position_wrong_length() {
+        let tag = NbtTag::List(vec![NbtTag::Double(1.0), NbtTag::Double(2.0)]);
+        assert_eq!(position_from_nbt(&tag), None);
+    }
+
+    #[test]
+    fn position_wrong_type() {
+        let tag = NbtTag::List(vec![NbtTag::Int(1), NbtTag::Int(2), NbtTag::Int(3)]);
+        assert_eq!(position_from_nbt(&tag), None);
+    }
+
+    #[test]
+    fn rotation_roundtrip() {
+        let tag = rotation_to_nbt(90.0, -45.5);
+        assert_eq!(rotation_from_nbt(&tag), Some((90.0, -45.5)));
+    }
+
+    #[test]
+    fn rotation_wrong_length() {
+        let tag = NbtTag::List(vec![NbtTag::Float(1.0)]);
+        assert_eq!(rotation_from_nbt(&tag), None);
+    }
+
+    #[test]
+    fn motion_roundtrip() {
+        let tag = motion_to_nbt(0.1, -0.5, 0.3);
+        assert_eq!(motion_from_nbt(&tag), Some((0.1, -0.5, 0.3)));
+    }
+
+    #[test]
+    fn entity_base_roundtrip() {
+        let mut compound = NbtCompound::new();
+        let entity = EntityBase {
+            uuid: 0xABCDEF01_23456789_ABCDEF01_23456789u128,
+            pos: (100.5, 64.0, -200.25),
+            motion: (0.1, -0.5, 0.3),
+            rotation: (90.0f32, -45.0f32),
+            on_ground: true,
+            fire_ticks: 100,
+        };
+        entity.write_to(&mut compound);
+
+        let parsed = EntityBase::read_from(&compound).unwrap();
+        assert_eq!(parsed, entity);
+    }
+
+    #[test]
+    fn entity_base_missing_field() {
+        let compound = NbtCompound::new();
+        assert!(EntityBase::read_from(&compound).is_none());
+    }
+
+    #[test]
+    fn abilities_roundtrip() {
+        let mut compound = NbtCompound::new();
+        let abilities = PlayerAbilities {
+            invulnerable: false,
+            flying: true,
+            may_fly: true,
+            instabuild: false,
+            may_build: true,
+            fly_speed: 0.05,
+            walk_speed: 0.1,
+        };
+        abilities.write_to(&mut compound);
+
+        let parsed = PlayerAbilities::read_from(&compound).unwrap();
+        assert_eq!(parsed, abilities);
+    }
+
+    #[test]
+    fn abilities_missing() {
+        let compound = NbtCompound::new();
+        assert!(PlayerAbilities::read_from(&compound).is_none());
+    }
+
+    #[test]
+    fn game_mode_valid() {
+        assert_eq!(game_mode_from_byte(0), Some(0)); // Survival
+        assert_eq!(game_mode_from_byte(1), Some(1)); // Creative
+        assert_eq!(game_mode_from_byte(2), Some(2)); // Adventure
+        assert_eq!(game_mode_from_byte(3), Some(3)); // Spectator
+    }
+
+    #[test]
+    fn game_mode_invalid() {
+        assert_eq!(game_mode_from_byte(-1), None);
+        assert_eq!(game_mode_from_byte(4), None);
+        assert_eq!(game_mode_from_byte(127), None);
+    }
+
+    #[test]
+    fn full_player_compound() {
+        let mut compound = NbtCompound::new();
+
+        // Entity base
+        let entity = EntityBase {
+            uuid: 0x01234567_89ABCDEF_01234567_89ABCDEFu128,
+            pos: (100.0, 65.0, -200.0),
+            motion: (0.0, 0.0, 0.0),
+            rotation: (180.0, 0.0),
+            on_ground: true,
+            fire_ticks: 0,
+        };
+        entity.write_to(&mut compound);
+
+        // Player-specific
+        compound.put_int("DataVersion", 4671);
+        compound.put_byte("playerGameType", game_mode_to_byte(1));
+        compound.put_bool("HasPlayedBefore", true);
+        compound.put_string("Dimension", "minecraft:overworld".to_string());
+        compound.put_int("XpTotal", 1000);
+
+        // Hunger
+        compound.put_int("foodLevel", 20);
+        compound.put_float("foodSaturationLevel", 5.0);
+        compound.put_float("foodExhaustionLevel", 0.0);
+        compound.put_int("foodTickTimer", 0);
+
+        // Health
+        compound.put_float("Health", 20.0);
+
+        // Abilities
+        let abilities = PlayerAbilities {
+            invulnerable: false,
+            flying: false,
+            may_fly: true,
+            instabuild: true,
+            may_build: true,
+            fly_speed: 0.05,
+            walk_speed: 0.1,
+        };
+        abilities.write_to(&mut compound);
+
+        // Spawn point
+        compound.put_int("SpawnX", 0);
+        compound.put_int("SpawnY", 64);
+        compound.put_int("SpawnZ", 0);
+
+        // Verify all fields
+        assert_eq!(compound.get_int("DataVersion"), Some(4671));
+        assert_eq!(compound.get_byte("playerGameType"), Some(1));
+        assert_eq!(
+            game_mode_from_byte(compound.get_byte("playerGameType").unwrap()),
+            Some(1)
+        );
+        assert_eq!(compound.get_bool("HasPlayedBefore"), Some(true));
+        assert_eq!(compound.get_string("Dimension"), Some("minecraft:overworld"));
+        assert_eq!(compound.get_int("XpTotal"), Some(1000));
+        assert_eq!(compound.get_int("foodLevel"), Some(20));
+        assert_eq!(compound.get_float("Health"), Some(20.0));
+        assert_eq!(compound.get_int("SpawnX"), Some(0));
+
+        let parsed_entity = EntityBase::read_from(&compound).unwrap();
+        assert_eq!(parsed_entity.pos, (100.0, 65.0, -200.0));
+
+        let parsed_abilities = PlayerAbilities::read_from(&compound).unwrap();
+        assert!(parsed_abilities.instabuild);
+    }
+
+    #[test]
+    fn nbt_binary_roundtrip() {
+        use crate::Nbt;
+
+        let mut compound = NbtCompound::new();
+        let uuid = 0xDEADBEEF_12345678_CAFEBABE_87654321u128;
+        let entity = EntityBase {
+            uuid,
+            pos: (1.0, 2.0, 3.0),
+            motion: (0.0, 0.0, 0.0),
+            rotation: (0.0, 0.0),
+            on_ground: false,
+            fire_ticks: 0,
+        };
+        entity.write_to(&mut compound);
+
+        let abilities = PlayerAbilities {
+            invulnerable: false,
+            flying: false,
+            may_fly: false,
+            instabuild: false,
+            may_build: true,
+            fly_speed: 0.05,
+            walk_speed: 0.1,
+        };
+        abilities.write_to(&mut compound);
+
+        // Serialize to NBT binary
+        let nbt = Nbt::new(String::new(), compound);
+        let bytes = nbt.write();
+
+        // Deserialize back
+        let mut cursor = std::io::Cursor::new(bytes.to_vec());
+        let mut reader = crate::deserializer::NbtReadHelper::new(&mut cursor);
+        let parsed = Nbt::read(&mut reader).unwrap();
+
+        // Verify UUID survives roundtrip
+        let re_uuid = parsed.root_tag.get("UUID").and_then(uuid_from_nbt);
+        assert_eq!(re_uuid, Some(uuid));
+
+        // Verify abilities survive roundtrip
+        let parsed_abilities = PlayerAbilities::read_from(&parsed.root_tag);
+        assert!(parsed_abilities.is_some());
+        assert!(parsed_abilities.unwrap().may_build);
+    }
+}

--- a/pumpkin-nbt/src/snbt.rs
+++ b/pumpkin-nbt/src/snbt.rs
@@ -1,0 +1,1028 @@
+//! SNBT (Stringified NBT) parser.
+//!
+//! Parses SNBT text format into [`NbtTag`] values. SNBT is Minecraft's
+//! human-readable text representation of NBT data, used in commands,
+//! data packs, and debugging.
+//!
+//! # SNBT Syntax
+//!
+//! | NBT Type    | SNBT Example                  |
+//! |-------------|-------------------------------|
+//! | Byte        | `1b` or `1B` or `true`/`false`|
+//! | Short       | `1s` or `1S`                  |
+//! | Int         | `1`                           |
+//! | Long        | `1l` or `1L`                  |
+//! | Float       | `1.0f` or `1.0F`              |
+//! | Double      | `1.0d` or `1.0D` or `1.0`     |
+//! | String      | `"hello"` or `'hello'` or `hello` |
+//! | `ByteArray` | `[B; 1b, 2b, 3b]`            |
+//! | `IntArray`  | `[I; 1, 2, 3]`               |
+//! | `LongArray` | `[L; 1L, 2L, 3L]`            |
+//! | List        | `[1, 2, 3]`                   |
+//! | Compound    | `{key: value, key2: value2}`  |
+//!
+//! # Example
+//!
+//! ```
+//! use pumpkin_nbt::snbt::from_snbt;
+//! use pumpkin_nbt::tag::NbtTag;
+//!
+//! let tag = from_snbt("{name: \"Steve\", health: 20.0f}").unwrap();
+//! if let NbtTag::Compound(compound) = &tag {
+//!     assert_eq!(compound.get_string("name"), Some("Steve"));
+//!     assert_eq!(compound.get_float("health"), Some(20.0));
+//! }
+//! ```
+
+use crate::compound::NbtCompound;
+use crate::tag::NbtTag;
+
+/// Errors that can occur during SNBT parsing.
+#[derive(Debug)]
+pub enum SnbtError {
+    /// Unexpected end of input.
+    UnexpectedEof,
+    /// Expected a specific character but found something else.
+    Expected {
+        expected: char,
+        found: Option<char>,
+        pos: usize,
+    },
+    /// Invalid number format.
+    InvalidNumber { text: String, pos: usize },
+    /// Unterminated string literal.
+    UnterminatedString { pos: usize },
+    /// Unexpected character at the given position.
+    UnexpectedChar { ch: char, pos: usize },
+    /// Trailing characters after a complete value.
+    TrailingData { pos: usize },
+    /// Invalid escape sequence in a string.
+    InvalidEscape { ch: char, pos: usize },
+}
+
+impl std::fmt::Display for SnbtError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnexpectedEof => write!(f, "Unexpected end of SNBT input"),
+            Self::Expected {
+                expected,
+                found,
+                pos,
+            } => match found {
+                Some(ch) => write!(f, "Expected '{expected}' at position {pos}, found '{ch}'"),
+                None => write!(f, "Expected '{expected}' at position {pos}, found EOF"),
+            },
+            Self::InvalidNumber { text, pos } => {
+                write!(f, "Invalid number '{text}' at position {pos}")
+            }
+            Self::UnterminatedString { pos } => {
+                write!(f, "Unterminated string starting at position {pos}")
+            }
+            Self::UnexpectedChar { ch, pos } => {
+                write!(f, "Unexpected character '{ch}' at position {pos}")
+            }
+            Self::TrailingData { pos } => {
+                write!(f, "Trailing data at position {pos}")
+            }
+            Self::InvalidEscape { ch, pos } => {
+                write!(f, "Invalid escape sequence '\\{ch}' at position {pos}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SnbtError {}
+
+/// Parse an SNBT string into an [`NbtTag`].
+///
+/// The input must contain exactly one complete SNBT value with no trailing
+/// data (except whitespace).
+pub fn from_snbt(input: &str) -> Result<NbtTag, SnbtError> {
+    let mut parser = SnbtParser::new(input);
+    let tag = parser.parse_value()?;
+    parser.skip_whitespace();
+    if parser.pos < parser.input.len() {
+        return Err(SnbtError::TrailingData { pos: parser.pos });
+    }
+    Ok(tag)
+}
+
+/// Parse an SNBT string into an [`NbtCompound`].
+///
+/// Convenience function that parses a compound and returns it directly.
+/// The input must represent a compound value (starting with `{`).
+pub fn from_snbt_compound(input: &str) -> Result<NbtCompound, SnbtError> {
+    match from_snbt(input)? {
+        NbtTag::Compound(compound) => Ok(compound),
+        _other => Err(SnbtError::UnexpectedChar {
+            ch: input.chars().next().unwrap_or(' '),
+            pos: 0,
+        }),
+    }
+}
+
+struct SnbtParser<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> SnbtParser<'a> {
+    const fn new(input: &'a str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let ch = self.input.get(self.pos).copied();
+        if ch.is_some() {
+            self.pos += 1;
+        }
+        ch
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.input.len() && self.input[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn expect(&mut self, expected: u8) -> Result<(), SnbtError> {
+        match self.advance() {
+            Some(ch) if ch == expected => Ok(()),
+            Some(ch) => Err(SnbtError::Expected {
+                expected: expected as char,
+                found: Some(ch as char),
+                pos: self.pos - 1,
+            }),
+            None => Err(SnbtError::Expected {
+                expected: expected as char,
+                found: None,
+                pos: self.pos,
+            }),
+        }
+    }
+
+    fn parse_value(&mut self) -> Result<NbtTag, SnbtError> {
+        self.skip_whitespace();
+
+        match self.peek() {
+            None => Err(SnbtError::UnexpectedEof),
+            Some(b'{') => self.parse_compound().map(NbtTag::Compound),
+            Some(b'[') => self.parse_list_or_array(),
+            Some(b'"') => self.parse_quoted_string(b'"').map(NbtTag::String),
+            Some(b'\'') => self.parse_quoted_string(b'\'').map(NbtTag::String),
+            Some(_) => self.parse_primitive(),
+        }
+    }
+
+    fn parse_compound(&mut self) -> Result<NbtCompound, SnbtError> {
+        self.expect(b'{')?;
+        self.skip_whitespace();
+
+        let mut compound = NbtCompound::new();
+
+        if self.peek() == Some(b'}') {
+            self.advance();
+            return Ok(compound);
+        }
+
+        loop {
+            self.skip_whitespace();
+
+            // Parse key: quoted or unquoted string
+            let key = self.parse_key()?;
+
+            self.skip_whitespace();
+            self.expect(b':')?;
+
+            let value = self.parse_value()?;
+            compound.child_tags.push((key, value));
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b'}') => {
+                    self.advance();
+                    return Ok(compound);
+                }
+                Some(ch) => {
+                    return Err(SnbtError::Expected {
+                        expected: '}',
+                        found: Some(ch as char),
+                        pos: self.pos,
+                    });
+                }
+                None => return Err(SnbtError::UnexpectedEof),
+            }
+        }
+    }
+
+    fn parse_key(&mut self) -> Result<String, SnbtError> {
+        match self.peek() {
+            Some(b'"') => self.parse_quoted_string(b'"'),
+            Some(b'\'') => self.parse_quoted_string(b'\''),
+            _ => self.parse_unquoted_string(),
+        }
+    }
+
+    fn parse_quoted_string(&mut self, quote: u8) -> Result<String, SnbtError> {
+        let start = self.pos;
+        self.expect(quote)?;
+
+        let mut result = String::new();
+        loop {
+            match self.advance() {
+                None => return Err(SnbtError::UnterminatedString { pos: start }),
+                Some(b'\\') => {
+                    // Escape sequence
+                    match self.advance() {
+                        None => return Err(SnbtError::UnterminatedString { pos: start }),
+                        Some(b'"') => result.push('"'),
+                        Some(b'\'') => result.push('\''),
+                        Some(b'\\') => result.push('\\'),
+                        Some(b'n') => result.push('\n'),
+                        Some(b't') => result.push('\t'),
+                        Some(b'r') => result.push('\r'),
+                        Some(ch) => {
+                            return Err(SnbtError::InvalidEscape {
+                                ch: ch as char,
+                                pos: self.pos - 1,
+                            });
+                        }
+                    }
+                }
+                Some(ch) if ch == quote => return Ok(result),
+                Some(ch) => result.push(ch as char),
+            }
+        }
+    }
+
+    fn parse_unquoted_string(&mut self) -> Result<String, SnbtError> {
+        let start = self.pos;
+        while self.pos < self.input.len() {
+            let ch = self.input[self.pos];
+            // Unquoted strings can contain alphanumeric, underscore, hyphen, dot, plus
+            if ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'-' || ch == b'.' || ch == b'+' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+
+        if self.pos == start {
+            return Err(match self.peek() {
+                Some(ch) => SnbtError::UnexpectedChar {
+                    ch: ch as char,
+                    pos: self.pos,
+                },
+                None => SnbtError::UnexpectedEof,
+            });
+        }
+
+        Ok(std::str::from_utf8(&self.input[start..self.pos])
+            .unwrap()
+            .to_string())
+    }
+
+    fn parse_list_or_array(&mut self) -> Result<NbtTag, SnbtError> {
+        // Peek ahead to check for array prefix: [B;  [I;  [L;
+        self.expect(b'[')?;
+        self.skip_whitespace();
+
+        if self.pos + 1 < self.input.len() {
+            let type_char = self.input[self.pos];
+            // Check for whitespace between type char and semicolon
+            let mut check_pos = self.pos + 1;
+            while check_pos < self.input.len() && self.input[check_pos].is_ascii_whitespace() {
+                check_pos += 1;
+            }
+            if check_pos < self.input.len() && self.input[check_pos] == b';' {
+                match type_char {
+                    b'B' => {
+                        self.pos = check_pos + 1;
+                        return self.parse_byte_array();
+                    }
+                    b'I' => {
+                        self.pos = check_pos + 1;
+                        return self.parse_int_array();
+                    }
+                    b'L' => {
+                        self.pos = check_pos + 1;
+                        return self.parse_long_array();
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // It's a regular list
+        self.parse_list()
+    }
+
+    fn parse_byte_array(&mut self) -> Result<NbtTag, SnbtError> {
+        self.skip_whitespace();
+        let mut values = Vec::new();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Ok(NbtTag::ByteArray(values.into_boxed_slice()));
+        }
+
+        loop {
+            self.skip_whitespace();
+            let value = self.parse_byte_value()?;
+            values.push(value as u8);
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b']') => {
+                    self.advance();
+                    return Ok(NbtTag::ByteArray(values.into_boxed_slice()));
+                }
+                Some(ch) => {
+                    return Err(SnbtError::Expected {
+                        expected: ']',
+                        found: Some(ch as char),
+                        pos: self.pos,
+                    });
+                }
+                None => return Err(SnbtError::UnexpectedEof),
+            }
+        }
+    }
+
+    fn parse_byte_value(&mut self) -> Result<i8, SnbtError> {
+        // Check for boolean values
+        let start = self.pos;
+        let text = self.collect_number_text();
+
+        if text == "true" {
+            return Ok(1);
+        }
+        if text == "false" {
+            return Ok(0);
+        }
+
+        // Strip trailing 'b' or 'B'
+        let num_text = if text.ends_with('b') || text.ends_with('B') {
+            &text[..text.len() - 1]
+        } else {
+            &text
+        };
+
+        num_text
+            .parse::<i8>()
+            .map_err(|_| SnbtError::InvalidNumber {
+                text: text.clone(),
+                pos: start,
+            })
+    }
+
+    fn parse_int_array(&mut self) -> Result<NbtTag, SnbtError> {
+        self.skip_whitespace();
+        let mut values = Vec::new();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Ok(NbtTag::IntArray(values));
+        }
+
+        loop {
+            self.skip_whitespace();
+            let start = self.pos;
+            let text = self.collect_number_text();
+            let value = text.parse::<i32>().map_err(|_| SnbtError::InvalidNumber {
+                text: text.clone(),
+                pos: start,
+            })?;
+            values.push(value);
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b']') => {
+                    self.advance();
+                    return Ok(NbtTag::IntArray(values));
+                }
+                Some(ch) => {
+                    return Err(SnbtError::Expected {
+                        expected: ']',
+                        found: Some(ch as char),
+                        pos: self.pos,
+                    });
+                }
+                None => return Err(SnbtError::UnexpectedEof),
+            }
+        }
+    }
+
+    fn parse_long_array(&mut self) -> Result<NbtTag, SnbtError> {
+        self.skip_whitespace();
+        let mut values = Vec::new();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Ok(NbtTag::LongArray(values));
+        }
+
+        loop {
+            self.skip_whitespace();
+            let start = self.pos;
+            let text = self.collect_number_text();
+
+            // Strip trailing 'l' or 'L'
+            let num_text = if text.ends_with('l') || text.ends_with('L') {
+                &text[..text.len() - 1]
+            } else {
+                &text
+            };
+
+            let value = num_text
+                .parse::<i64>()
+                .map_err(|_| SnbtError::InvalidNumber {
+                    text: text.clone(),
+                    pos: start,
+                })?;
+            values.push(value);
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b']') => {
+                    self.advance();
+                    return Ok(NbtTag::LongArray(values));
+                }
+                Some(ch) => {
+                    return Err(SnbtError::Expected {
+                        expected: ']',
+                        found: Some(ch as char),
+                        pos: self.pos,
+                    });
+                }
+                None => return Err(SnbtError::UnexpectedEof),
+            }
+        }
+    }
+
+    fn parse_list(&mut self) -> Result<NbtTag, SnbtError> {
+        self.skip_whitespace();
+        let mut values = Vec::new();
+
+        if self.peek() == Some(b']') {
+            self.advance();
+            return Ok(NbtTag::List(values));
+        }
+
+        loop {
+            let value = self.parse_value()?;
+            values.push(value);
+
+            self.skip_whitespace();
+            match self.peek() {
+                Some(b',') => {
+                    self.advance();
+                }
+                Some(b']') => {
+                    self.advance();
+                    return Ok(NbtTag::List(values));
+                }
+                Some(ch) => {
+                    return Err(SnbtError::Expected {
+                        expected: ']',
+                        found: Some(ch as char),
+                        pos: self.pos,
+                    });
+                }
+                None => return Err(SnbtError::UnexpectedEof),
+            }
+        }
+    }
+
+    /// Collect characters that could be part of a number or unquoted string.
+    fn collect_number_text(&mut self) -> String {
+        let start = self.pos;
+        while self.pos < self.input.len() {
+            let ch = self.input[self.pos];
+            if ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'-' || ch == b'.' || ch == b'+' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        std::str::from_utf8(&self.input[start..self.pos])
+            .unwrap()
+            .to_string()
+    }
+
+    fn parse_primitive(&mut self) -> Result<NbtTag, SnbtError> {
+        let text = self.collect_number_text();
+
+        if text.is_empty() {
+            return Err(match self.peek() {
+                Some(ch) => SnbtError::UnexpectedChar {
+                    ch: ch as char,
+                    pos: self.pos,
+                },
+                None => SnbtError::UnexpectedEof,
+            });
+        }
+
+        // Boolean literals
+        if text == "true" {
+            return Ok(NbtTag::Byte(1));
+        }
+        if text == "false" {
+            return Ok(NbtTag::Byte(0));
+        }
+
+        let last_char = text.as_bytes()[text.len() - 1];
+
+        // Byte: suffix b or B
+        if last_char == b'b' || last_char == b'B' {
+            let num_text = &text[..text.len() - 1];
+            if let Ok(v) = num_text.parse::<i8>() {
+                return Ok(NbtTag::Byte(v));
+            }
+        }
+
+        // Short: suffix s or S
+        if last_char == b's' || last_char == b'S' {
+            let num_text = &text[..text.len() - 1];
+            if let Ok(v) = num_text.parse::<i16>() {
+                return Ok(NbtTag::Short(v));
+            }
+        }
+
+        // Long: suffix l or L
+        if last_char == b'l' || last_char == b'L' {
+            let num_text = &text[..text.len() - 1];
+            if let Ok(v) = num_text.parse::<i64>() {
+                return Ok(NbtTag::Long(v));
+            }
+        }
+
+        // Float: suffix f or F
+        if last_char == b'f' || last_char == b'F' {
+            let num_text = &text[..text.len() - 1];
+            if let Ok(v) = num_text.parse::<f32>() {
+                return Ok(NbtTag::Float(v));
+            }
+        }
+
+        // Double: suffix d or D
+        if last_char == b'd' || last_char == b'D' {
+            let num_text = &text[..text.len() - 1];
+            if let Ok(v) = num_text.parse::<f64>() {
+                return Ok(NbtTag::Double(v));
+            }
+        }
+
+        // Integer (no suffix, no decimal point)
+        if !text.contains('.')
+            && let Ok(v) = text.parse::<i32>()
+        {
+            return Ok(NbtTag::Int(v));
+        }
+
+        // Double (no suffix, has decimal point)
+        if text.contains('.')
+            && let Ok(v) = text.parse::<f64>()
+        {
+            return Ok(NbtTag::Double(v));
+        }
+
+        // Fall back to unquoted string
+        Ok(NbtTag::String(text))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Primitive types ---
+
+    #[test]
+    fn parse_byte() {
+        assert_eq!(from_snbt("42b").unwrap(), NbtTag::Byte(42));
+        assert_eq!(from_snbt("-1B").unwrap(), NbtTag::Byte(-1));
+        assert_eq!(from_snbt("0b").unwrap(), NbtTag::Byte(0));
+        assert_eq!(from_snbt("127b").unwrap(), NbtTag::Byte(127));
+        assert_eq!(from_snbt("-128b").unwrap(), NbtTag::Byte(-128));
+    }
+
+    #[test]
+    fn parse_boolean() {
+        assert_eq!(from_snbt("true").unwrap(), NbtTag::Byte(1));
+        assert_eq!(from_snbt("false").unwrap(), NbtTag::Byte(0));
+    }
+
+    #[test]
+    fn parse_short() {
+        assert_eq!(from_snbt("1342s").unwrap(), NbtTag::Short(1342));
+        assert_eq!(from_snbt("-100S").unwrap(), NbtTag::Short(-100));
+        assert_eq!(from_snbt("0s").unwrap(), NbtTag::Short(0));
+    }
+
+    #[test]
+    fn parse_int() {
+        assert_eq!(from_snbt("4313").unwrap(), NbtTag::Int(4313));
+        assert_eq!(from_snbt("-999").unwrap(), NbtTag::Int(-999));
+        assert_eq!(from_snbt("0").unwrap(), NbtTag::Int(0));
+        assert_eq!(from_snbt("2147483647").unwrap(), NbtTag::Int(i32::MAX));
+        assert_eq!(from_snbt("-2147483648").unwrap(), NbtTag::Int(i32::MIN));
+    }
+
+    #[test]
+    fn parse_long() {
+        assert_eq!(from_snbt("34L").unwrap(), NbtTag::Long(34));
+        assert_eq!(from_snbt("-500l").unwrap(), NbtTag::Long(-500));
+        assert_eq!(from_snbt("0L").unwrap(), NbtTag::Long(0));
+    }
+
+    #[test]
+    fn parse_float() {
+        assert_eq!(from_snbt("1.0f").unwrap(), NbtTag::Float(1.0));
+        assert_eq!(from_snbt("-69.42F").unwrap(), NbtTag::Float(-69.42));
+        assert_eq!(from_snbt("0.0f").unwrap(), NbtTag::Float(0.0));
+    }
+
+    #[test]
+    fn parse_double() {
+        assert_eq!(from_snbt("1.5d").unwrap(), NbtTag::Double(1.5));
+        assert_eq!(from_snbt("-3.15D").unwrap(), NbtTag::Double(-3.15));
+        // Bare decimal is double
+        assert_eq!(from_snbt("2.719").unwrap(), NbtTag::Double(2.719));
+    }
+
+    // --- Strings ---
+
+    #[test]
+    fn parse_double_quoted_string() {
+        assert_eq!(
+            from_snbt("\"hello world\"").unwrap(),
+            NbtTag::String("hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_single_quoted_string() {
+        assert_eq!(
+            from_snbt("'hello world'").unwrap(),
+            NbtTag::String("hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_string_with_escapes() {
+        assert_eq!(
+            from_snbt("\"hello\\nworld\"").unwrap(),
+            NbtTag::String("hello\nworld".to_string())
+        );
+        assert_eq!(
+            from_snbt("\"tab\\there\"").unwrap(),
+            NbtTag::String("tab\there".to_string())
+        );
+        assert_eq!(
+            from_snbt("\"escaped\\\\backslash\"").unwrap(),
+            NbtTag::String("escaped\\backslash".to_string())
+        );
+        assert_eq!(
+            from_snbt("\"quote\\\"inside\"").unwrap(),
+            NbtTag::String("quote\"inside".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_unquoted_string() {
+        // Unquoted strings that don't match any numeric pattern
+        assert_eq!(
+            from_snbt("minecraft_stone").unwrap(),
+            NbtTag::String("minecraft_stone".to_string())
+        );
+    }
+
+    // --- Arrays ---
+
+    #[test]
+    fn parse_byte_array() {
+        assert_eq!(
+            from_snbt("[B; 1b, 2b, 3b]").unwrap(),
+            NbtTag::ByteArray(vec![1, 2, 3].into_boxed_slice())
+        );
+    }
+
+    #[test]
+    fn parse_byte_array_empty() {
+        assert_eq!(
+            from_snbt("[B;]").unwrap(),
+            NbtTag::ByteArray(vec![].into_boxed_slice())
+        );
+    }
+
+    #[test]
+    fn parse_int_array() {
+        assert_eq!(
+            from_snbt("[I; 100, 200, 300]").unwrap(),
+            NbtTag::IntArray(vec![100, 200, 300])
+        );
+    }
+
+    #[test]
+    fn parse_int_array_empty() {
+        assert_eq!(from_snbt("[I;]").unwrap(), NbtTag::IntArray(vec![]));
+    }
+
+    #[test]
+    fn parse_long_array() {
+        assert_eq!(
+            from_snbt("[L; 1L, 2L, 3L]").unwrap(),
+            NbtTag::LongArray(vec![1, 2, 3])
+        );
+    }
+
+    #[test]
+    fn parse_long_array_empty() {
+        assert_eq!(from_snbt("[L;]").unwrap(), NbtTag::LongArray(vec![]));
+    }
+
+    // --- Lists ---
+
+    #[test]
+    fn parse_list_of_ints() {
+        assert_eq!(
+            from_snbt("[1, 2, 3]").unwrap(),
+            NbtTag::List(vec![NbtTag::Int(1), NbtTag::Int(2), NbtTag::Int(3)])
+        );
+    }
+
+    #[test]
+    fn parse_list_of_strings() {
+        assert_eq!(
+            from_snbt("[\"a\", \"b\"]").unwrap(),
+            NbtTag::List(vec![
+                NbtTag::String("a".to_string()),
+                NbtTag::String("b".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_empty_list() {
+        assert_eq!(from_snbt("[]").unwrap(), NbtTag::List(vec![]));
+    }
+
+    #[test]
+    fn parse_nested_list() {
+        assert_eq!(
+            from_snbt("[[1, 2], [3, 4]]").unwrap(),
+            NbtTag::List(vec![
+                NbtTag::List(vec![NbtTag::Int(1), NbtTag::Int(2)]),
+                NbtTag::List(vec![NbtTag::Int(3), NbtTag::Int(4)]),
+            ])
+        );
+    }
+
+    // --- Compounds ---
+
+    #[test]
+    fn parse_compound_simple() {
+        let tag = from_snbt("{x: 1, y: 2, z: 3}").unwrap();
+        if let NbtTag::Compound(compound) = tag {
+            assert_eq!(compound.get_int("x"), Some(1));
+            assert_eq!(compound.get_int("y"), Some(2));
+            assert_eq!(compound.get_int("z"), Some(3));
+        } else {
+            panic!("Expected compound");
+        }
+    }
+
+    #[test]
+    fn parse_compound_empty() {
+        let tag = from_snbt("{}").unwrap();
+        if let NbtTag::Compound(compound) = tag {
+            assert!(compound.is_empty());
+        } else {
+            panic!("Expected compound");
+        }
+    }
+
+    #[test]
+    fn parse_compound_quoted_keys() {
+        let tag = from_snbt("{\"key with spaces\": 42}").unwrap();
+        if let NbtTag::Compound(compound) = tag {
+            assert_eq!(compound.get_int("key with spaces"), Some(42));
+        } else {
+            panic!("Expected compound");
+        }
+    }
+
+    #[test]
+    fn parse_compound_nested() {
+        let tag = from_snbt("{outer: {inner: 1}}").unwrap();
+        if let NbtTag::Compound(compound) = tag {
+            let outer = compound.get_compound("outer").unwrap();
+            assert_eq!(outer.get_int("inner"), Some(1));
+        } else {
+            panic!("Expected compound");
+        }
+    }
+
+    #[test]
+    fn parse_compound_mixed_types() {
+        let tag = from_snbt("{name: \"Steve\", health: 20.0f, level: 5, alive: true}").unwrap();
+        if let NbtTag::Compound(compound) = tag {
+            assert_eq!(compound.get_string("name"), Some("Steve"));
+            assert_eq!(compound.get_float("health"), Some(20.0));
+            assert_eq!(compound.get_int("level"), Some(5));
+            assert_eq!(compound.get_bool("alive"), Some(true));
+        } else {
+            panic!("Expected compound");
+        }
+    }
+
+    // --- from_snbt_compound ---
+
+    #[test]
+    fn parse_snbt_compound_convenience() {
+        let compound = from_snbt_compound("{a: 1, b: 2}").unwrap();
+        assert_eq!(compound.get_int("a"), Some(1));
+        assert_eq!(compound.get_int("b"), Some(2));
+    }
+
+    // --- Whitespace handling ---
+
+    #[test]
+    fn parse_with_extra_whitespace() {
+        assert_eq!(from_snbt("  42  ").unwrap(), NbtTag::Int(42));
+        assert_eq!(
+            from_snbt("  {  x  :  1  ,  y  :  2  }  ").unwrap(),
+            from_snbt("{x:1,y:2}").unwrap()
+        );
+    }
+
+    // --- Error cases ---
+
+    #[test]
+    fn error_empty_input() {
+        assert!(from_snbt("").is_err());
+    }
+
+    #[test]
+    fn error_unterminated_string() {
+        assert!(from_snbt("\"hello").is_err());
+    }
+
+    #[test]
+    fn error_unterminated_compound() {
+        assert!(from_snbt("{x: 1").is_err());
+    }
+
+    #[test]
+    fn error_unterminated_list() {
+        assert!(from_snbt("[1, 2").is_err());
+    }
+
+    #[test]
+    fn error_trailing_data() {
+        assert!(from_snbt("42 extra").is_err());
+    }
+
+    #[test]
+    fn error_invalid_escape() {
+        assert!(from_snbt("\"hello\\x\"").is_err());
+    }
+
+    // --- Display roundtrip ---
+
+    #[test]
+    fn display_then_parse_roundtrip() {
+        let original = NbtTag::Compound({
+            let mut c = NbtCompound::new();
+            c.put_int("x", 42);
+            c.put_string("name", "test".to_string());
+            c.put_byte("b", 1);
+            c.put_long("l", 100);
+            c.put_float("f", 3.15);
+            c.put_double("d", 2.719);
+            c
+        });
+
+        let snbt = format!("{original}");
+        let parsed = from_snbt(&snbt).unwrap();
+
+        if let (NbtTag::Compound(orig), NbtTag::Compound(pars)) = (&original, &parsed) {
+            assert_eq!(orig.get_int("x"), pars.get_int("x"));
+            assert_eq!(orig.get_string("name"), pars.get_string("name"));
+            assert_eq!(orig.get_byte("b"), pars.get_byte("b"));
+            assert_eq!(orig.get_long("l"), pars.get_long("l"));
+            // Floats need approximate comparison due to display precision
+        } else {
+            panic!("Expected compounds");
+        }
+    }
+
+    #[test]
+    fn parse_negative_numbers_in_arrays() {
+        assert_eq!(
+            from_snbt("[B; -1b, -128b]").unwrap(),
+            NbtTag::ByteArray(vec![255, 128].into_boxed_slice()) // -1i8 as u8 = 255, -128i8 as u8 = 128
+        );
+        assert_eq!(
+            from_snbt("[I; -1, -2147483648]").unwrap(),
+            NbtTag::IntArray(vec![-1, i32::MIN])
+        );
+        assert_eq!(
+            from_snbt("[L; -1L, -9223372036854775808L]").unwrap(),
+            NbtTag::LongArray(vec![-1, i64::MIN])
+        );
+    }
+
+    // --- Display escape roundtrip tests ---
+
+    #[test]
+    fn display_escape_roundtrip_backslash() {
+        let tag = NbtTag::String("back\\slash".to_string());
+        let snbt = format!("{tag}");
+        assert_eq!(snbt, "\"back\\\\slash\"");
+        let parsed = from_snbt(&snbt).unwrap();
+        assert_eq!(parsed, tag);
+    }
+
+    #[test]
+    fn display_escape_roundtrip_quotes() {
+        let tag = NbtTag::String("say \"hello\"".to_string());
+        let snbt = format!("{tag}");
+        assert_eq!(snbt, "\"say \\\"hello\\\"\"");
+        let parsed = from_snbt(&snbt).unwrap();
+        assert_eq!(parsed, tag);
+    }
+
+    #[test]
+    fn display_escape_roundtrip_newlines() {
+        let tag = NbtTag::String("line1\nline2\ttab\rcarriage".to_string());
+        let snbt = format!("{tag}");
+        assert_eq!(snbt, "\"line1\\nline2\\ttab\\rcarriage\"");
+        let parsed = from_snbt(&snbt).unwrap();
+        assert_eq!(parsed, tag);
+    }
+
+    #[test]
+    fn display_escape_compound_with_special_strings() {
+        let mut c = NbtCompound::new();
+        c.put_string("msg", "hello \"world\"\nnewline".to_string());
+        c.put_string("path", "C:\\Users\\test".to_string());
+        let tag = NbtTag::Compound(c);
+
+        let snbt = format!("{tag}");
+        let parsed = from_snbt(&snbt).unwrap();
+
+        if let (NbtTag::Compound(orig), NbtTag::Compound(pars)) = (&tag, &parsed) {
+            assert_eq!(orig.get_string("msg"), pars.get_string("msg"));
+            assert_eq!(orig.get_string("path"), pars.get_string("path"));
+        } else {
+            panic!("Expected compounds");
+        }
+    }
+
+    #[test]
+    fn display_array_roundtrip() {
+        let tag = NbtTag::ByteArray(vec![1, 2, 255].into_boxed_slice());
+        let snbt = format!("{tag}");
+        // ByteArray Display shows signed: 1b, 2b, -1b (255 as i8 = -1)
+        let parsed = from_snbt(&snbt).unwrap();
+        // Should match: -1i8 as u8 = 255
+        assert_eq!(parsed, tag);
+    }
+
+    #[test]
+    fn display_int_array_roundtrip() {
+        let tag = NbtTag::IntArray(vec![-1, 0, i32::MAX, i32::MIN]);
+        let snbt = format!("{tag}");
+        let parsed = from_snbt(&snbt).unwrap();
+        assert_eq!(parsed, tag);
+    }
+
+    #[test]
+    fn display_long_array_roundtrip() {
+        let tag = NbtTag::LongArray(vec![-1, 0, i64::MAX, i64::MIN]);
+        let snbt = format!("{tag}");
+        let parsed = from_snbt(&snbt).unwrap();
+        assert_eq!(parsed, tag);
+    }
+}


### PR DESCRIPTION
## What this adds

Two major additions to `pumpkin-nbt` (~2K new lines):

### Anvil Region Format (`anvil.rs`, 1,056 lines)
- Read/write Minecraft .mca region files
- Chunk compression (zlib, gzip, uncompressed)
- Chunk coordinate → offset mapping
- Proper header parsing with timestamps

### SNBT Parser (`snbt.rs`, 1,028 lines)  
- Full Stringified NBT parser
- Supports all NBT types including arrays
- Quoted and unquoted string handling
- Player data NBT helpers

### Also includes
- Edge case tests and hardening
- Clippy compliance (7 fixes)

Part 3 of 11. Depends on: nothing (leaf crate).
