### PR TITLE
add more entites to which if they are there a block cant be placed | fixes #1492

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -2010,6 +2010,7 @@ impl JavaClient {
             || entity_type == &EntityType::PAINTING
             || entity_type == &EntityType::FISHING_BOBBER
             || entity_type == &EntityType::SHULKER_BULLET
+    }
 
     fn has_blocking_entity_in_box(world: &World, placed_box: &BoundingBox) -> bool {
         let players = world.players.load();


### PR DESCRIPTION
this fixes issue #1492  since some entities weren't added to it , I added 
|| entity_type == &EntityType::ARMOR_STAND
|| entity_type == &EntityType::ITEM_FRAME
|| entity_type == &EntityType::GLOW_ITEM_FRAME
|| entity_type == &EntityType::PAINTING
|| entity_type == &EntityType::FISHING_BOBBER
|| entity_type == &EntityType::SHULKER_BULLET
