### PR TITLE
fix(chunk): add fallback when chunk ACK stalls

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -348,7 +348,10 @@ impl ChunkManager {
     }
 
     pub fn next_entity(&mut self) -> Box<[SyncEntityChunk]> {
-        let chunk_size = self.entity_chunk_queue.len().min(self.chunks_per_tick);
+        let chunk_size = self
+            .entity_chunk_queue
+            .len()
+            .min(self.chunks_per_tick.max(1));
 
         let chunks: Box<[Arc<ChunkEntityData>]> = self
             .entity_chunk_queue
@@ -361,8 +364,9 @@ impl ChunkManager {
                 *count = count.saturating_add(1);
             }
             state @ BatchState::Initial => *state = BatchState::Waiting,
-            BatchState::Waiting => unreachable!(),
+            BatchState::Waiting => (),
         }
+        self.last_chunk_batch_sent_at = Instant::now();
 
         chunks
     }


### PR DESCRIPTION
  This PR adds a safe fallback path for chunk streaming when chunk batch ACKs are delayed or missing.

  ### What changed
  - Added ACK-stall fallback timing in `ChunkManager`.
  - Allowed chunk sending to continue if ACK window is closed for too long (`250ms` fallback delay).
  - Kept normal ACK-based flow control intact.
  - Reset fallback timing on cleanup/world change and after each sent batch.
  - Ensured at least one chunk can be sent per batch decision path (`chunks_per_tick.max(1)`).

  ## Why
  In some real-world cases, chunk visibility can stall at region borders even after prior fixes, likely due to ACK cadence issues.
  This fallback prevents the stream from getting stuck while still remaining rate-limited and conservative.
