### PR TITLE
[feat] Commands, config enforcement, lifecycle events

### DIFF
--- a/pumpkin-config/src/lib.rs
+++ b/pumpkin-config/src/lib.rs
@@ -127,6 +127,20 @@ pub struct BasicConfiguration {
     pub white_list: bool,
     /// Whether to enforce the whitelist.
     pub enforce_whitelist: bool,
+    /// Whether to allow flight in Survival mode (vanilla: allow-flight)
+    pub allow_flight: bool,
+    /// Radius of spawn protection (0 = disabled, vanilla default: 16)
+    pub spawn_protection: u32,
+    /// Whether structures (villages, temples, etc.) are generated (vanilla: generate-structures)
+    pub generate_structures: bool,
+    /// Minutes before kicking idle players (0 = disabled, vanilla: player-idle-timeout)
+    pub player_idle_timeout: u32,
+    /// Whether console command output is broadcast to online operators (vanilla: broadcast-console-to-ops)
+    pub broadcast_console_to_ops: bool,
+    /// Maximum world border radius in blocks (vanilla: max-world-size, default: 29999984)
+    pub max_world_size: u32,
+    /// Permission level for function command execution (vanilla: function-permission-level, default: 2)
+    pub function_permission_level: PermissionLvl,
 }
 
 impl Default for BasicConfiguration {
@@ -158,6 +172,13 @@ impl Default for BasicConfiguration {
             allow_chat_reports: false,
             white_list: false,
             enforce_whitelist: false,
+            allow_flight: false,
+            spawn_protection: 16,
+            generate_structures: true,
+            player_idle_timeout: 0,
+            broadcast_console_to_ops: true,
+            max_world_size: 29_999_984,
+            function_permission_level: PermissionLvl::Two,
         }
     }
 }

--- a/pumpkin/src/command/commands/debug.rs
+++ b/pumpkin/src/command/commands/debug.rs
@@ -1,0 +1,124 @@
+use std::sync::atomic::Ordering;
+
+use crate::command::CommandResult;
+use crate::command::{
+    CommandError, CommandExecutor, CommandSender, args::ConsumedArgs, tree::CommandTree,
+    tree::builder::literal,
+};
+use pumpkin_util::text::TextComponent;
+use pumpkin_util::text::color::NamedColor;
+
+const NAMES: [&str; 1] = ["debug"];
+
+const DESCRIPTION: &str = "Starts or stops a debugging session.";
+
+struct StartExecutor;
+
+impl CommandExecutor for StartExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            if server.tick_profiler.is_enabled() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    "commands.debug.alreadyRunning",
+                    [],
+                )));
+            }
+
+            server.tick_profiler.reset_slow_count();
+            server.tick_profiler.set_enabled(true);
+
+            sender
+                .send_message(
+                    TextComponent::translate("commands.debug.started", [])
+                        .color_named(NamedColor::Green),
+                )
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct StopExecutor;
+
+impl CommandExecutor for StopExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            if !server.tick_profiler.is_enabled() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    "commands.debug.notRunning",
+                    [],
+                )));
+            }
+
+            server.tick_profiler.set_enabled(false);
+
+            let snapshot = server.tick_profiler.snapshot();
+            let tick_count = server.tick_count.load(Ordering::Relaxed);
+
+            // Build a summary message similar to vanilla debug report
+            let summary = format!(
+                "Stopped debug profiling after {} ticks ({:.1}ms avg, {:.1}ms peak, {} slow ticks, {:.1}% budget)",
+                snapshot.total_ticks,
+                snapshot.total_avg_ms(),
+                snapshot.total_peak_nanos as f64 / 1_000_000.0,
+                snapshot.slow_tick_count,
+                snapshot.budget_usage_percent(),
+            );
+
+            sender
+                .send_message(
+                    TextComponent::translate("commands.debug.stopped", [])
+                        .color_named(NamedColor::Green),
+                )
+                .await;
+
+            // Send detailed breakdown
+            let detail = format!(
+                "World: {:.2}ms avg | Player/Net: {:.2}ms avg | Total: {:.2}ms avg | Ticks: {} | Slow: {}",
+                snapshot.world_avg_ms(),
+                snapshot.player_avg_ms(),
+                snapshot.total_avg_ms(),
+                tick_count,
+                snapshot.slow_tick_count,
+            );
+            sender
+                .send_message(TextComponent::text(detail).color_named(NamedColor::Gray))
+                .await;
+
+            // Send budget usage line
+            let budget_color = if snapshot.budget_usage_percent() > 80.0 {
+                NamedColor::Red
+            } else if snapshot.budget_usage_percent() > 50.0 {
+                NamedColor::Yellow
+            } else {
+                NamedColor::Green
+            };
+            let budget_msg = format!(
+                "Tick budget usage: {:.1}% of 50ms",
+                snapshot.budget_usage_percent(),
+            );
+            sender
+                .send_message(TextComponent::text(budget_msg).color_named(budget_color))
+                .await;
+
+            log::info!("{summary}");
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(literal("start").execute(StartExecutor))
+        .then(literal("stop").execute(StopExecutor))
+}

--- a/pumpkin/src/command/commands/mod.rs
+++ b/pumpkin/src/command/commands/mod.rs
@@ -14,6 +14,7 @@ mod bossbar;
 mod clear;
 mod damage;
 mod data;
+mod debug;
 pub mod defaultgamemode;
 mod deop;
 mod difficulty;
@@ -34,11 +35,15 @@ mod op;
 mod pardon;
 mod pardonip;
 mod particle;
+mod perf;
 mod playsound;
 mod plugin;
 mod plugins;
 mod pumpkin;
 mod rotate;
+mod save_all;
+mod save_off;
+mod save_on;
 mod say;
 mod seed;
 mod setblock;
@@ -66,7 +71,12 @@ pub async fn default_dispatcher(
     let mut dispatcher = CommandDispatcher::default();
 
     register_permissions(registry).await;
+    register_commands(&mut dispatcher, basic_config);
 
+    dispatcher
+}
+
+fn register_commands(dispatcher: &mut CommandDispatcher, basic_config: &BasicConfiguration) {
     // Zero
     dispatcher.register(pumpkin::init_command_tree(), "pumpkin:command.pumpkin");
     dispatcher.register(help::init_command_tree(), "minecraft:command.help");
@@ -152,10 +162,22 @@ pub async fn default_dispatcher(
         setidletimeout::init_command_tree(),
         "minecraft:command.setidletimeout",
     );
+    dispatcher.register(debug::init_command_tree(), "minecraft:command.debug");
     // Four
     dispatcher.register(stop::init_command_tree(), "minecraft:command.stop");
-
-    dispatcher
+    dispatcher.register(perf::init_command_tree(), "minecraft:command.perf");
+    dispatcher.register(
+        save_all::init_command_tree(),
+        "minecraft:command.save-all",
+    );
+    dispatcher.register(
+        save_off::init_command_tree(),
+        "minecraft:command.save-off",
+    );
+    dispatcher.register(
+        save_on::init_command_tree(),
+        "minecraft:command.save-on",
+    );
 }
 
 async fn register_permissions(permission_registry: &RwLock<PermissionRegistry>) {
@@ -529,6 +551,13 @@ fn register_level_3_permissions(registry: &mut PermissionRegistry) {
             PermissionDefault::Op(PermissionLvl::Three),
         ))
         .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.debug",
+            "Starts or stops a debugging session",
+            PermissionDefault::Op(PermissionLvl::Three),
+        ))
+        .unwrap();
 }
 
 fn register_level_4_permissions(registry: &mut PermissionRegistry) {
@@ -537,6 +566,34 @@ fn register_level_4_permissions(registry: &mut PermissionRegistry) {
         .register_permission(Permission::new(
             "minecraft:command.stop",
             "Stops the server",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.save-all",
+            "Forces the server to save all data to disk",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.save-off",
+            "Disables automatic server saving",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.save-on",
+            "Enables automatic server saving",
+            PermissionDefault::Op(PermissionLvl::Four),
+        ))
+        .unwrap();
+    registry
+        .register_permission(Permission::new(
+            "minecraft:command.perf",
+            "Captures performance metrics",
             PermissionDefault::Op(PermissionLvl::Four),
         ))
         .unwrap();

--- a/pumpkin/src/command/commands/perf.rs
+++ b/pumpkin/src/command/commands/perf.rs
@@ -1,0 +1,100 @@
+use crate::command::CommandResult;
+use crate::command::{
+    CommandError, CommandExecutor, CommandSender, args::ConsumedArgs, tree::CommandTree,
+    tree::builder::literal,
+};
+use pumpkin_util::text::TextComponent;
+use pumpkin_util::text::color::NamedColor;
+
+const NAMES: [&str; 1] = ["perf"];
+
+const DESCRIPTION: &str = "Captures performance metrics for 10 seconds.";
+
+struct StartExecutor;
+
+impl CommandExecutor for StartExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            if server.tick_profiler.is_enabled() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    "commands.perf.alreadyRunning",
+                    [],
+                )));
+            }
+
+            server.tick_profiler.reset_slow_count();
+            server.tick_profiler.set_enabled(true);
+
+            sender
+                .send_message(
+                    TextComponent::translate("commands.perf.started", [])
+                        .color_named(NamedColor::Green),
+                )
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct StopExecutor;
+
+impl CommandExecutor for StopExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            if !server.tick_profiler.is_enabled() {
+                return Err(CommandError::CommandFailed(TextComponent::translate(
+                    "commands.perf.notRunning",
+                    [],
+                )));
+            }
+
+            server.tick_profiler.set_enabled(false);
+            let snapshot = server.tick_profiler.snapshot();
+
+            sender
+                .send_message(
+                    TextComponent::translate("commands.perf.stopped", [])
+                        .color_named(NamedColor::Green),
+                )
+                .await;
+
+            // Send performance summary
+            let summary = format!(
+                "Average tick: {:.2}ms (world: {:.2}ms, player/net: {:.2}ms) | Peak: {:.2}ms | Slow ticks: {}",
+                snapshot.total_avg_ms(),
+                snapshot.world_avg_ms(),
+                snapshot.player_avg_ms(),
+                snapshot.total_peak_nanos as f64 / 1_000_000.0,
+                snapshot.slow_tick_count,
+            );
+            sender
+                .send_message(TextComponent::text(summary).color_named(NamedColor::Gray))
+                .await;
+
+            log::info!(
+                "Perf profiling stopped: {:.2}ms avg tick, {} slow ticks, {:.1}% budget",
+                snapshot.total_avg_ms(),
+                snapshot.slow_tick_count,
+                snapshot.budget_usage_percent(),
+            );
+
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .then(literal("start").execute(StartExecutor))
+        .then(literal("stop").execute(StopExecutor))
+}

--- a/pumpkin/src/command/commands/save_all.rs
+++ b/pumpkin/src/command/commands/save_all.rs
@@ -1,0 +1,60 @@
+use crate::command::CommandResult;
+use crate::command::{
+    CommandExecutor, CommandSender, args::ConsumedArgs, tree::CommandTree,
+    tree::builder::literal,
+};
+use pumpkin_util::text::TextComponent;
+
+const NAMES: [&str; 1] = ["save-all"];
+
+const DESCRIPTION: &str = "Saves the server to disk.";
+
+struct SaveExecutor;
+
+impl CommandExecutor for SaveExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            sender
+                .send_message(TextComponent::translate("commands.save.saving", []))
+                .await;
+            server.save_all(false).await;
+            sender
+                .send_message(TextComponent::translate("commands.save.success", []))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+struct FlushExecutor;
+
+impl CommandExecutor for FlushExecutor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            sender
+                .send_message(TextComponent::translate("commands.save.saving", []))
+                .await;
+            server.save_all(true).await;
+            sender
+                .send_message(TextComponent::translate("commands.save.success", []))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION)
+        .execute(SaveExecutor)
+        .then(literal("flush").execute(FlushExecutor))
+}

--- a/pumpkin/src/command/commands/save_off.rs
+++ b/pumpkin/src/command/commands/save_off.rs
@@ -1,0 +1,37 @@
+use std::sync::atomic::Ordering;
+
+use crate::command::CommandResult;
+use crate::command::{
+    CommandExecutor, CommandSender, args::ConsumedArgs, tree::CommandTree,
+};
+use pumpkin_util::text::TextComponent;
+
+const NAMES: [&str; 1] = ["save-off"];
+
+const DESCRIPTION: &str = "Disables automatic saving.";
+
+struct Executor;
+
+impl CommandExecutor for Executor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            server.autosave_enabled.store(false, Ordering::Relaxed);
+            sender
+                .send_message(TextComponent::translate(
+                    "commands.save.disabled",
+                    [],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).execute(Executor)
+}

--- a/pumpkin/src/command/commands/save_on.rs
+++ b/pumpkin/src/command/commands/save_on.rs
@@ -1,0 +1,37 @@
+use std::sync::atomic::Ordering;
+
+use crate::command::CommandResult;
+use crate::command::{
+    CommandExecutor, CommandSender, args::ConsumedArgs, tree::CommandTree,
+};
+use pumpkin_util::text::TextComponent;
+
+const NAMES: [&str; 1] = ["save-on"];
+
+const DESCRIPTION: &str = "Enables automatic saving.";
+
+struct Executor;
+
+impl CommandExecutor for Executor {
+    fn execute<'a>(
+        &'a self,
+        sender: &'a CommandSender,
+        server: &'a crate::server::Server,
+        _args: &'a ConsumedArgs<'a>,
+    ) -> CommandResult<'a> {
+        Box::pin(async move {
+            server.autosave_enabled.store(true, Ordering::Relaxed);
+            sender
+                .send_message(TextComponent::translate(
+                    "commands.save.enabled",
+                    [],
+                ))
+                .await;
+            Ok(1)
+        })
+    }
+}
+
+pub fn init_command_tree() -> CommandTree {
+    CommandTree::new(NAMES, DESCRIPTION).execute(Executor)
+}

--- a/pumpkin/src/command/dispatcher.rs
+++ b/pumpkin/src/command/dispatcher.rs
@@ -263,6 +263,11 @@ impl CommandDispatcher {
             return Err(PermissionDenied);
         }
 
+        // Log admin commands if the game rule is enabled
+        if server.level_info.load().game_rules.log_admin_commands {
+            log::info!("{src} issued server command: /{cmd}");
+        }
+
         let tree = self.get_tree(key)?;
 
         // try paths until fitting path is found

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -307,6 +307,21 @@ impl PumpkinServer {
         }
     }
 
+    /// Fires the `ServerStartedEvent` to notify plugins that the server is ready.
+    pub async fn fire_started_event(&self) {
+        let world_count = self.server.worlds.load().len();
+        let plugin_count = self.server.plugin_manager.loaded_plugins().await.len();
+        self.server
+            .plugin_manager
+            .fire(
+                plugin::server::server_started::ServerStartedEvent::new(
+                    world_count,
+                    plugin_count,
+                ),
+            )
+            .await;
+    }
+
     pub async fn unload_plugins(&self) {
         if let Err(err) = self.server.plugin_manager.unload_all_plugins().await {
             log::error!("Error unloading plugins: {err}");
@@ -330,6 +345,14 @@ impl PumpkinServer {
         }
 
         log::info!("Stopped accepting incoming connections");
+
+        // Notify plugins that the server is stopping
+        self.server
+            .plugin_manager
+            .fire(
+                plugin::server::server_stop::ServerStopEvent::new("Server shutting down".to_string()),
+            )
+            .await;
 
         if let Err(e) = self
             .server
@@ -530,6 +553,7 @@ fn setup_stdin_console(server: Arc<Server>) {
                         server.command_dispatcher.read().await
                             .handle_command(&command::CommandSender::Console, &server, command.as_str())
                             .await;
+                        broadcast_console_command_to_ops(&server, &command).await;
                     };
                 }}
             }
@@ -597,6 +621,7 @@ fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: A
                         server.command_dispatcher.read().await
                             .handle_command(&command::CommandSender::Console, &server, &line)
                             .await;
+                        broadcast_console_command_to_ops(&server, &line).await;
                     }
                 }}
             } else {
@@ -605,6 +630,22 @@ fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: A
         }
         log::debug!("Stopped console commands task");
     });
+}
+
+/// When `broadcast_console_to_ops` is enabled, notify all online operators
+/// that a console command was executed.
+async fn broadcast_console_command_to_ops(server: &Server, command: &str) {
+    if !server.basic_config.broadcast_console_to_ops {
+        return;
+    }
+    let msg = TextComponent::text(format!("[Server: /{command}]"))
+        .color_named(pumpkin_util::text::color::NamedColor::Gray)
+        .italic();
+    for player in server.get_all_players() {
+        if player.permission_lvl.load() >= pumpkin_util::PermissionLvl::Two {
+            player.send_system_message(&msg).await;
+        }
+    }
 }
 
 fn scrub_address(ip: &str) -> String {

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -93,6 +93,7 @@ async fn main() {
 
     let pumpkin_server = PumpkinServer::new(basic_config, advanced_config, vanilla_data).await;
     pumpkin_server.init_plugins().await;
+    pumpkin_server.fire_started_event().await;
 
     log::info!("Started server; took {}ms", time.elapsed().as_millis());
     let basic_config = &pumpkin_server.server.basic_config;

--- a/pumpkin/src/server/tick_profiler.rs
+++ b/pumpkin/src/server/tick_profiler.rs
@@ -1,0 +1,390 @@
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Instant;
+
+/// Per-tick phase timing for performance diagnostics.
+///
+/// Tracks how long each phase of the server tick takes, enabling
+/// identification of bottlenecks. When enabled, records timing for
+/// the world tick phase and the player/network tick phase separately.
+///
+/// The profiler is lock-free and uses atomic operations throughout,
+/// making it safe to use from the hot tick path without contention.
+pub struct TickProfiler {
+    enabled: AtomicBool,
+
+    // Current tick timing (written during tick, read by diagnostics)
+    phase_start: crossbeam::atomic::AtomicCell<Instant>,
+
+    // Rolling statistics over the last WINDOW_SIZE ticks
+    world_tick_nanos: RollingAverage,
+    player_tick_nanos: RollingAverage,
+    total_tick_nanos: RollingAverage,
+
+    // Slow tick tracking
+    slow_tick_threshold_ms: AtomicU64,
+    slow_tick_count: AtomicU64,
+}
+
+/// A lock-free rolling average over a fixed window.
+///
+/// Uses atomic operations for concurrent reads during diagnostics
+/// while the tick loop writes new samples.
+struct RollingAverage {
+    samples: [AtomicU64; Self::WINDOW_SIZE],
+    index: AtomicU64,
+    sum: AtomicU64,
+}
+
+impl RollingAverage {
+    const WINDOW_SIZE: usize = 100;
+
+    fn new() -> Self {
+        Self {
+            samples: std::array::from_fn(|_| AtomicU64::new(0)),
+            index: AtomicU64::new(0),
+            sum: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, value_nanos: u64) {
+        let idx = self.index.fetch_add(1, Ordering::Relaxed) as usize % Self::WINDOW_SIZE;
+        let old = self.samples[idx].swap(value_nanos, Ordering::Relaxed);
+        // Update sum: add new, subtract old
+        self.sum.fetch_add(value_nanos, Ordering::Relaxed);
+        self.sum.fetch_sub(old, Ordering::Relaxed);
+    }
+
+    fn average_nanos(&self) -> u64 {
+        let count = self
+            .index
+            .load(Ordering::Relaxed)
+            .min(Self::WINDOW_SIZE as u64);
+        if count == 0 {
+            return 0;
+        }
+        self.sum.load(Ordering::Relaxed) / count
+    }
+
+    fn last_nanos(&self) -> u64 {
+        let idx = self.index.load(Ordering::Relaxed);
+        if idx == 0 {
+            return 0;
+        }
+        let last_idx = (idx - 1) as usize % Self::WINDOW_SIZE;
+        self.samples[last_idx].load(Ordering::Relaxed)
+    }
+
+    fn peak_nanos(&self) -> u64 {
+        let count = self
+            .index
+            .load(Ordering::Relaxed)
+            .min(Self::WINDOW_SIZE as u64) as usize;
+        let mut peak = 0u64;
+        for i in 0..count {
+            let val = self.samples[i].load(Ordering::Relaxed);
+            if val > peak {
+                peak = val;
+            }
+        }
+        peak
+    }
+
+    fn sample_count(&self) -> u64 {
+        self.index.load(Ordering::Relaxed)
+    }
+}
+
+/// Snapshot of profiling data for diagnostics display.
+#[derive(Debug, Clone)]
+pub struct TickProfileSnapshot {
+    /// Average world tick duration in nanoseconds (last 100 ticks)
+    pub world_avg_nanos: u64,
+    /// Average player/network tick duration in nanoseconds (last 100 ticks)
+    pub player_avg_nanos: u64,
+    /// Average total tick duration in nanoseconds (last 100 ticks)
+    pub total_avg_nanos: u64,
+    /// Last world tick duration in nanoseconds
+    pub world_last_nanos: u64,
+    /// Last player/network tick duration in nanoseconds
+    pub player_last_nanos: u64,
+    /// Last total tick duration in nanoseconds
+    pub total_last_nanos: u64,
+    /// Peak world tick duration in nanoseconds (last 100 ticks)
+    pub world_peak_nanos: u64,
+    /// Peak player/network tick duration in nanoseconds (last 100 ticks)
+    pub player_peak_nanos: u64,
+    /// Peak total tick duration in nanoseconds (last 100 ticks)
+    pub total_peak_nanos: u64,
+    /// Number of ticks that exceeded the slow tick threshold
+    pub slow_tick_count: u64,
+    /// Total ticks profiled
+    pub total_ticks: u64,
+}
+
+impl TickProfileSnapshot {
+    /// World tick average in milliseconds.
+    #[must_use]
+    pub fn world_avg_ms(&self) -> f64 {
+        self.world_avg_nanos as f64 / 1_000_000.0
+    }
+
+    /// Player/network tick average in milliseconds.
+    #[must_use]
+    pub fn player_avg_ms(&self) -> f64 {
+        self.player_avg_nanos as f64 / 1_000_000.0
+    }
+
+    /// Total tick average in milliseconds.
+    #[must_use]
+    pub fn total_avg_ms(&self) -> f64 {
+        self.total_avg_nanos as f64 / 1_000_000.0
+    }
+
+    /// Percentage of tick budget (50ms) used on average.
+    #[must_use]
+    pub fn budget_usage_percent(&self) -> f64 {
+        (self.total_avg_nanos as f64 / 50_000_000.0) * 100.0
+    }
+}
+
+impl Default for TickProfiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TickProfiler {
+    /// The default slow tick threshold: 50ms (one full tick at 20 TPS).
+    const DEFAULT_SLOW_THRESHOLD_MS: u64 = 50;
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            enabled: AtomicBool::new(false),
+            phase_start: crossbeam::atomic::AtomicCell::new(Instant::now()),
+            world_tick_nanos: RollingAverage::new(),
+            player_tick_nanos: RollingAverage::new(),
+            total_tick_nanos: RollingAverage::new(),
+            slow_tick_threshold_ms: AtomicU64::new(Self::DEFAULT_SLOW_THRESHOLD_MS),
+            slow_tick_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Enable or disable profiling.
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    /// Whether profiling is currently enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    /// Set the threshold (in milliseconds) above which a tick is considered "slow".
+    pub fn set_slow_threshold_ms(&self, ms: u64) {
+        self.slow_tick_threshold_ms.store(ms, Ordering::Relaxed);
+    }
+
+    /// Mark the beginning of a phase. Returns the start instant for later use.
+    pub fn begin_phase(&self) -> Instant {
+        let now = Instant::now();
+        self.phase_start.store(now);
+        now
+    }
+
+    /// Record world tick duration.
+    pub fn record_world_tick(&self, start: Instant) {
+        if !self.is_enabled() {
+            return;
+        }
+        let elapsed = start.elapsed().as_nanos() as u64;
+        self.world_tick_nanos.record(elapsed);
+    }
+
+    /// Record player/network tick duration.
+    pub fn record_player_tick(&self, start: Instant) {
+        if !self.is_enabled() {
+            return;
+        }
+        let elapsed = start.elapsed().as_nanos() as u64;
+        self.player_tick_nanos.record(elapsed);
+    }
+
+    /// Record total tick duration and check for slow ticks.
+    pub fn record_total_tick(&self, start: Instant) {
+        if !self.is_enabled() {
+            return;
+        }
+        let elapsed_nanos = start.elapsed().as_nanos() as u64;
+        self.total_tick_nanos.record(elapsed_nanos);
+
+        let threshold_nanos = self.slow_tick_threshold_ms.load(Ordering::Relaxed) * 1_000_000;
+        if elapsed_nanos > threshold_nanos {
+            self.slow_tick_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Reset slow tick counter.
+    pub fn reset_slow_count(&self) {
+        self.slow_tick_count.store(0, Ordering::Relaxed);
+    }
+
+    /// Get a snapshot of current profiling data.
+    pub fn snapshot(&self) -> TickProfileSnapshot {
+        TickProfileSnapshot {
+            world_avg_nanos: self.world_tick_nanos.average_nanos(),
+            player_avg_nanos: self.player_tick_nanos.average_nanos(),
+            total_avg_nanos: self.total_tick_nanos.average_nanos(),
+            world_last_nanos: self.world_tick_nanos.last_nanos(),
+            player_last_nanos: self.player_tick_nanos.last_nanos(),
+            total_last_nanos: self.total_tick_nanos.last_nanos(),
+            world_peak_nanos: self.world_tick_nanos.peak_nanos(),
+            player_peak_nanos: self.player_tick_nanos.peak_nanos(),
+            total_peak_nanos: self.total_tick_nanos.peak_nanos(),
+            slow_tick_count: self.slow_tick_count.load(Ordering::Relaxed),
+            total_ticks: self.total_tick_nanos.sample_count(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn rolling_average_empty() {
+        let avg = RollingAverage::new();
+        assert_eq!(avg.average_nanos(), 0);
+        assert_eq!(avg.last_nanos(), 0);
+        assert_eq!(avg.peak_nanos(), 0);
+        assert_eq!(avg.sample_count(), 0);
+    }
+
+    #[test]
+    fn rolling_average_single_sample() {
+        let avg = RollingAverage::new();
+        avg.record(1_000_000); // 1ms
+        assert_eq!(avg.average_nanos(), 1_000_000);
+        assert_eq!(avg.last_nanos(), 1_000_000);
+        assert_eq!(avg.peak_nanos(), 1_000_000);
+        assert_eq!(avg.sample_count(), 1);
+    }
+
+    #[test]
+    fn rolling_average_multiple_samples() {
+        let avg = RollingAverage::new();
+        avg.record(2_000_000); // 2ms
+        avg.record(4_000_000); // 4ms
+        // Average should be 3ms
+        assert_eq!(avg.average_nanos(), 3_000_000);
+        assert_eq!(avg.last_nanos(), 4_000_000);
+        assert_eq!(avg.peak_nanos(), 4_000_000);
+        assert_eq!(avg.sample_count(), 2);
+    }
+
+    #[test]
+    fn rolling_average_wraps_around() {
+        let avg = RollingAverage::new();
+        // Fill all 100 slots with 1ms each
+        for _ in 0..100 {
+            avg.record(1_000_000);
+        }
+        assert_eq!(avg.average_nanos(), 1_000_000);
+
+        // Now add a 101st sample of 2ms, replacing the first 1ms
+        avg.record(2_000_000);
+        // Sum should now be 99 * 1ms + 1 * 2ms = 101ms, count capped at 100
+        assert_eq!(avg.average_nanos(), 1_010_000);
+    }
+
+    #[test]
+    fn profiler_disabled_by_default() {
+        let profiler = TickProfiler::new();
+        assert!(!profiler.is_enabled());
+    }
+
+    #[test]
+    fn profiler_enable_disable() {
+        let profiler = TickProfiler::new();
+        profiler.set_enabled(true);
+        assert!(profiler.is_enabled());
+        profiler.set_enabled(false);
+        assert!(!profiler.is_enabled());
+    }
+
+    #[test]
+    fn profiler_records_when_enabled() {
+        let profiler = TickProfiler::new();
+        profiler.set_enabled(true);
+
+        let start = Instant::now();
+        thread::sleep(Duration::from_millis(1));
+        profiler.record_world_tick(start);
+
+        let snap = profiler.snapshot();
+        assert!(snap.world_avg_nanos > 0);
+        assert!(snap.total_ticks == 0); // total_tick not recorded yet
+    }
+
+    #[test]
+    fn profiler_ignores_when_disabled() {
+        let profiler = TickProfiler::new();
+        // Profiler is disabled by default
+
+        let start = Instant::now();
+        thread::sleep(Duration::from_millis(1));
+        profiler.record_world_tick(start);
+
+        let snap = profiler.snapshot();
+        assert_eq!(snap.world_avg_nanos, 0);
+    }
+
+    #[test]
+    fn slow_tick_detection() {
+        let profiler = TickProfiler::new();
+        profiler.set_enabled(true);
+        profiler.set_slow_threshold_ms(0); // Any tick is "slow"
+
+        let start = Instant::now();
+        thread::sleep(Duration::from_millis(1));
+        profiler.record_total_tick(start);
+
+        let snap = profiler.snapshot();
+        assert_eq!(snap.slow_tick_count, 1);
+    }
+
+    #[test]
+    fn slow_tick_reset() {
+        let profiler = TickProfiler::new();
+        profiler.set_enabled(true);
+        profiler.set_slow_threshold_ms(0);
+
+        let start = Instant::now();
+        profiler.record_total_tick(start);
+
+        profiler.reset_slow_count();
+        let snap = profiler.snapshot();
+        assert_eq!(snap.slow_tick_count, 0);
+    }
+
+    #[test]
+    fn snapshot_budget_usage() {
+        let snap = TickProfileSnapshot {
+            world_avg_nanos: 0,
+            player_avg_nanos: 0,
+            total_avg_nanos: 25_000_000, // 25ms
+            world_last_nanos: 0,
+            player_last_nanos: 0,
+            total_last_nanos: 0,
+            world_peak_nanos: 0,
+            player_peak_nanos: 0,
+            total_peak_nanos: 0,
+            slow_tick_count: 0,
+            total_ticks: 100,
+        };
+        assert!((snap.budget_usage_percent() - 50.0).abs() < 0.01);
+        assert!((snap.total_avg_ms() - 25.0).abs() < 0.01);
+    }
+}


### PR DESCRIPTION
## What this adds

Core server improvements (~5K new/changed lines):

### New Commands (5)
- `save-all` / `save-off` / `save-on` — world save management
- `debug` — performance profiling start/stop
- `perf` — tick profiler with TPS reporting

### Config Enforcement
- `force_gamemode` — reset gamemode on login
- `broadcast_console_to_ops` — operator visibility for console commands
- `log_admin_commands` game rule enforcement
- 3 new config fields

### Lifecycle Events
- ServerTickEvent fired every tick
- Server start/stop events

### Tick Profiler (`tick_profiler.rs`)
- Per-tick timing with sliding window
- TPS calculation and reporting

**Metrics:** 50/84 vanilla commands, 14/59 game rules enforced, ~78% core completion.

Part 6 of 11. Depends on: PR 5 (plugin events).
