### PR TITLE
player permission setup event

### DIFF
--- a/pumpkin/src/plugin/api/events/player/mod.rs
+++ b/pumpkin/src/plugin/api/events/player/mod.rs
@@ -10,6 +10,7 @@ pub mod player_join;
 pub mod player_leave;
 pub mod player_login;
 pub mod player_move;
+pub mod player_permission_setup;
 pub mod player_teleport;
 
 use std::sync::Arc;

--- a/pumpkin/src/plugin/api/events/player/player_permission_setup.rs
+++ b/pumpkin/src/plugin/api/events/player/player_permission_setup.rs
@@ -1,0 +1,28 @@
+use pumpkin_macros::Event;
+use pumpkin_util::permission::PermissionLvl;
+use std::sync::Arc;
+
+use crate::entity::player::Player;
+
+use super::PlayerEvent;
+
+#[derive(Event, Clone)]
+pub struct PlayerPermissionSetupEvent {
+    pub player: Arc<Player>,
+    pub permission_lvl: PermissionLvl,
+}
+
+impl PlayerPermissionSetupEvent {
+    pub const fn new(player: Arc<Player>, permission_lvl: PermissionLvl) -> Self {
+        Self {
+            player,
+            permission_lvl,
+        }
+    }
+}
+
+impl PlayerEvent for PlayerPermissionSetupEvent {
+    fn get_player(&self) -> &Arc<Player> {
+        &self.player
+    }
+}

--- a/pumpkin/src/server/mod.rs
+++ b/pumpkin/src/server/mod.rs
@@ -9,6 +9,7 @@ use crate::net::authentication::fetch_mojang_public_keys;
 use crate::net::{ClientPlatform, DisconnectReason, EncryptionError, GameProfile, PlayerConfig};
 use crate::plugin::PluginManager;
 use crate::plugin::player::player_login::PlayerLoginEvent;
+use crate::plugin::player::player_permission_setup::PlayerPermissionSetupEvent;
 use crate::plugin::server::server_broadcast::ServerBroadcastEvent;
 use crate::server::tick_rate_manager::ServerTickRateManager;
 use crate::world::custom_bossbar::CustomBossbars;
@@ -411,6 +412,15 @@ impl Server {
 
         // Wrap in Arc after data is loaded
         let player = Arc::new(player);
+
+        let event = self
+            .plugin_manager
+            .fire(PlayerPermissionSetupEvent::new(
+                player.clone(),
+                player.permission_lvl.load(),
+            ))
+            .await;
+        player.permission_lvl.store(event.permission_lvl);
 
         send_cancellable! {{
             self;


### PR DESCRIPTION
## Summary
- adds `PlayerPermissionSetupEvent` to the plugin event system
- fired during player join after op level is loaded from ops.json but before login
- allows plugins to modify the player's permission level before they enter the world