### PR TITLE
permission check event

### DIFF
--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -85,6 +85,7 @@ use crate::net::{ClientPlatform, GameProfile};
 use crate::net::{DisconnectReason, PlayerConfig};
 use crate::plugin::player::player_change_world::PlayerChangeWorldEvent;
 use crate::plugin::player::player_gamemode_change::PlayerGamemodeChangeEvent;
+use crate::plugin::player::player_permission_check::PlayerPermissionCheckEvent;
 use crate::plugin::player::player_teleport::PlayerTeleportEvent;
 use crate::server::Server;
 use crate::world::World;
@@ -2752,11 +2753,22 @@ impl Player {
     }
 
     /// Check if the player has a specific permission
-    pub async fn has_permission(&self, server: &Server, node: &str) -> bool {
+    pub async fn has_permission(self: &Arc<Self>, server: &Server, node: &str) -> bool {
         let perm_manager = server.permission_manager.read().await;
-        perm_manager
+        let result = perm_manager
             .has_permission(&self.gameprofile.id, node, self.permission_lvl.load())
-            .await
+            .await;
+        drop(perm_manager);
+
+        let event = server
+            .plugin_manager
+            .fire(PlayerPermissionCheckEvent::new(
+                self.clone(),
+                node.to_string(),
+                result,
+            ))
+            .await;
+        event.result
     }
 
     pub fn is_creative(&self) -> bool {

--- a/pumpkin/src/plugin/api/events/player/mod.rs
+++ b/pumpkin/src/plugin/api/events/player/mod.rs
@@ -10,6 +10,7 @@ pub mod player_join;
 pub mod player_leave;
 pub mod player_login;
 pub mod player_move;
+pub mod player_permission_check;
 pub mod player_teleport;
 
 use std::sync::Arc;

--- a/pumpkin/src/plugin/api/events/player/player_permission_check.rs
+++ b/pumpkin/src/plugin/api/events/player/player_permission_check.rs
@@ -1,0 +1,29 @@
+use pumpkin_macros::Event;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+#[derive(Event, Clone)]
+pub struct PlayerPermissionCheckEvent {
+    pub player: Arc<Player>,
+    pub permission: String,
+    pub result: bool,
+}
+
+impl PlayerPermissionCheckEvent {
+    pub const fn new(player: Arc<Player>, permission: String, result: bool) -> Self {
+        Self {
+            player,
+            permission,
+            result,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerPermissionCheckEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}


### PR DESCRIPTION
## Summary
- adds `PlayerPermissionCheckEvent` to the plugin event system
- fired after every permission check on a player, allowing plugins to override the result
- enables permission plugins to hook into the permission system