### PR TITLE
fix: void damage

### DIFF
--- a/pumpkin/src/entity/mod.rs
+++ b/pumpkin/src/entity/mod.rs
@@ -1939,7 +1939,8 @@ impl Entity {
     }
 
     pub fn is_invulnerable_to(&self, damage_type: &DamageType) -> bool {
-        *damage_type != DamageType::GENERIC_KILL && *damage_type != DamageType::OUT_OF_WORLD
+        *damage_type != DamageType::GENERIC_KILL
+            && *damage_type != DamageType::OUT_OF_WORLD
             && (self.invulnerable.load(Relaxed) || self.damage_immunities.contains(damage_type))
     }
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -2876,7 +2876,10 @@ impl EntityBase for Player {
         cause: Option<&'a dyn EntityBase>,
     ) -> EntityBaseFuture<'a, bool> {
         Box::pin(async move {
-            if self.abilities.lock().await.invulnerable && damage_type != DamageType::GENERIC_KILL && damage_type != DamageType::OUT_OF_WORLD {
+            if self.abilities.lock().await.invulnerable
+                && damage_type != DamageType::GENERIC_KILL
+                && damage_type != DamageType::OUT_OF_WORLD
+            {
                 return false;
             }
             let result = self


### PR DESCRIPTION
## Description
Before, players would get locked in the void due to an ``entity.remove()`` call on the player.
Now, players take damage in the void at/under y=-128 and die normally (in all game modes).

## Testing
Yes.

Fixes #1314