### PR TITLE
Prevent subtraction overflow in `translation_to_pretty`

### DIFF
--- a/pumpkin-util/src/translation.rs
+++ b/pumpkin-util/src/translation.rs
@@ -138,30 +138,31 @@ pub fn reorder_substitutions(
     }
     (substitutions, ranges)
 }
-
 pub fn translation_to_pretty<P: Into<Cow<'static, str>>>(
     namespaced_key: P,
     locale: Locale,
     with: Vec<TextComponentBase>,
 ) -> String {
-    let mut translation = get_translation(&namespaced_key.into(), locale);
+    let translation = get_translation(&namespaced_key.into(), locale);
     if with.is_empty() || !translation.contains('%') {
         return translation;
     }
 
     let (substitutions, indices) = reorder_substitutions(&translation, with);
-    let mut displacement = 0i32;
+    let mut result = String::new();
+    let mut pos = 0;
+
     for (idx, &range) in indices.iter().enumerate() {
         let sub_idx = idx.clamp(0, substitutions.len() - 1);
         let substitution = substitutions[sub_idx].clone().to_pretty_console();
-        translation.replace_range(
-            (range.start as i32 + displacement) as usize
-                ..=(range.end as i32 + displacement) as usize,
-            &substitution,
-        );
-        displacement += substitution.len() as i32 - range.len() as i32;
+
+        result.push_str(&translation[pos..range.start]);
+        result.push_str(&substitution);
+        pos = range.end + 1;
     }
-    translation
+
+    result.push_str(&translation[pos..]);
+    result
 }
 
 pub fn get_translation_text<P: Into<Cow<'static, str>>>(
@@ -169,28 +170,26 @@ pub fn get_translation_text<P: Into<Cow<'static, str>>>(
     locale: Locale,
     with: Vec<TextComponentBase>,
 ) -> String {
-    let mut translation = get_translation(&namespaced_key.into(), locale);
+    let translation = get_translation(&namespaced_key.into(), locale);
     if with.is_empty() || !translation.contains('%') {
         return translation;
     }
 
     let (substitutions, indices) = reorder_substitutions(&translation, with);
+    let mut result = String::new();
+    let mut pos = 0;
 
-    // i32 since displacement can be negative. Casting from usize to i32 is safe in this context
-    // since it is unreasonable for the length of `range` or `substitution` to exceed 2147483647
-    // (i.e. i32::MAX).
-    let mut displacement = 0i32;
     for (idx, &range) in indices.iter().enumerate() {
         let sub_idx = idx.clamp(0, substitutions.len() - 1);
         let substitution = substitutions[sub_idx].clone().get_text(locale);
-        translation.replace_range(
-            (range.start as i32 + displacement) as usize
-                ..=(range.end as i32 + displacement) as usize,
-            &substitution,
-        );
-        displacement += substitution.len() as i32 - range.len() as i32;
+
+        result.push_str(&translation[pos..range.start]);
+        result.push_str(&substitution);
+        pos = range.end + 1;
     }
-    translation
+
+    result.push_str(&translation[pos..]);
+    result
 }
 
 pub static TRANSLATIONS: LazyLock<Mutex<[HashMap<String, String>; Locale::last() as usize]>> =


### PR DESCRIPTION
## Description
Prevent subtraction overflow in `translation_to_pretty`. fixes #1507 

## Testing

1. boot up pumpkin server
2. from console type `give @a minecraft:lava_bucket`
3. it should not panic because of an overflow error


