### PR TITLE
fix: resolve piston ghost blocks, block swapping, and retraction desync

### DIFF
--- a/pumpkin-world/src/block/entities/piston.rs
+++ b/pumpkin-world/src/block/entities/piston.rs
@@ -30,7 +30,10 @@ impl PistonBlockEntity {
                 let state = if self.source {
                     Block::AIR.default_state.id
                 } else {
-                    self.pushed_block_state.id
+                    world
+                        .clone()
+                        .update_from_neighbor_shapes(self.pushed_block_state.id, &pos)
+                        .await
                 };
                 world
                     .clone()
@@ -79,17 +82,21 @@ impl BlockEntity for PistonBlockEntity {
                             )
                             .await;
                     } else {
+                        let updated_state = world
+                            .clone()
+                            .update_from_neighbor_shapes(self.pushed_block_state.id, &pos)
+                            .await;
                         world
                             .clone()
                             .set_block_state(
                                 &pos,
-                                self.pushed_block_state.id,
+                                updated_state,
                                 BlockFlags::NOTIFY_ALL | BlockFlags::MOVED,
                             )
                             .await;
                         world
                             .clone()
-                            .update_neighbor(&pos, Block::from_state_id(self.pushed_block_state.id))
+                            .update_neighbor(&pos, Block::from_state_id(updated_state))
                             .await;
                     }
                 }

--- a/pumpkin-world/src/world.rs
+++ b/pumpkin-world/src/world.rs
@@ -137,6 +137,14 @@ pub trait SimpleWorld: BlockAccessor + Send + Sync {
         position: Vector3<f64>,
         amount: u32,
     ) -> WorldFuture<'static, ()>;
+
+    /// `Block.updateFromNeighbourShapes`: updates a block state by calling
+    /// `get_state_for_neighbor_update` on itself for each of the 6 directions.
+    fn update_from_neighbor_shapes(
+        self: Arc<Self>,
+        block_state_id: BlockStateId,
+        position: &BlockPos,
+    ) -> WorldFuture<'_, BlockStateId>;
 }
 
 pub trait BlockRegistryExt: Send + Sync {

--- a/pumpkin/src/block/blocks/piston/piston.rs
+++ b/pumpkin/src/block/blocks/piston/piston.rs
@@ -60,20 +60,18 @@ impl PistonBlock {
         }
         if block == &Block::PISTON || block == &Block::STICKY_PISTON {
             let props = PistonProps::from_state_id(state.id, block);
-            if props.extended {
-                return false;
-            }
-        } else {
-            #[expect(clippy::float_cmp)]
-            if state.hardness == -1.0 {
-                return false;
-            }
-            match state.piston_behavior {
-                pumpkin_data::block_state::PistonBehavior::Destroy => return can_break,
-                pumpkin_data::block_state::PistonBehavior::Block => return false,
-                pumpkin_data::block_state::PistonBehavior::PushOnly => return dir == piston_dir,
-                _ => {}
-            }
+            // Extended pistons are immovable. Non-extended pistons are movable
+            return !props.extended;
+        }
+        #[expect(clippy::float_cmp)]
+        if state.hardness == -1.0 {
+            return false;
+        }
+        match state.piston_behavior {
+            pumpkin_data::block_state::PistonBehavior::Destroy => return can_break,
+            pumpkin_data::block_state::PistonBehavior::Block => return false,
+            pumpkin_data::block_state::PistonBehavior::PushOnly => return dir == piston_dir,
+            _ => {}
         }
         !has_block_block_entity(block)
     }


### PR DESCRIPTION
## Summary

Fixes multiple piston bugs causing ghost blocks, block state swapping, and client desync during both push and pull operations, including flying machine failures.

## Bugs Fixed

### 1. Wrong PistonBlockEntity position for moved blocks

Every moved block's `PistonBlockEntity` was created with `position: extended_pos` (the piston head position) instead of `position: target_pos` (the block's actual destination). When the block entity finalizes at progress 1.0, it places the real block at `self.position` — so **all** pushed blocks materialized at the piston head position instead of their correct locations.

```rust
// Before:
position: extended_pos,
// After:
position: target_pos,
```

### 2. Reversed index causes pushed blocks to swap states

`moved_block_states` is built iterating `moved_blocks` in forward order (0, 1, 2...), but the processing loop iterates in reverse via `.iter().rev().enumerate()`. Enumerate index 0 maps to the **last** block, yet `moved_block_states.get(0)` returns the **first** block's state — causing blocks to receive each other's states. Visually, a slime block and its attached block would swap positions after being pushed.

```rust
// Before:
moved_block_states.get(index)
// After:
moved_block_states.get(moved_blocks.len() - 1 - index)
```

### 3. Variable shadowing passes wrong position to `move_piston` on retraction

In the sticky piston retraction path, `let pos = pos.offset_dir(dir.to_offset(), 2)` shadowed the original `pos` (piston base) with a position 2 blocks ahead. `move_piston` then computed `extended_pos` 3 blocks ahead and searched for pullable blocks 4 blocks ahead — all wrong. The real piston head was never removed (ghost head) and blocks at the correct position were never pulled (duplication).

```rust
// Before (pos shadowed):
let pos = pos.offset_dir(dir.to_offset(), 2);
// ...
move_piston(world, dir, &pos, false, sticky).await;

// After (no shadowing):
let pull_pos = pos.offset_dir(dir.to_offset(), 2);
// ...
move_piston(world, dir, pos, false, sticky).await;
```

### 4. Non-extended pistons incorrectly treated as immovable

`has_block_block_entity()` returned `true` for piston blocks because `Block::PISTON.name` ("piston") matched the `"piston"` entry in `BLOCK_ENTITY_TYPES`. However, in vanilla the piston base is **not** a block entity — that registry entry refers to the `MovingPiston` block entity type used during piston animations. This caused `is_movable()` to return `false` for non-extended pistons, preventing them from being pushed by other pistons. When a piston on a slime block couldn't be moved, it stayed at its original position while the slime moved away, creating a ghost block on the client.

```rust
// Before: fell through to has_block_block_entity() which returned true
if block == &Block::PISTON || block == &Block::STICKY_PISTON {
    if props.extended { return false; }
} else { ... }
!has_block_block_entity(block) // false for pistons!

// After: return early for non-extended pistons
if block == &Block::PISTON || block == &Block::STICKY_PISTON {
    return !props.extended;
}
```

### 5. Missing `update_from_neighbor_shapes` during block entity finalization

In vanilla, `MovingBlockEntity.tick()` calls `Block.updateFromNeighbourShapes(movedState, level, pos)` **before** placing the finalized block. This method calls `get_state_for_neighbor_update` on the block itself for each of the 6 directions, allowing blocks like observers to detect their new surroundings at their destination.

Without this call, observers pushed by pistons never detected neighbor changes at their new position, so they never scheduled redstone ticks — breaking flying machines and observer+piston contraptions.

Added `update_from_neighbor_shapes` to the `SimpleWorld` trait and `World` implementation, called from both `PistonBlockEntity::tick()` and `finish()` before placing the finalized block.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo test` passes
- [x] In-game: push blocks with piston — no ghost blocks
- [x] In-game: push slime block structure — all blocks move correctly, no swapping
- [x] In-game: retract sticky piston — piston head removed, pulled block moves correctly
- [x] In-game: retract sticky piston with another piston attached — no ghost blocks
- [x] In-game: push piston on slime block — piston moves with the group correctly
- [x] In-game: observer+piston on slime block — observer detects changes and triggers piston
- [x] In-game: flying machine with pistons, observers, and slime blocks — operates correctly