### PR TITLE
fix: double-click behavior on empty slot after placing or dragging items in chests

### DIFF
--- a/pumpkin-inventory/src/screen_handler.rs
+++ b/pumpkin-inventory/src/screen_handler.rs
@@ -757,6 +757,7 @@ pub trait ScreenHandler: Send + Sync {
                                     cursor_stack.decrement(inserting_count);
                                 }
                                 if cursor_stack.is_empty() {
+                                    *cursor_stack = ItemStack::EMPTY.clone();
                                     break;
                                 }
                             }

--- a/pumpkin-inventory/src/slot.rs
+++ b/pumpkin-inventory/src/slot.rs
@@ -245,7 +245,11 @@ pub trait Slot: Send + Sync {
                     }
                 }
             }
-            stack
+            if stack.is_empty() {
+                ItemStack::EMPTY.clone()
+            } else {
+                stack
+            }
         })
     }
 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
What was changed?:
If the cursor has no items after placing or dragging items into a slot, the cursor is changed to type ItemStack::EMPTY instead of the the type of item it just placed. 

Why were these changes necessary?:
When double clicking on an empty slot, it shouldn't pick up anything. In the current build, after placing or dragging items, the cursor is still the type of the item that was just placed, so when you double click on an empty slot, it will collect that type of item into the cursor.

It passes clippy and cargo test.
## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
