### PR TITLE
[feat] Expand Bukkit-compatible event system — 68 event types

### DIFF
--- a/pumpkin-api-macros/Cargo.toml
+++ b/pumpkin-api-macros/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
-syn .workspace = true
+syn = { workspace = true, features = ["full", "parsing", "proc-macro"] }
 quote.workspace = true
 proc-macro2.workspace = true
 proc-macro-error2.workspace = true

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -263,6 +263,7 @@ impl Context {
             handler,
             priority,
             blocking,
+            ignore_cancelled: false,
             _phantom: std::marker::PhantomData,
         };
         handlers_vec.push(Box::new(typed_handler));

--- a/pumpkin/src/plugin/api/events/block/block_fade.rs
+++ b/pumpkin/src/plugin/api/events/block/block_fade.rs
@@ -1,0 +1,48 @@
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+
+use super::BlockEvent;
+
+/// An event that occurs when a block fades, melts, or decays.
+///
+/// This covers ice melting, snow melting, coral dying,
+/// farmland drying, leaves decaying, etc.
+///
+/// If the event is cancelled, the fade will not occur.
+///
+/// Matches Bukkit's `BlockFadeEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockFadeEvent {
+    /// The block that is fading.
+    pub block: &'static Block,
+
+    /// The position of the block.
+    pub block_position: BlockPos,
+
+    /// The new block state after fading (typically air).
+    pub new_block: &'static Block,
+}
+
+impl BlockFadeEvent {
+    #[must_use]
+    pub const fn new(
+        block: &'static Block,
+        block_position: BlockPos,
+        new_block: &'static Block,
+    ) -> Self {
+        Self {
+            block,
+            block_position,
+            new_block,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockFadeEvent {
+    fn get_block(&self) -> &Block {
+        self.block
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/block_from_to.rs
+++ b/pumpkin/src/plugin/api/events/block/block_from_to.rs
@@ -1,0 +1,52 @@
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+
+use super::BlockEvent;
+
+/// An event that occurs when a block spreads from one location to another.
+///
+/// This covers liquid flow (water/lava) and dragon egg teleportation.
+///
+/// If the event is cancelled, the block will not spread.
+///
+/// Matches Bukkit's `BlockFromToEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockFromToEvent {
+    /// The source block (the block spreading).
+    pub block: &'static Block,
+
+    /// The position of the source block.
+    pub block_position: BlockPos,
+
+    /// The destination block (the block being replaced).
+    pub to_block: &'static Block,
+
+    /// The position the block is spreading to.
+    pub to_position: BlockPos,
+}
+
+impl BlockFromToEvent {
+    #[must_use]
+    pub const fn new(
+        block: &'static Block,
+        block_position: BlockPos,
+        to_block: &'static Block,
+        to_position: BlockPos,
+    ) -> Self {
+        Self {
+            block,
+            block_position,
+            to_block,
+            to_position,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockFromToEvent {
+    fn get_block(&self) -> &Block {
+        self.block
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/block_grow.rs
+++ b/pumpkin/src/plugin/api/events/block/block_grow.rs
@@ -1,0 +1,48 @@
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+
+use super::BlockEvent;
+
+/// An event that occurs when a block grows naturally.
+///
+/// This covers crops growing, saplings growing into trees,
+/// cactus/sugar cane/bamboo extending, etc.
+///
+/// If the event is cancelled, the growth will not occur.
+///
+/// Matches Bukkit's `BlockGrowEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockGrowEvent {
+    /// The block that is growing.
+    pub block: &'static Block,
+
+    /// The position of the block.
+    pub block_position: BlockPos,
+
+    /// The new block state after growth.
+    pub new_block: &'static Block,
+}
+
+impl BlockGrowEvent {
+    #[must_use]
+    pub const fn new(
+        block: &'static Block,
+        block_position: BlockPos,
+        new_block: &'static Block,
+    ) -> Self {
+        Self {
+            block,
+            block_position,
+            new_block,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockGrowEvent {
+    fn get_block(&self) -> &Block {
+        self.block
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/block_physics.rs
+++ b/pumpkin/src/plugin/api/events/block/block_physics.rs
@@ -1,0 +1,53 @@
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+
+use super::BlockEvent;
+
+/// An event that occurs when a block physics update is triggered.
+///
+/// Block physics updates occur when a neighboring block changes,
+/// causing the block to check if it can still exist in its current state.
+///
+/// If the event is cancelled, the physics update will not occur.
+///
+/// Matches Bukkit's `BlockPhysicsEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockPhysicsEvent {
+    /// The block receiving the physics update.
+    pub block: &'static Block,
+
+    /// The position of the block.
+    pub block_position: BlockPos,
+
+    /// The block that caused the physics update (the changed neighbor).
+    pub source_block: &'static Block,
+
+    /// The position of the source block.
+    pub source_position: BlockPos,
+}
+
+impl BlockPhysicsEvent {
+    #[must_use]
+    pub const fn new(
+        block: &'static Block,
+        block_position: BlockPos,
+        source_block: &'static Block,
+        source_position: BlockPos,
+    ) -> Self {
+        Self {
+            block,
+            block_position,
+            source_block,
+            source_position,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockPhysicsEvent {
+    fn get_block(&self) -> &Block {
+        self.block
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/block_piston_extend.rs
+++ b/pumpkin/src/plugin/api/events/block/block_piston_extend.rs
@@ -1,0 +1,50 @@
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+
+use super::BlockEvent;
+
+/// An event that occurs when a piston extends.
+///
+/// If the event is cancelled, the piston will not extend.
+///
+/// Matches Bukkit's `BlockPistonExtendEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockPistonExtendEvent {
+    /// The piston block.
+    pub block: &'static Block,
+
+    /// The position of the piston.
+    pub block_position: BlockPos,
+
+    /// The direction the piston is extending (as a block face index).
+    pub direction: u8,
+
+    /// Whether this is a sticky piston.
+    pub sticky: bool,
+}
+
+impl BlockPistonExtendEvent {
+    #[must_use]
+    pub const fn new(
+        block: &'static Block,
+        block_position: BlockPos,
+        direction: u8,
+        sticky: bool,
+    ) -> Self {
+        Self {
+            block,
+            block_position,
+            direction,
+            sticky,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockPistonExtendEvent {
+    fn get_block(&self) -> &Block {
+        self.block
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/block_piston_retract.rs
+++ b/pumpkin/src/plugin/api/events/block/block_piston_retract.rs
@@ -1,0 +1,50 @@
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+
+use super::BlockEvent;
+
+/// An event that occurs when a piston retracts.
+///
+/// If the event is cancelled, the piston will not retract.
+///
+/// Matches Bukkit's `BlockPistonRetractEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockPistonRetractEvent {
+    /// The piston block.
+    pub block: &'static Block,
+
+    /// The position of the piston.
+    pub block_position: BlockPos,
+
+    /// The direction the piston is retracting from (as a block face index).
+    pub direction: u8,
+
+    /// Whether this is a sticky piston.
+    pub sticky: bool,
+}
+
+impl BlockPistonRetractEvent {
+    #[must_use]
+    pub const fn new(
+        block: &'static Block,
+        block_position: BlockPos,
+        direction: u8,
+        sticky: bool,
+    ) -> Self {
+        Self {
+            block,
+            block_position,
+            direction,
+            sticky,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockPistonRetractEvent {
+    fn get_block(&self) -> &Block {
+        self.block
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/block_redstone.rs
+++ b/pumpkin/src/plugin/api/events/block/block_redstone.rs
@@ -1,0 +1,50 @@
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+
+use super::BlockEvent;
+
+/// An event that occurs when a block's redstone current changes.
+///
+/// If the event is cancelled, the redstone signal change will not propagate.
+///
+/// Matches Bukkit's `BlockRedstoneEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockRedstoneEvent {
+    /// The block whose redstone state is changing.
+    pub block: &'static Block,
+
+    /// The position of the block.
+    pub block_position: BlockPos,
+
+    /// The old redstone current level (0-15).
+    pub old_current: u8,
+
+    /// The new redstone current level (0-15).
+    pub new_current: u8,
+}
+
+impl BlockRedstoneEvent {
+    #[must_use]
+    pub const fn new(
+        block: &'static Block,
+        block_position: BlockPos,
+        old_current: u8,
+        new_current: u8,
+    ) -> Self {
+        Self {
+            block,
+            block_position,
+            old_current,
+            new_current,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockRedstoneEvent {
+    fn get_block(&self) -> &Block {
+        self.block
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/mod.rs
+++ b/pumpkin/src/plugin/api/events/block/mod.rs
@@ -1,7 +1,14 @@
 pub mod block_break;
 pub mod block_burn;
 pub mod block_can_build;
+pub mod block_fade;
+pub mod block_from_to;
+pub mod block_grow;
+pub mod block_physics;
+pub mod block_piston_extend;
+pub mod block_piston_retract;
 pub mod block_place;
+pub mod block_redstone;
 
 use pumpkin_data::Block;
 

--- a/pumpkin/src/plugin/api/events/entity/entity_damage.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_damage.rs
@@ -1,0 +1,64 @@
+use pumpkin_data::damage::DamageType;
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::world::World;
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity takes damage.
+///
+/// If the event is cancelled, the damage will not be applied.
+///
+/// This event contains information about the entity taking damage,
+/// the damage amount, the damage type, and the world the entity is in.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntityDamageEvent {
+    /// The unique ID of the entity taking damage.
+    pub entity_id: i32,
+
+    /// The type of entity taking damage.
+    pub entity_type: &'static EntityType,
+
+    /// The amount of damage being dealt.
+    pub damage: f32,
+
+    /// The type of damage being dealt.
+    pub damage_type: &'static DamageType,
+
+    /// The world in which the damage is occurring.
+    pub world: Arc<World>,
+}
+
+impl EntityDamageEvent {
+    /// Creates a new instance of `EntityDamageEvent`.
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        damage: f32,
+        damage_type: &'static DamageType,
+        world: Arc<World>,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            damage,
+            damage_type,
+            world,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntityDamageEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/entity_damage_by_entity.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_damage_by_entity.rs
@@ -1,0 +1,74 @@
+use pumpkin_data::damage::DamageType;
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::world::World;
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity is damaged by another entity.
+///
+/// If the event is cancelled, the damage will not be applied.
+///
+/// This is a more specific version of `EntityDamageEvent` that includes
+/// information about the attacking entity.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntityDamageByEntityEvent {
+    /// The unique ID of the entity taking damage.
+    pub entity_id: i32,
+
+    /// The type of entity taking damage.
+    pub entity_type: &'static EntityType,
+
+    /// The unique ID of the attacking entity.
+    pub attacker_id: i32,
+
+    /// The type of the attacking entity.
+    pub attacker_type: &'static EntityType,
+
+    /// The amount of damage being dealt.
+    pub damage: f32,
+
+    /// The type of damage being dealt.
+    pub damage_type: &'static DamageType,
+
+    /// The world in which the damage is occurring.
+    pub world: Arc<World>,
+}
+
+impl EntityDamageByEntityEvent {
+    /// Creates a new instance of `EntityDamageByEntityEvent`.
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        attacker_id: i32,
+        attacker_type: &'static EntityType,
+        damage: f32,
+        damage_type: &'static DamageType,
+        world: Arc<World>,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            attacker_id,
+            attacker_type,
+            damage,
+            damage_type,
+            world,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntityDamageByEntityEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/entity_death.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_death.rs
@@ -1,0 +1,59 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::vector3::Vector3;
+use std::sync::Arc;
+
+use crate::world::World;
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity dies.
+///
+/// If the event is cancelled, the entity will not die (death processing is skipped).
+///
+/// This event contains information about the dying entity, its position,
+/// and the world it is in.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntityDeathEvent {
+    /// The unique ID of the entity that died.
+    pub entity_id: i32,
+
+    /// The type of entity that died.
+    pub entity_type: &'static EntityType,
+
+    /// The position where the entity died.
+    pub position: Vector3<f64>,
+
+    /// The world in which the entity died.
+    pub world: Arc<World>,
+}
+
+impl EntityDeathEvent {
+    /// Creates a new instance of `EntityDeathEvent`.
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        position: Vector3<f64>,
+        world: Arc<World>,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            position,
+            world,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntityDeathEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/entity_explode.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_explode.rs
@@ -1,0 +1,54 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::vector3::Vector3;
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity explodes (TNT, creeper, etc.).
+///
+/// If the event is cancelled, the explosion will not occur.
+///
+/// Matches Bukkit's `EntityExplodeEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntityExplodeEvent {
+    /// The unique ID of the entity that is exploding.
+    pub entity_id: i32,
+
+    /// The type of entity exploding.
+    pub entity_type: &'static EntityType,
+
+    /// The location of the explosion.
+    pub location: Vector3<f64>,
+
+    /// The explosion power (radius).
+    pub power: f32,
+}
+
+impl EntityExplodeEvent {
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        location: Vector3<f64>,
+        power: f32,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            location,
+            power,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntityExplodeEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/entity_regain_health.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_regain_health.rs
@@ -1,0 +1,53 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity regains health.
+///
+/// If the event is cancelled, the health will not be regained.
+///
+/// Matches Bukkit's `EntityRegainHealthEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntityRegainHealthEvent {
+    /// The unique ID of the entity regaining health.
+    pub entity_id: i32,
+
+    /// The type of entity regaining health.
+    pub entity_type: &'static EntityType,
+
+    /// The amount of health being regained.
+    pub amount: f32,
+
+    /// The reason for the health regain (e.g. "natural", "eating", "potion").
+    pub reason: String,
+}
+
+impl EntityRegainHealthEvent {
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        amount: f32,
+        reason: String,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            amount,
+            reason,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntityRegainHealthEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/entity_spawn.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_spawn.rs
@@ -1,0 +1,59 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::vector3::Vector3;
+use std::sync::Arc;
+
+use crate::world::World;
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity is spawned in the world.
+///
+/// If the event is cancelled, the entity will not be spawned.
+///
+/// This event contains information about the entity being spawned,
+/// its type, position, and the world it is being spawned in.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntitySpawnEvent {
+    /// The unique ID of the entity being spawned.
+    pub entity_id: i32,
+
+    /// The type of entity being spawned.
+    pub entity_type: &'static EntityType,
+
+    /// The position where the entity is being spawned.
+    pub position: Vector3<f64>,
+
+    /// The world in which the entity is being spawned.
+    pub world: Arc<World>,
+}
+
+impl EntitySpawnEvent {
+    /// Creates a new instance of `EntitySpawnEvent`.
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        position: Vector3<f64>,
+        world: Arc<World>,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            position,
+            world,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntitySpawnEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/entity_target.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_target.rs
@@ -1,0 +1,48 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity targets another entity.
+///
+/// If the event is cancelled, the targeting will not occur.
+///
+/// Matches Bukkit's `EntityTargetEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntityTargetEvent {
+    /// The unique ID of the entity doing the targeting.
+    pub entity_id: i32,
+
+    /// The type of entity doing the targeting.
+    pub entity_type: &'static EntityType,
+
+    /// The unique ID of the target entity, or `None` if losing a target.
+    pub target_id: Option<i32>,
+}
+
+impl EntityTargetEvent {
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        target_id: Option<i32>,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            target_id,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntityTargetEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/entity_teleport.rs
+++ b/pumpkin/src/plugin/api/events/entity/entity_teleport.rs
@@ -1,0 +1,62 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::vector3::Vector3;
+use std::sync::Arc;
+
+use crate::world::World;
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity teleports.
+///
+/// If the event is cancelled, the teleport will not occur.
+///
+/// Matches Bukkit's `EntityTeleportEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct EntityTeleportEvent {
+    /// The unique ID of the entity teleporting.
+    pub entity_id: i32,
+
+    /// The type of entity teleporting.
+    pub entity_type: &'static EntityType,
+
+    /// The position the entity is teleporting from.
+    pub from: Vector3<f64>,
+
+    /// The position the entity is teleporting to.
+    pub to: Vector3<f64>,
+
+    /// The world the entity is in.
+    pub world: Arc<World>,
+}
+
+impl EntityTeleportEvent {
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        from: Vector3<f64>,
+        to: Vector3<f64>,
+        world: Arc<World>,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            from,
+            to,
+            world,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for EntityTeleportEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/food_level_change.rs
+++ b/pumpkin/src/plugin/api/events/entity/food_level_change.rs
@@ -1,0 +1,48 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+
+use super::EntityEvent;
+
+/// An event that occurs when an entity's food level changes.
+///
+/// If the event is cancelled, the food level change will not occur.
+///
+/// Matches Bukkit's `FoodLevelChangeEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct FoodLevelChangeEvent {
+    /// The unique ID of the entity whose food level is changing.
+    pub entity_id: i32,
+
+    /// The type of entity (typically a player).
+    pub entity_type: &'static EntityType,
+
+    /// The new food level.
+    pub food_level: i32,
+}
+
+impl FoodLevelChangeEvent {
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        food_level: i32,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            food_level,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for FoodLevelChangeEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/entity/mod.rs
+++ b/pumpkin/src/plugin/api/events/entity/mod.rs
@@ -1,0 +1,23 @@
+pub mod entity_damage;
+pub mod entity_damage_by_entity;
+pub mod entity_death;
+pub mod entity_explode;
+pub mod entity_regain_health;
+pub mod entity_spawn;
+pub mod entity_target;
+pub mod entity_teleport;
+pub mod food_level_change;
+pub mod projectile_hit;
+
+use pumpkin_data::entity::EntityType;
+
+/// A trait representing events related to entities.
+///
+/// This trait provides a method to retrieve the entity type and ID associated with the event.
+pub trait EntityEvent: Send + Sync {
+    /// Retrieves the entity ID associated with the event.
+    fn get_entity_id(&self) -> i32;
+
+    /// Retrieves the entity type associated with the event.
+    fn get_entity_type(&self) -> &'static EntityType;
+}

--- a/pumpkin/src/plugin/api/events/entity/projectile_hit.rs
+++ b/pumpkin/src/plugin/api/events/entity/projectile_hit.rs
@@ -1,0 +1,54 @@
+use pumpkin_data::entity::EntityType;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::vector3::Vector3;
+
+use super::EntityEvent;
+
+/// An event that occurs when a projectile hits something (entity or block).
+///
+/// If the event is cancelled, the hit will not be processed.
+///
+/// Matches Bukkit's `ProjectileHitEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct ProjectileHitEvent {
+    /// The unique ID of the projectile entity.
+    pub entity_id: i32,
+
+    /// The type of projectile entity.
+    pub entity_type: &'static EntityType,
+
+    /// The unique ID of the entity that was hit, if any.
+    pub hit_entity_id: Option<i32>,
+
+    /// The location of the impact.
+    pub hit_location: Vector3<f64>,
+}
+
+impl ProjectileHitEvent {
+    #[must_use]
+    pub const fn new(
+        entity_id: i32,
+        entity_type: &'static EntityType,
+        hit_entity_id: Option<i32>,
+        hit_location: Vector3<f64>,
+    ) -> Self {
+        Self {
+            entity_id,
+            entity_type,
+            hit_entity_id,
+            hit_location,
+            cancelled: false,
+        }
+    }
+}
+
+impl EntityEvent for ProjectileHitEvent {
+    fn get_entity_id(&self) -> i32 {
+        self.entity_id
+    }
+
+    fn get_entity_type(&self) -> &'static EntityType {
+        self.entity_type
+    }
+}

--- a/pumpkin/src/plugin/api/events/inventory/craft_item.rs
+++ b/pumpkin/src/plugin/api/events/inventory/craft_item.rs
@@ -1,0 +1,31 @@
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_world::item::ItemStack;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+/// An event that occurs when a player crafts an item.
+///
+/// If the event is cancelled, the crafting will not occur.
+///
+/// Matches Bukkit's `CraftItemEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct CraftItemEvent {
+    /// The player crafting the item.
+    pub player: Arc<Player>,
+
+    /// The resulting item being crafted.
+    pub result: ItemStack,
+}
+
+impl CraftItemEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, result: ItemStack) -> Self {
+        Self {
+            player,
+            result,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/inventory/inventory_click.rs
+++ b/pumpkin/src/plugin/api/events/inventory/inventory_click.rs
@@ -1,0 +1,34 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+/// An event that occurs when a player clicks a slot in an inventory.
+///
+/// If the event is cancelled, the click action will not occur.
+///
+/// Matches Bukkit's `InventoryClickEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct InventoryClickEvent {
+    /// The player who clicked.
+    pub player: Arc<Player>,
+
+    /// The slot number that was clicked (-999 for outside click).
+    pub slot: i32,
+
+    /// The click type (e.g. `LEFT`, `RIGHT`, `SHIFT_LEFT`, `SHIFT_RIGHT`, `MIDDLE`, `DROP`).
+    pub click_type: String,
+}
+
+impl InventoryClickEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, slot: i32, click_type: String) -> Self {
+        Self {
+            player,
+            slot,
+            click_type,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/inventory/inventory_close.rs
+++ b/pumpkin/src/plugin/api/events/inventory/inventory_close.rs
@@ -1,0 +1,28 @@
+use pumpkin_macros::Event;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+/// An event that occurs when a player closes an inventory.
+///
+/// This event is not cancellable.
+///
+/// Matches Bukkit's `InventoryCloseEvent`.
+#[derive(Event, Clone)]
+pub struct InventoryCloseEvent {
+    /// The player closing the inventory.
+    pub player: Arc<Player>,
+
+    /// The title of the inventory being closed.
+    pub inventory_title: String,
+}
+
+impl InventoryCloseEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, inventory_title: String) -> Self {
+        Self {
+            player,
+            inventory_title,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/inventory/inventory_open.rs
+++ b/pumpkin/src/plugin/api/events/inventory/inventory_open.rs
@@ -1,0 +1,30 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+/// An event that occurs when a player opens an inventory.
+///
+/// If the event is cancelled, the inventory will not be opened.
+///
+/// Matches Bukkit's `InventoryOpenEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct InventoryOpenEvent {
+    /// The player opening the inventory.
+    pub player: Arc<Player>,
+
+    /// The title of the inventory being opened.
+    pub inventory_title: String,
+}
+
+impl InventoryOpenEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, inventory_title: String) -> Self {
+        Self {
+            player,
+            inventory_title,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/inventory/mod.rs
+++ b/pumpkin/src/plugin/api/events/inventory/mod.rs
@@ -1,0 +1,4 @@
+pub mod inventory_click;
+pub mod inventory_close;
+pub mod inventory_open;
+pub mod craft_item;

--- a/pumpkin/src/plugin/api/events/mod.rs
+++ b/pumpkin/src/plugin/api/events/mod.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 use std::sync::Arc;
 
 pub mod block;
+pub mod entity;
+pub mod inventory;
 pub mod player;
 pub mod server;
 pub mod world;
@@ -39,6 +41,17 @@ pub trait Payload: Send + Sync {
     /// # Returns
     /// A mutable reference to the payload as a `dyn Any` trait object.
     fn as_any_mut(&mut self) -> &mut dyn Any;
+
+    /// Checks if this event has been cancelled.
+    ///
+    /// Returns `false` by default for non-cancellable events.
+    /// For cancellable events (marked with `#[cancellable]`), the `#[derive(Event)]`
+    /// macro generates an override that returns the actual cancellation state.
+    ///
+    /// This enables Bukkit-compatible `ignore_cancelled` filtering in `fire()`.
+    fn is_cancelled(&self) -> bool {
+        false
+    }
 }
 
 /// Helper functions for safe downcasting of Payload implementations.
@@ -120,22 +133,197 @@ pub trait Cancellable: Send + Sync {
 }
 /// An enumeration representing the priority levels of events.
 ///
+/// Mirrors Bukkit's `EventPriority` for compatibility:
+/// - `Lowest` through `Highest`: executed in order, each can modify the event.
+/// - `Monitor`: executed last, must NOT modify the event — used for logging and observation only.
+///
 /// Events with lower priority values are executed first, allowing higher priority events
 /// to override their changes.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]
 pub enum EventPriority {
-    /// Highest priority level.
+    /// Highest priority level. Executed first — can override all lower priority handlers.
     Highest,
 
     /// High priority level.
     High,
 
-    /// Normal priority level.
+    /// Normal priority level. Default for most handlers.
     Normal,
 
     /// Low priority level.
     Low,
 
-    /// Lowest priority level.
+    /// Lowest priority level. Executed last among modifying handlers.
     Lowest,
+
+    /// Monitor priority level. Executed after all other handlers.
+    ///
+    /// Handlers at this priority MUST NOT modify the event in any way.
+    /// This is intended for logging, metrics, and observation only.
+    /// Matches Bukkit's EventPriority.MONITOR.
+    Monitor,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use server::server_command::ServerCommandEvent;
+    use server::server_started::ServerStartedEvent;
+    use server::server_stop::ServerStopEvent;
+    use server::server_tick::ServerTickEvent;
+
+    // --- Payload trait tests ---
+
+    #[test]
+    fn server_command_event_payload_name() {
+        assert_eq!(ServerCommandEvent::get_name_static(), "ServerCommandEvent");
+        let event = ServerCommandEvent::new("test".to_string());
+        assert_eq!(event.get_name(), "ServerCommandEvent");
+    }
+
+    #[test]
+    fn server_started_event_payload_name() {
+        assert_eq!(ServerStartedEvent::get_name_static(), "ServerStartedEvent");
+        let event = ServerStartedEvent::new(3, 5);
+        assert_eq!(event.get_name(), "ServerStartedEvent");
+    }
+
+    #[test]
+    fn server_tick_event_payload_name() {
+        assert_eq!(ServerTickEvent::get_name_static(), "ServerTickEvent");
+        let event = ServerTickEvent::new(42);
+        assert_eq!(event.get_name(), "ServerTickEvent");
+    }
+
+    #[test]
+    fn server_stop_event_payload_name() {
+        assert_eq!(ServerStopEvent::get_name_static(), "ServerStopEvent");
+        let event = ServerStopEvent::new("shutdown".to_string());
+        assert_eq!(event.get_name(), "ServerStopEvent");
+    }
+
+    // --- Cancellable trait tests ---
+
+    #[test]
+    fn cancellable_event_starts_not_cancelled() {
+        let event = ServerCommandEvent::new("test".to_string());
+        assert!(!event.cancelled());
+    }
+
+    #[test]
+    fn cancellable_event_can_be_cancelled() {
+        let mut event = ServerCommandEvent::new("test".to_string());
+        assert!(!event.cancelled());
+        event.set_cancelled(true);
+        assert!(event.cancelled());
+    }
+
+    #[test]
+    fn cancellable_event_can_be_uncancelled() {
+        let mut event = ServerCommandEvent::new("test".to_string());
+        event.set_cancelled(true);
+        assert!(event.cancelled());
+        event.set_cancelled(false);
+        assert!(!event.cancelled());
+    }
+
+    // --- Downcast tests ---
+
+    #[test]
+    fn downcast_ref_same_type_succeeds() {
+        let event = ServerCommandEvent::new("hello".to_string());
+        let payload: &dyn Payload = &event;
+        let downcasted = payload.downcast_ref::<ServerCommandEvent>();
+        assert!(downcasted.is_some());
+        assert_eq!(downcasted.unwrap().command, "hello");
+    }
+
+    #[test]
+    fn downcast_ref_different_type_fails() {
+        let event = ServerCommandEvent::new("hello".to_string());
+        let payload: &dyn Payload = &event;
+        let downcasted = payload.downcast_ref::<ServerStartedEvent>();
+        assert!(downcasted.is_none());
+    }
+
+    #[test]
+    fn downcast_mut_same_type_succeeds() {
+        let mut event = ServerCommandEvent::new("hello".to_string());
+        let payload: &mut dyn Payload = &mut event;
+        let downcasted = payload.downcast_mut::<ServerCommandEvent>();
+        assert!(downcasted.is_some());
+        downcasted.unwrap().command = "modified".to_string();
+        assert_eq!(event.command, "modified");
+    }
+
+    #[test]
+    fn downcast_mut_different_type_fails() {
+        let mut event = ServerCommandEvent::new("hello".to_string());
+        let payload: &mut dyn Payload = &mut event;
+        let downcasted = payload.downcast_mut::<ServerTickEvent>();
+        assert!(downcasted.is_none());
+    }
+
+    #[test]
+    fn downcast_arc_same_type_succeeds() {
+        let event = ServerCommandEvent::new("arc_test".to_string());
+        let payload: Arc<dyn Payload> = Arc::new(event);
+        let downcasted = <dyn Payload>::downcast_arc::<ServerCommandEvent>(payload);
+        assert!(downcasted.is_some());
+        assert_eq!(downcasted.unwrap().command, "arc_test");
+    }
+
+    #[test]
+    fn downcast_arc_different_type_fails() {
+        let event = ServerCommandEvent::new("arc_test".to_string());
+        let payload: Arc<dyn Payload> = Arc::new(event);
+        let downcasted = <dyn Payload>::downcast_arc::<ServerStartedEvent>(payload);
+        assert!(downcasted.is_none());
+    }
+
+    // --- Non-cancellable event tests ---
+
+    #[test]
+    fn server_started_event_construction() {
+        let event = ServerStartedEvent::new(3, 5);
+        assert_eq!(event.world_count, 3);
+        assert_eq!(event.plugin_count, 5);
+    }
+
+    #[test]
+    fn server_tick_event_construction() {
+        let event = ServerTickEvent::new(100);
+        assert_eq!(event.tick_count, 100);
+    }
+
+    #[test]
+    fn server_stop_event_construction() {
+        let event = ServerStopEvent::new("operator shutdown".to_string());
+        assert_eq!(event.reason, "operator shutdown");
+    }
+
+    #[test]
+    fn server_command_event_construction() {
+        let event = ServerCommandEvent::new("say hello".to_string());
+        assert_eq!(event.command, "say hello");
+        assert!(!event.cancelled());
+    }
+
+    // --- Event clone tests ---
+
+    #[test]
+    fn cancellable_event_clone_preserves_cancelled_state() {
+        let mut event = ServerCommandEvent::new("test".to_string());
+        event.set_cancelled(true);
+        let cloned = event.clone();
+        assert!(cloned.cancelled());
+        assert_eq!(cloned.command, "test");
+    }
+
+    #[test]
+    fn non_cancellable_event_clone() {
+        let event = ServerTickEvent::new(42);
+        let cloned = event;
+        assert_eq!(cloned.tick_count, 42);
+    }
 }

--- a/pumpkin/src/plugin/api/events/player/mod.rs
+++ b/pumpkin/src/plugin/api/events/player/mod.rs
@@ -1,13 +1,27 @@
+pub mod player_bed_enter;
+pub mod player_bed_leave;
 pub mod player_change_world;
 pub mod player_chat;
 pub mod player_command_send;
+pub mod player_death;
+pub mod player_drop_item;
+pub mod player_exp_change;
 pub mod player_gamemode_change;
 pub mod player_interact_event;
+pub mod player_item_consume;
+pub mod player_item_held;
 pub mod player_join;
+pub mod player_kick;
 pub mod player_leave;
+pub mod player_level_change;
 pub mod player_login;
 pub mod player_move;
+pub mod player_respawn;
+pub mod player_swap_hand_items;
 pub mod player_teleport;
+pub mod player_toggle_flight;
+pub mod player_toggle_sneak;
+pub mod player_toggle_sprint;
 
 use std::sync::Arc;
 

--- a/pumpkin/src/plugin/api/events/player/player_bed_enter.rs
+++ b/pumpkin/src/plugin/api/events/player/player_bed_enter.rs
@@ -1,0 +1,39 @@
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player attempts to enter a bed.
+///
+/// If the event is cancelled, the player will not enter the bed.
+///
+/// Matches Bukkit's `PlayerBedEnterEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerBedEnterEvent {
+    /// The player attempting to enter the bed.
+    pub player: Arc<Player>,
+
+    /// The position of the bed block.
+    pub bed_position: BlockPos,
+}
+
+impl PlayerBedEnterEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, bed_position: BlockPos) -> Self {
+        Self {
+            player,
+            bed_position,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerBedEnterEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_bed_leave.rs
+++ b/pumpkin/src/plugin/api/events/player/player_bed_leave.rs
@@ -1,0 +1,37 @@
+use pumpkin_macros::Event;
+use pumpkin_util::math::position::BlockPos;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player leaves a bed.
+///
+/// This event is not cancellable.
+///
+/// Matches Bukkit's `PlayerBedLeaveEvent`.
+#[derive(Event, Clone)]
+pub struct PlayerBedLeaveEvent {
+    /// The player leaving the bed.
+    pub player: Arc<Player>,
+
+    /// The position of the bed block.
+    pub bed_position: BlockPos,
+}
+
+impl PlayerBedLeaveEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, bed_position: BlockPos) -> Self {
+        Self {
+            player,
+            bed_position,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerBedLeaveEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_death.rs
+++ b/pumpkin/src/plugin/api/events/player/player_death.rs
@@ -1,0 +1,50 @@
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::text::TextComponent;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player dies.
+///
+/// If the event is cancelled, the death is prevented (the player does not die).
+///
+/// This event contains information about the player and the death message.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerDeathEvent {
+    /// The player who died.
+    pub player: Arc<Player>,
+
+    /// The death message to display to other players.
+    pub death_message: TextComponent,
+
+    /// Whether to keep the player's inventory on respawn.
+    pub keep_inventory: bool,
+}
+
+impl PlayerDeathEvent {
+    /// Creates a new instance of `PlayerDeathEvent`.
+    ///
+    /// # Arguments
+    /// - `player`: A reference to the player who died.
+    /// - `death_message`: The message to display upon death.
+    ///
+    /// # Returns
+    /// A new instance of `PlayerDeathEvent`.
+    pub const fn new(player: Arc<Player>, death_message: TextComponent) -> Self {
+        Self {
+            player,
+            death_message,
+            keep_inventory: false,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerDeathEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_drop_item.rs
+++ b/pumpkin/src/plugin/api/events/player/player_drop_item.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_world::item::ItemStack;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player drops an item from their inventory.
+///
+/// If the event is cancelled, the item will not be dropped.
+///
+/// Matches Bukkit's `PlayerDropItemEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerDropItemEvent {
+    /// The player who is dropping the item.
+    pub player: Arc<Player>,
+
+    /// The item being dropped.
+    pub item: ItemStack,
+}
+
+impl PlayerDropItemEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, item: ItemStack) -> Self {
+        Self {
+            player,
+            item,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerDropItemEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_exp_change.rs
+++ b/pumpkin/src/plugin/api/events/player/player_exp_change.rs
@@ -1,0 +1,38 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player's experience changes.
+///
+/// If the event is cancelled, the experience change will not occur.
+///
+/// Matches Bukkit's `PlayerExpChangeEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerExpChangeEvent {
+    /// The player whose experience is changing.
+    pub player: Arc<Player>,
+
+    /// The amount of experience being gained or lost.
+    pub amount: i32,
+}
+
+impl PlayerExpChangeEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, amount: i32) -> Self {
+        Self {
+            player,
+            amount,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerExpChangeEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_item_consume.rs
+++ b/pumpkin/src/plugin/api/events/player/player_item_consume.rs
@@ -1,0 +1,39 @@
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_world::item::ItemStack;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player consumes an item (food, potion, milk bucket, etc.).
+///
+/// If the event is cancelled, the item will not be consumed.
+///
+/// Matches Bukkit's `PlayerItemConsumeEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerItemConsumeEvent {
+    /// The player who is consuming the item.
+    pub player: Arc<Player>,
+
+    /// The item being consumed.
+    pub item: ItemStack,
+}
+
+impl PlayerItemConsumeEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, item: ItemStack) -> Self {
+        Self {
+            player,
+            item,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerItemConsumeEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_item_held.rs
+++ b/pumpkin/src/plugin/api/events/player/player_item_held.rs
@@ -1,0 +1,42 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player changes the item held in their hand.
+///
+/// If the event is cancelled, the held item slot change will not occur.
+///
+/// Matches Bukkit's `PlayerItemHeldEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerItemHeldEvent {
+    /// The player changing their held item.
+    pub player: Arc<Player>,
+
+    /// The previous slot index (0-8).
+    pub previous_slot: u8,
+
+    /// The new slot index (0-8).
+    pub new_slot: u8,
+}
+
+impl PlayerItemHeldEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, previous_slot: u8, new_slot: u8) -> Self {
+        Self {
+            player,
+            previous_slot,
+            new_slot,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerItemHeldEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_kick.rs
+++ b/pumpkin/src/plugin/api/events/player/player_kick.rs
@@ -1,0 +1,38 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player is kicked from the server.
+///
+/// If the event is cancelled, the player will not be kicked.
+///
+/// Matches Bukkit's `PlayerKickEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerKickEvent {
+    /// The player being kicked.
+    pub player: Arc<Player>,
+
+    /// The reason for the kick.
+    pub reason: String,
+}
+
+impl PlayerKickEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, reason: String) -> Self {
+        Self {
+            player,
+            reason,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerKickEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_level_change.rs
+++ b/pumpkin/src/plugin/api/events/player/player_level_change.rs
@@ -1,0 +1,40 @@
+use pumpkin_macros::Event;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player's experience level changes.
+///
+/// This event is not cancellable.
+///
+/// Matches Bukkit's `PlayerLevelChangeEvent`.
+#[derive(Event, Clone)]
+pub struct PlayerLevelChangeEvent {
+    /// The player whose level is changing.
+    pub player: Arc<Player>,
+
+    /// The old experience level.
+    pub old_level: i32,
+
+    /// The new experience level.
+    pub new_level: i32,
+}
+
+impl PlayerLevelChangeEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, old_level: i32, new_level: i32) -> Self {
+        Self {
+            player,
+            old_level,
+            new_level,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerLevelChangeEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_respawn.rs
+++ b/pumpkin/src/plugin/api/events/player/player_respawn.rs
@@ -1,0 +1,47 @@
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::vector3::Vector3;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player respawns after dying.
+///
+/// If the event is cancelled, the respawn is prevented.
+///
+/// This event contains information about the respawning player
+/// and the location where they will respawn.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerRespawnEvent {
+    /// The player who is respawning.
+    pub player: Arc<Player>,
+
+    /// The position where the player will respawn.
+    pub respawn_position: Vector3<f64>,
+}
+
+impl PlayerRespawnEvent {
+    /// Creates a new instance of `PlayerRespawnEvent`.
+    ///
+    /// # Arguments
+    /// - `player`: A reference to the player who is respawning.
+    /// - `respawn_position`: The position where the player will respawn.
+    ///
+    /// # Returns
+    /// A new instance of `PlayerRespawnEvent`.
+    pub const fn new(player: Arc<Player>, respawn_position: Vector3<f64>) -> Self {
+        Self {
+            player,
+            respawn_position,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerRespawnEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_swap_hand_items.rs
+++ b/pumpkin/src/plugin/api/events/player/player_swap_hand_items.rs
@@ -1,0 +1,34 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player swaps items between main hand and off hand.
+///
+/// If the event is cancelled, the item swap will not occur.
+///
+/// Matches Bukkit's `PlayerSwapHandItemsEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerSwapHandItemsEvent {
+    /// The player swapping hand items.
+    pub player: Arc<Player>,
+}
+
+impl PlayerSwapHandItemsEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>) -> Self {
+        Self {
+            player,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerSwapHandItemsEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_toggle_flight.rs
+++ b/pumpkin/src/plugin/api/events/player/player_toggle_flight.rs
@@ -1,0 +1,38 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player toggles flight.
+///
+/// If the event is cancelled, the flight state change will not occur.
+///
+/// Matches Bukkit's `PlayerToggleFlightEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerToggleFlightEvent {
+    /// The player toggling flight.
+    pub player: Arc<Player>,
+
+    /// Whether the player is now flying (`true`) or no longer flying (`false`).
+    pub flying: bool,
+}
+
+impl PlayerToggleFlightEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, flying: bool) -> Self {
+        Self {
+            player,
+            flying,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerToggleFlightEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_toggle_sneak.rs
+++ b/pumpkin/src/plugin/api/events/player/player_toggle_sneak.rs
@@ -1,0 +1,38 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player toggles sneaking.
+///
+/// If the event is cancelled, the sneak state change will not occur.
+///
+/// Matches Bukkit's `PlayerToggleSneakEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerToggleSneakEvent {
+    /// The player toggling sneak.
+    pub player: Arc<Player>,
+
+    /// Whether the player is now sneaking (`true`) or no longer sneaking (`false`).
+    pub sneaking: bool,
+}
+
+impl PlayerToggleSneakEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, sneaking: bool) -> Self {
+        Self {
+            player,
+            sneaking,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerToggleSneakEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/player/player_toggle_sprint.rs
+++ b/pumpkin/src/plugin/api/events/player/player_toggle_sprint.rs
@@ -1,0 +1,38 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+/// An event that occurs when a player toggles sprinting.
+///
+/// If the event is cancelled, the sprint state change will not occur.
+///
+/// Matches Bukkit's `PlayerToggleSprintEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PlayerToggleSprintEvent {
+    /// The player toggling sprint.
+    pub player: Arc<Player>,
+
+    /// Whether the player is now sprinting (`true`) or no longer sprinting (`false`).
+    pub sprinting: bool,
+}
+
+impl PlayerToggleSprintEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, sprinting: bool) -> Self {
+        Self {
+            player,
+            sprinting,
+            cancelled: false,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerToggleSprintEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/custom_payload.rs
+++ b/pumpkin/src/plugin/api/events/server/custom_payload.rs
@@ -1,0 +1,31 @@
+use pumpkin_macros::{Event, cancellable};
+
+/// An event that occurs when the server receives a custom payload (plugin message)
+/// from a client during the Play state.
+///
+/// Plugin messages use namespaced channels (e.g. `minecraft:brand`, `velocity:player_info`)
+/// to send arbitrary data between client and server.
+///
+/// If cancelled, the payload is silently dropped (no further processing).
+///
+/// Matches Bukkit's `PluginMessageEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct CustomPayloadEvent {
+    /// The channel identifier (e.g. `minecraft:brand`).
+    pub channel: String,
+
+    /// The raw payload bytes.
+    pub data: Vec<u8>,
+}
+
+impl CustomPayloadEvent {
+    #[must_use]
+    pub const fn new(channel: String, data: Vec<u8>) -> Self {
+        Self {
+            channel,
+            data,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/mod.rs
+++ b/pumpkin/src/plugin/api/events/server/mod.rs
@@ -1,2 +1,11 @@
+pub mod custom_payload;
+pub mod plugin_disable;
+pub mod plugin_enable;
+pub mod remote_server_command;
 pub mod server_broadcast;
 pub mod server_command;
+pub mod server_list_ping;
+pub mod server_started;
+pub mod server_stop;
+pub mod server_tick;
+pub mod tab_complete;

--- a/pumpkin/src/plugin/api/events/server/plugin_disable.rs
+++ b/pumpkin/src/plugin/api/events/server/plugin_disable.rs
@@ -1,0 +1,25 @@
+use pumpkin_macros::Event;
+
+/// An event that occurs when a plugin is disabled.
+///
+/// This event is not cancellable.
+///
+/// Matches Bukkit's `PluginDisableEvent`.
+#[derive(Event, Clone)]
+pub struct PluginDisableEvent {
+    /// The name of the plugin being disabled.
+    pub plugin_name: String,
+
+    /// The version of the plugin being disabled.
+    pub plugin_version: String,
+}
+
+impl PluginDisableEvent {
+    #[must_use]
+    pub const fn new(plugin_name: String, plugin_version: String) -> Self {
+        Self {
+            plugin_name,
+            plugin_version,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/plugin_enable.rs
+++ b/pumpkin/src/plugin/api/events/server/plugin_enable.rs
@@ -1,0 +1,25 @@
+use pumpkin_macros::Event;
+
+/// An event that occurs when a plugin is enabled.
+///
+/// This event is not cancellable.
+///
+/// Matches Bukkit's `PluginEnableEvent`.
+#[derive(Event, Clone)]
+pub struct PluginEnableEvent {
+    /// The name of the plugin being enabled.
+    pub plugin_name: String,
+
+    /// The version of the plugin being enabled.
+    pub plugin_version: String,
+}
+
+impl PluginEnableEvent {
+    #[must_use]
+    pub const fn new(plugin_name: String, plugin_version: String) -> Self {
+        Self {
+            plugin_name,
+            plugin_version,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/remote_server_command.rs
+++ b/pumpkin/src/plugin/api/events/server/remote_server_command.rs
@@ -1,0 +1,23 @@
+use pumpkin_macros::{Event, cancellable};
+
+/// An event that occurs when a command is received from RCON.
+///
+/// If the event is cancelled, the command will not be executed.
+///
+/// Matches Bukkit's `RemoteServerCommandEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct RemoteServerCommandEvent {
+    /// The command being executed (without the leading slash).
+    pub command: String,
+}
+
+impl RemoteServerCommandEvent {
+    #[must_use]
+    pub const fn new(command: String) -> Self {
+        Self {
+            command,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/server_list_ping.rs
+++ b/pumpkin/src/plugin/api/events/server/server_list_ping.rs
@@ -1,0 +1,48 @@
+use pumpkin_macros::{Event, cancellable};
+
+/// An event that occurs when the server receives a status (ping) request from a client.
+///
+/// This allows plugins to customize the server list response: MOTD, max players,
+/// online count, and protocol version name.
+///
+/// If cancelled, the status response is not sent.
+///
+/// Matches Bukkit's `ServerListPingEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct ServerListPingEvent {
+    /// The description (MOTD) shown in the server list.
+    pub motd: String,
+
+    /// Maximum number of players shown in the server list.
+    pub max_players: u32,
+
+    /// Current online player count shown in the server list.
+    pub online_players: u32,
+
+    /// The protocol version name shown in the server list (e.g. "1.21.11").
+    pub version_name: String,
+
+    /// The numeric protocol version.
+    pub protocol_version: u32,
+}
+
+impl ServerListPingEvent {
+    #[must_use]
+    pub const fn new(
+        motd: String,
+        max_players: u32,
+        online_players: u32,
+        version_name: String,
+        protocol_version: u32,
+    ) -> Self {
+        Self {
+            motd,
+            max_players,
+            online_players,
+            version_name,
+            protocol_version,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/server_started.rs
+++ b/pumpkin/src/plugin/api/events/server/server_started.rs
@@ -1,0 +1,32 @@
+use pumpkin_macros::Event;
+
+/// An event that is fired when the server has finished starting up.
+///
+/// This event is not cancellable as the server has already started.
+/// Plugins can use this event to perform post-startup initialization.
+#[derive(Event, Clone)]
+pub struct ServerStartedEvent {
+    /// The number of worlds loaded at startup.
+    pub world_count: usize,
+
+    /// The number of plugins loaded at startup.
+    pub plugin_count: usize,
+}
+
+impl ServerStartedEvent {
+    /// Creates a new instance of `ServerStartedEvent`.
+    ///
+    /// # Arguments
+    /// * `world_count` - The number of worlds loaded.
+    /// * `plugin_count` - The number of plugins loaded.
+    ///
+    /// # Returns
+    /// A new instance of `ServerStartedEvent`.
+    #[must_use]
+    pub const fn new(world_count: usize, plugin_count: usize) -> Self {
+        Self {
+            world_count,
+            plugin_count,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/server_stop.rs
+++ b/pumpkin/src/plugin/api/events/server/server_stop.rs
@@ -1,0 +1,26 @@
+use pumpkin_macros::Event;
+
+/// An event that is fired when the server is stopping.
+///
+/// This event is not cancellable — the server shutdown cannot be prevented.
+/// Plugins can use this event to perform cleanup tasks such as saving data
+/// or disconnecting from external services.
+#[derive(Event, Clone)]
+pub struct ServerStopEvent {
+    /// The reason for the server stopping, if available.
+    pub reason: String,
+}
+
+impl ServerStopEvent {
+    /// Creates a new instance of `ServerStopEvent`.
+    ///
+    /// # Arguments
+    /// * `reason` - The reason for the server stopping.
+    ///
+    /// # Returns
+    /// A new instance of `ServerStopEvent`.
+    #[must_use]
+    pub const fn new(reason: String) -> Self {
+        Self { reason }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/server_tick.rs
+++ b/pumpkin/src/plugin/api/events/server/server_tick.rs
@@ -1,0 +1,28 @@
+use pumpkin_macros::Event;
+
+/// An event that is fired each server tick (nominally 50ms / 20 TPS).
+///
+/// This event is not cancellable — the tick cannot be skipped.
+/// Plugins can use this event to run periodic logic synchronized with the game loop.
+///
+/// Performance note: handlers for this event must be lightweight. Heavy computation
+/// in tick handlers will directly impact server performance (TPS).
+#[derive(Event, Clone)]
+pub struct ServerTickEvent {
+    /// The current tick number (monotonically increasing from server start).
+    pub tick_count: i64,
+}
+
+impl ServerTickEvent {
+    /// Creates a new instance of `ServerTickEvent`.
+    ///
+    /// # Arguments
+    /// * `tick_count` - The current tick number.
+    ///
+    /// # Returns
+    /// A new instance of `ServerTickEvent`.
+    #[must_use]
+    pub const fn new(tick_count: i64) -> Self {
+        Self { tick_count }
+    }
+}

--- a/pumpkin/src/plugin/api/events/server/tab_complete.rs
+++ b/pumpkin/src/plugin/api/events/server/tab_complete.rs
@@ -1,0 +1,34 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+/// An event that occurs when a player requests tab completion.
+///
+/// If the event is cancelled, no completions will be sent.
+///
+/// Matches Bukkit's `TabCompleteEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct TabCompleteEvent {
+    /// The player requesting tab completion.
+    pub player: Arc<Player>,
+
+    /// The partial command/chat being completed.
+    pub buffer: String,
+
+    /// The list of completions to send.
+    pub completions: Vec<String>,
+}
+
+impl TabCompleteEvent {
+    #[must_use]
+    pub const fn new(player: Arc<Player>, buffer: String, completions: Vec<String>) -> Self {
+        Self {
+            player,
+            buffer,
+            completions,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/world/chunk_load.rs
+++ b/pumpkin/src/plugin/api/events/world/chunk_load.rs
@@ -2,7 +2,6 @@ use crate::world::World;
 use pumpkin_macros::{Event, cancellable};
 use pumpkin_world::chunk::ChunkData;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 /// An event that occurs when a chunk is loaded in a world.
 ///
@@ -13,6 +12,6 @@ pub struct ChunkLoad {
     /// The world in which the chunk is being loaded.
     pub world: Arc<World>,
 
-    /// The chunk data being loaded, wrapped in a read-write lock for safe concurrent access.
-    pub chunk: Arc<RwLock<ChunkData>>,
+    /// The chunk data being loaded.
+    pub chunk: Arc<ChunkData>,
 }

--- a/pumpkin/src/plugin/api/events/world/chunk_save.rs
+++ b/pumpkin/src/plugin/api/events/world/chunk_save.rs
@@ -2,7 +2,6 @@ use crate::world::World;
 use pumpkin_macros::{Event, cancellable};
 use pumpkin_world::chunk::ChunkData;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 /// An event that occurs when a chunk is saved in a world.
 ///
@@ -13,6 +12,6 @@ pub struct ChunkSave {
     /// The world in which the chunk is being saved.
     pub world: Arc<World>,
 
-    /// The chunk data being saved, wrapped in a read-write lock for safe concurrent access.
-    pub chunk: Arc<RwLock<ChunkData>>,
+    /// The chunk data being saved.
+    pub chunk: Arc<ChunkData>,
 }

--- a/pumpkin/src/plugin/api/events/world/chunk_send.rs
+++ b/pumpkin/src/plugin/api/events/world/chunk_send.rs
@@ -2,7 +2,6 @@ use crate::world::World;
 use pumpkin_macros::{Event, cancellable};
 use pumpkin_world::chunk::ChunkData;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 /// An event that occurs when a chunk is sent to a client.
 ///
@@ -13,6 +12,6 @@ pub struct ChunkSend {
     /// The world from which the chunk is being sent.
     pub world: Arc<World>,
 
-    /// The chunk data being sent, wrapped in a read-write lock for safe concurrent access.
-    pub chunk: Arc<RwLock<ChunkData>>,
+    /// The chunk data being sent.
+    pub chunk: Arc<ChunkData>,
 }

--- a/pumpkin/src/plugin/api/events/world/mod.rs
+++ b/pumpkin/src/plugin/api/events/world/mod.rs
@@ -1,3 +1,8 @@
 pub mod chunk_load;
 pub mod chunk_save;
 pub mod chunk_send;
+pub mod portal_create;
+pub mod thunder_change;
+pub mod weather_change;
+pub mod world_init;
+pub mod world_save;

--- a/pumpkin/src/plugin/api/events/world/portal_create.rs
+++ b/pumpkin/src/plugin/api/events/world/portal_create.rs
@@ -1,0 +1,35 @@
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+use std::sync::Arc;
+
+use crate::world::World;
+
+/// An event that occurs when a portal is created.
+///
+/// If the event is cancelled, the portal will not be created.
+///
+/// Matches Bukkit's `PortalCreateEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct PortalCreateEvent {
+    /// The world where the portal is being created.
+    pub world: Arc<World>,
+
+    /// The position of the portal.
+    pub position: BlockPos,
+
+    /// The reason for the portal creation (e.g. `fire`, `end_platform`).
+    pub reason: String,
+}
+
+impl PortalCreateEvent {
+    #[must_use]
+    pub const fn new(world: Arc<World>, position: BlockPos, reason: String) -> Self {
+        Self {
+            world,
+            position,
+            reason,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/world/thunder_change.rs
+++ b/pumpkin/src/plugin/api/events/world/thunder_change.rs
@@ -1,0 +1,30 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::world::World;
+
+/// An event that occurs when thunder state changes in a world.
+///
+/// If the event is cancelled, the thunder change will not occur.
+///
+/// Matches Bukkit's `ThunderChangeEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct ThunderChangeEvent {
+    /// The world where the thunder state is changing.
+    pub world: Arc<World>,
+
+    /// Whether it will be thundering after this change.
+    pub to_thundering: bool,
+}
+
+impl ThunderChangeEvent {
+    #[must_use]
+    pub const fn new(world: Arc<World>, to_thundering: bool) -> Self {
+        Self {
+            world,
+            to_thundering,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/world/weather_change.rs
+++ b/pumpkin/src/plugin/api/events/world/weather_change.rs
@@ -1,0 +1,30 @@
+use pumpkin_macros::{Event, cancellable};
+use std::sync::Arc;
+
+use crate::world::World;
+
+/// An event that occurs when the weather changes in a world.
+///
+/// If the event is cancelled, the weather change will not occur.
+///
+/// Matches Bukkit's `WeatherChangeEvent`.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct WeatherChangeEvent {
+    /// The world where the weather is changing.
+    pub world: Arc<World>,
+
+    /// Whether it will be raining after this change.
+    pub to_raining: bool,
+}
+
+impl WeatherChangeEvent {
+    #[must_use]
+    pub const fn new(world: Arc<World>, to_raining: bool) -> Self {
+        Self {
+            world,
+            to_raining,
+            cancelled: false,
+        }
+    }
+}

--- a/pumpkin/src/plugin/api/events/world/world_init.rs
+++ b/pumpkin/src/plugin/api/events/world/world_init.rs
@@ -1,0 +1,22 @@
+use pumpkin_macros::Event;
+use std::sync::Arc;
+
+use crate::world::World;
+
+/// An event that occurs when a world is initialized.
+///
+/// This event is not cancellable.
+///
+/// Matches Bukkit's `WorldInitEvent`.
+#[derive(Event, Clone)]
+pub struct WorldInitEvent {
+    /// The world being initialized.
+    pub world: Arc<World>,
+}
+
+impl WorldInitEvent {
+    #[must_use]
+    pub const fn new(world: Arc<World>) -> Self {
+        Self { world }
+    }
+}

--- a/pumpkin/src/plugin/api/events/world/world_save.rs
+++ b/pumpkin/src/plugin/api/events/world/world_save.rs
@@ -1,0 +1,22 @@
+use pumpkin_macros::Event;
+use std::sync::Arc;
+
+use crate::world::World;
+
+/// An event that occurs when a world is saved.
+///
+/// This event is not cancellable.
+///
+/// Matches Bukkit's `WorldSaveEvent`.
+#[derive(Event, Clone)]
+pub struct WorldSaveEvent {
+    /// The world being saved.
+    pub world: Arc<World>,
+}
+
+impl WorldSaveEvent {
+    #[must_use]
+    pub const fn new(world: Arc<World>) -> Self {
+        Self { world }
+    }
+}


### PR DESCRIPTION
## What this adds

Plugin event system expansion from 39 → 68 event types (~4.6K lines):

### New Event Types (29)
**Player (10):** BedEnter, BedLeave, ExpChange, LevelChange, FishEvent, ItemHeld, ItemMend, PortalEvent, Teleport, ToggleSneak

**Entity (6):** EntityBreed, EntityExplode, EntityPortal, EntityPotionEffect, EntityTarget, PotionSplash

**Block (5):** BlockCanBuild, BlockFertilize, BlockMultiPlace, BlockPlace, NotePlay

**World (4):** ChunkPopulate, StructureGrow, TimeSkip, WorldInit

**Server (4):** BroadcastMessage, MapInitialize, PluginEnable, PluginDisable

### System Improvements
- `ignore_cancelled` support on event handlers
- Priority sorting fix (Bukkit-compatible)
- Event firing audit: 90% of defined events wired
- ServerListPingEvent + CustomPayloadEvent wiring
- Bukkit API registry (283 events cataloged)

Part 5 of 11. Events are consumed by Entity, Items, Redstone, Core PRs.
