### PR TITLE
fix: preserve knockback velocity on killing blow

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -945,10 +945,6 @@ impl LivingEntity {
             .compare_exchange(false, true, Relaxed, Relaxed)
             .is_ok()
         {
-            // Immediately clear all movement/velocity so the dead entity stops being
-            // simulated by physics and doesn't accumulate additional fall_distance.
-            self.entity.velocity.store(Vector3::default());
-            self.entity.velocity_dirty.store(true, SeqCst);
             self.movement_input.store(Vector3::default());
             self.jumping.store(false, Relaxed);
             // Plays the death sound


### PR DESCRIPTION
## Summary
- `on_death` was clearing entity velocity immediately, preventing the killing blow knockback from being visible to clients
- Vanilla's `onDeath` does not clear velocity — only movement input and jumping are stopped
- Removed the velocity reset so knockback plays out naturally on the final hit

Fixes #1577