### PR TITLE
fix(chunk): prevent stale chunk_sent entries from blocking visibility

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -195,7 +195,7 @@ impl ChunkManager {
         mut view_distance: u8,
         level: &Arc<Level>,
         loading_chunks: &[Vector2<i32>],
-        _unloading_chunks: &[Vector2<i32>],
+        unloading_chunks: &[Vector2<i32>],
     ) {
         view_distance += 1; // Margin for loading
         let old_center = self.center;
@@ -219,15 +219,17 @@ impl ChunkManager {
         self.center = center;
         self.view_distance = view_distance;
         let view_distance_i32 = i32::from(view_distance);
+        let unloading_chunks: HashSet<Vector2<i32>> = unloading_chunks.iter().copied().collect();
 
         self.chunk_sent.retain(|pos| {
             (pos.x - center.x).abs().max((pos.y - center.y).abs()) <= view_distance_i32
+                && !unloading_chunks.contains(pos)
         });
 
         let mut new_queue = BinaryHeap::with_capacity(self.chunk_queue.len());
         for node in self.chunk_queue.drain() {
             let dst = (node.1.x - center.x).abs().max((node.1.y - center.y).abs());
-            if dst <= view_distance_i32 {
+            if dst <= view_distance_i32 && !unloading_chunks.contains(&node.1) {
                 new_queue.push(HeapNode(dst, node.1, node.2));
             }
         }


### PR DESCRIPTION
This PR fixes intermittent missing chunk visibility while moving/flying.

  ### What changed

  - Updated ChunkManager::update_center_and_view_distance in pumpkin/src/entity/player.rs.
  - chunk_sent cleanup now uses current center + view distance bounds instead of only the unloading_chunks list.
  - Marked the now-unused parameter as _unloading_chunks.

  ### Why

  In some movement/update paths, unloading_chunks can be incomplete relative to actual out-of-range chunks.
  That leaves stale entries in chunk_sent, which can block re-queuing and prevent chunks from being sent to the client.

  ### Result

  - Reduces “holes” / not-loading chunk strips during movement.
  - Keeps chunk send state aligned with real view radius.