### PR TITLE
fix: make armor stands fall

### DIFF
--- a/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/pumpkin/src/entity/decoration/armor_stand.rs
@@ -437,7 +437,7 @@ impl EntityBase for ArmorStandEntity {
     }
 
     fn get_gravity(&self) -> f64 {
-        0.04
+        0.08
     }
 }
 


### PR DESCRIPTION
## Description

Implements `get_gravity` in `EntityBase` for `ArmorStandEntity` to make the armor stand fall instead of staying midair.
Fixes issue #1619.

## Testing

As expected, when testing in-game, the armor stand falls when a block is broken below it.
