### PR TITLE
fix: prevent mobs from attacking when already dead

### DIFF
--- a/pumpkin/src/entity/mob/mod.rs
+++ b/pumpkin/src/entity/mob/mod.rs
@@ -132,6 +132,11 @@ impl MobEntity {
         // TODO: Use entity attributes for damage once implemented
         const ZOMBIE_ATTACK_DAMAGE: f32 = 3.0;
 
+        if self.living_entity.dead.load(Relaxed) {
+            // do not attack if dead
+            return;
+        }
+
         target
             .damage_with_context(
                 target,


### PR DESCRIPTION
## Description
Mobs like zombies and drowned were still able to deal damage to players even after being killed, this fixes that.

## Testing

Before:
https://github.com/user-attachments/assets/e88738ad-a568-4a5b-826c-85e6908f940c

After:
https://github.com/user-attachments/assets/9fb3c082-f71b-453f-ba29-932f07128574

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
