### PR TITLE
feat(worldgen): implement blender biome supplier hook

### DIFF
--- a/pumpkin-world/src/biome/end.rs
+++ b/pumpkin-world/src/biome/end.rs
@@ -1,4 +1,4 @@
-use pumpkin_data::{chunk::Biome, dimension::Dimension};
+use pumpkin_data::chunk::Biome;
 
 use crate::{
     biome::BiomeSupplier,
@@ -18,13 +18,7 @@ impl TheEndBiomeSupplier {
 }
 
 impl BiomeSupplier for TheEndBiomeSupplier {
-    fn biome(
-        x: i32,
-        y: i32,
-        z: i32,
-        noise: &mut MultiNoiseSampler<'_>,
-        _dimension: Dimension,
-    ) -> &'static Biome {
+    fn biome(&self, x: i32, y: i32, z: i32, noise: &mut MultiNoiseSampler<'_>) -> &'static Biome {
         let x = biome_coords::to_block(x);
         let y = biome_coords::to_block(y);
         let z = biome_coords::to_block(z);

--- a/pumpkin-world/src/biome/multi_noise.rs
+++ b/pumpkin-world/src/biome/multi_noise.rs
@@ -122,8 +122,7 @@ mod test {
         );
 
         for (x, y, z, biome_id) in expected_data {
-            let calculated_biome =
-                MultiNoiseBiomeSupplier::biome(x, y, z, &mut sampler, Dimension::OVERWORLD);
+            let calculated_biome = MultiNoiseBiomeSupplier::OVERWORLD.biome(x, y, z, &mut sampler);
 
             assert_eq!(
                 biome_id,

--- a/pumpkin-world/src/generation/proto_chunk.rs
+++ b/pumpkin-world/src/generation/proto_chunk.rs
@@ -30,6 +30,7 @@ use super::{
     section_coords,
     surface::{MaterialRuleContext, estimate_surface_height, terrain::SurfaceTerrainBuilder},
 };
+use crate::biome::{BiomeSupplier, MultiNoiseBiomeSupplier, end::TheEndBiomeSupplier};
 use crate::chunk::format::LightContainer;
 use crate::chunk::{ChunkData, ChunkHeightmapType, ChunkLight};
 use crate::chunk_system::StagedChunkEnum;
@@ -628,7 +629,17 @@ impl ProtoChunk {
         dimension: Dimension,
         multi_noise_sampler: &mut MultiNoiseSampler,
     ) {
-        let biome_supplier = Blender::NO_BLEND.get_biome_supplier();
+        let overworld_supplier = MultiNoiseBiomeSupplier::OVERWORLD;
+        let nether_supplier = MultiNoiseBiomeSupplier::NETHER;
+        let end_supplier = TheEndBiomeSupplier;
+        let base_supplier: &dyn BiomeSupplier = if dimension == Dimension::THE_END {
+            &end_supplier
+        } else if dimension == Dimension::THE_NETHER {
+            &nether_supplier
+        } else {
+            &overworld_supplier
+        };
+        let biome_supplier = Blender::NO_BLEND.get_biome_supplier(base_supplier);
         let min_y = self.bottom_y();
         let bottom_section = section_coords::block_to_section(min_y as i32);
         let top_section = section_coords::block_to_section(min_y as i32 + self.height() as i32 - 1);
@@ -647,12 +658,11 @@ impl ProtoChunk {
             for x in 0..biomes_per_section {
                 for y in 0..biomes_per_section {
                     for z in 0..biomes_per_section {
-                        let biome = biome_supplier(
+                        let biome = biome_supplier.biome(
                             start_biome_x + x,
                             start_biome_y + y,
                             start_biome_z + z,
                             multi_noise_sampler,
-                            dimension,
                         );
                         let index = self.local_biome_pos_to_biome_index(
                             x,


### PR DESCRIPTION
  ### What changed
  - Added a BlenderBiomeSupplier function type.
  - Updated BlenderImpl::get_biome_supplier to return a concrete supplier function.
      - Uses MultiNoiseBiomeSupplier for Overworld/Nether.
  - Updated ProtoChunk::populate_biomes to resolve biomes via Blender::NO_BLEND.get_biome_supplier().

  ### Why

  - Removes the remaining todo!() in Blender biome supplier logic.
  - Makes biome selection flow cleaner and extensible for future blending implementations.

  ### Notes
  - Current no-blend runtime behavior is preserved.