### PR TITLE
update repo link for criterion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Note: Pumpkin's clippy settings are relatively strict, this can be may frustrati
 #### Best Practice
 
 - **Writing Unit Tests:** When adding new features or modifying existing code, consider adding unit tests to prevent regressions in the future. Refer to the Rust documentation for guidance on writing tests: <https://doc.rust-lang.org/book/ch11-01-writing-tests.html>
-- **Benchmarking:** If your changes might impact performance, consider adding benchmarks to track performance regressions or improvements. We use the Criterion library for benchmarking. Refer to their Quick Start guide for more information: <https://github.com/bheisler/criterion.rs#quickstart>
+- **Benchmarking:** If your changes might impact performance, consider adding benchmarks to track performance regressions or improvements. We use the Criterion library for benchmarking. Refer to their Quick Start guide for more information: <https://github.com/criterion-rs/criterion.rs#quickstart>
 - **Clear and Concise Commit Messages:** Use clear and concise commit messages that describe the changes you've made.
 - **Code Style:** Adhere to consistent coding style throughout your contributions.
 - **Documentation:** If your changes introduce new functionality, consider updating the relevant documentation.


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Existing link in CONTRIBUTING.md to https://github.com/bheisler/criterion.rs?tab=readme-ov-file is not working anymore, as project moved to another repo: https://github.com/criterion-rs/criterion.rs

I just updated link to newer one.
## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
