### PR TITLE
fix: creative drag of items and middle click in chests

### DIFF
--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -738,10 +738,13 @@ pub trait ScreenHandler: Send + Sync {
                             } else {
                                 panic!("Invalid drag button: {drag_button}");
                             };
-                            inserting_count = inserting_count.min(max(
-                                0,
-                                slot.get_max_item_count_for_stack(&stack).await - stack.item_count,
-                            ));
+                            inserting_count = inserting_count
+                                .min(max(
+                                    0,
+                                    slot.get_max_item_count_for_stack(&stack).await
+                                        - stack.item_count,
+                                ))
+                                .min(cursor_stack.item_count);
                             if inserting_count > 0 {
                                 let mut stack_clone = stack.clone();
                                 drop(stack);


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Fixes #969 

1) When dragging with scroll wheel, cursor_stack.item_count is changed to the max stack size for that item. In vanilla, if you have an item in the cursor, the item count is changed to the max stack size when you drag with the scroll wheel. 

2) Removed .min(cursor_stack.item_count); I believe this was so that the creative drag would insert only how many you had in the cursor_stack to each slot, but in vanilla it makes slot count max stack size.

3) Added a condition to check if we are dragging with the scroll wheel. If we are, then at the end (when we finish dragging) the cursor should be cleared or have no item in it.

4) Added a check to return early/do nothing when we click our scroll wheel if we already have an item in the cursor.

This pull request passes clippy and cargo test.
## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
