### PR TITLE
Prevent targeting of creative players for mobs and fixes 1 of the 2 bugs listed in bug #1515

### DIFF
--- a/pumpkin/src/entity/ai/goal/track_target.rs
+++ b/pumpkin/src/entity/ai/goal/track_target.rs
@@ -5,6 +5,7 @@ use crate::entity::ai::target_predicate::TargetPredicate;
 use crate::entity::living::LivingEntity;
 use crate::entity::mob::Mob;
 use crate::entity::mob::MobEntity;
+use pumpkin_util::gamemode::GameMode;
 use rand::RngExt;
 
 const UNSET: i32 = 0;
@@ -69,7 +70,7 @@ impl TrackTargetGoal {
         // Prevent targeting creative players
         if let Some(player) = target.entity.get_player() {
             let gm = player.gamemode.load();
-            if gm.is_creative() {
+            if gm == GameMode::Creative {
                 return false;
             }
         }


### PR DESCRIPTION
Added a check to prevent targeting creative players. like for Hostile Mob's such as zombies

fixes  1 of the 2 bugs in #1515 

what changed: Inside TrackTargetGoal::can_track() a check was added to see if the player was creative and if they were it would ignore them like normal vanilla behavior 

