### PR TITLE
feat: add redstone power support for fence gates

### DIFF
--- a/pumpkin/src/block/blocks/fence_gates.rs
+++ b/pumpkin/src/block/blocks/fence_gates.rs
@@ -121,20 +121,22 @@ impl BlockBehaviour for FenceGateBlock {
                 FenceGateProperties::from_state_id(block_state.id, args.block);
             let powered = block_receives_redstone_power(args.world, args.position).await;
 
-            if powered != fence_gate_props.powered {
-                fence_gate_props.powered = powered;
+            if powered == fence_gate_props.powered {
+                return;
+            }
 
-                if powered != fence_gate_props.open {
-                    fence_gate_props.open = powered;
+            fence_gate_props.powered = powered;
 
-                    args.world
-                        .play_block_sound(
-                            get_sound(args.block, powered),
-                            SoundCategory::Blocks,
-                            *args.position,
-                        )
-                        .await;
-                }
+            if powered != fence_gate_props.open {
+                fence_gate_props.open = powered;
+
+                args.world
+                    .play_block_sound(
+                        get_sound(args.block, powered),
+                        SoundCategory::Blocks,
+                        *args.position,
+                    )
+                    .await;
             }
 
             args.world


### PR DESCRIPTION
## Summary

- Fence gates now respond to redstone power changes (open when powered, close when unpowered)
- Initial placement checks redstone power and opens gate if powered
- Adds wood-type-specific open/close sounds for both manual and redstone toggling

## Changes

Single file: `pumpkin/src/block/blocks/fence_gates.rs`

- `on_neighbor_update()`: detects redstone power changes, updates `powered`/`open` properties, plays sound
- `on_place()`: checks redstone power at placement position
- `toggle_fence_gate()`: plays the correct fence gate sound on manual toggle (was a TODO)
- `get_sound()`: returns the appropriate sound variant per wood type (bamboo, cherry, nether wood, default)

Follows the same pattern used by trapdoors and doors.

## Test plan

- [x] Redstone-powered fence gate opens and closes correctly
- [x] Correct sound plays for redstone-triggered toggle
- [x] Manual right-click toggle still works with sound
- [x] Gate placed on powered block opens immediately
- [x] `cargo build` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo fmt --check` passes
- [x] All tests pass
- [x] Verified in-game with Minecraft client