### PR TITLE
fix: match campfires with vanilla logic

### DIFF
--- a/pumpkin/src/block/blocks/campfire.rs
+++ b/pumpkin/src/block/blocks/campfire.rs
@@ -44,7 +44,7 @@ impl BlockBehaviour for CampfireBlock {
                     .await
                     .is_some();
                 if has_frost_walker_enchantment || has_fire_res {
-                    //campfire burning doesn't work if entity's boots has frost walker enchantement or entity has fire res. source: https://minecraft.wiki/w/Campfire#Damage
+                    //campfire burning doesn't work if entity's boots has frost walker enchantment or entity has fire resistance. source: https://minecraft.wiki/w/Campfire#Damage
                     return;
                 }
                 let damage_amount = if args.block == &Block::SOUL_CAMPFIRE {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Partially fixes https://github.com/Pumpkin-MC/Pumpkin/issues/264
fix: soul campfire deals 2 damage per half second instead of 1
fix: campfires dont deal damage if entity is wearing boots with frost walker or has fire resistance effect

Sources:
https://minecraft.wiki/w/Soul_Campfire#Damage
https://minecraft.wiki/w/Campfire#Damage
