### PR TITLE
fix: spectators can no longer pickup items

### DIFF
--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -441,11 +441,8 @@ impl EntityBase for ItemEntity {
         Box::pin(async {
             if self.pickup_delay.load(Ordering::Relaxed) > 0
                 || player.living_entity.health.load() <= 0.0
+                || player.is_spectator()
             {
-                return;
-            }
-
-            if player.is_spectator() {
                 return;
             }
 


### PR DESCRIPTION
## Description
Simple fix for issue #1617, added a check for spectator mode on item pickup

## Testing
All tests passed successfully and no new clippy warning was found.
Manual testing was successful.