### PR TITLE
fix: replace oldest log file when log filename id has reached maximum

### DIFF
--- a/pumpkin/src/logging.rs
+++ b/pumpkin/src/logging.rs
@@ -81,7 +81,7 @@ macro_rules! plugin_log {
 }
 
 const LOG_DIR: &str = "logs";
-const MAX_ATTEMPTS: u32 = 100;
+const MAX_ATTEMPTS: u32 = 1000;
 
 /// A wrapper for our logger to hold the terminal input while no input is expected in order to
 /// properly flush logs to the output while they happen instead of batched


### PR DESCRIPTION
## Description
Overwrites oldest log file when log filename id has reached maximum (100), instead of panicking.

fixes #1484 

## Testing
**Clippy:** Passed
**Cargo test:** Passed
**Behaviour tested and works as intended**

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
