### PR TITLE
feat: zombie/skeleton sunburn in daylight, crit particles on attack

### DIFF
--- a/pumpkin/src/entity/mob/skeleton/skeleton.rs
+++ b/pumpkin/src/entity/mob/skeleton/skeleton.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBase, EntityBaseFuture, NBTStorage,
     mob::{Mob, MobEntity, skeleton::SkeletonEntityBase},
 };
 
@@ -22,5 +22,11 @@ impl NBTStorage for SkeletonEntity {}
 impl Mob for SkeletonEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.entity.mob_entity
+    }
+
+    fn mob_tick<'a>(&'a self, _caller: &'a Arc<dyn EntityBase>) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            self.tick_sunburn().await;
+        })
     }
 }

--- a/pumpkin/src/entity/mob/zombie/mod.rs
+++ b/pumpkin/src/entity/mob/zombie/mod.rs
@@ -7,7 +7,7 @@ use crate::entity::ai::goal::step_and_destroy_block::{
 use crate::entity::ai::goal::zombie_attack::ZombieAttackGoal;
 use crate::entity::ai::goal::{Controls, Goal, GoalFuture, ParentHandle};
 use crate::entity::{
-    Entity, NBTStorage,
+    Entity, EntityBase, EntityBaseFuture, NBTStorage,
     ai::goal::{active_target::ActiveTargetGoal, look_at_entity::LookAtEntityGoal},
 };
 use crate::world::World;
@@ -65,6 +65,12 @@ impl NBTStorage for ZombieEntity {}
 impl Mob for ZombieEntity {
     fn get_mob_entity(&self) -> &MobEntity {
         &self.mob_entity
+    }
+
+    fn mob_tick<'a>(&'a self, _caller: &'a Arc<dyn EntityBase>) -> EntityBaseFuture<'a, ()> {
+        Box::pin(async move {
+            self.tick_sunburn().await;
+        })
     }
 }
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -733,6 +733,13 @@ impl Player {
 
         player_attack_sound(&pos, &world, attack_type).await;
 
+        // Send crit particles to clients
+        if matches!(attack_type, AttackType::Critical) {
+            world
+                .send_entity_status(victim_entity, EntityStatus::KineticAttack)
+                .await;
+        }
+
         self.living_entity.last_attacking_id.store(
             victim_entity.entity_id,
             std::sync::atomic::Ordering::Relaxed,


### PR DESCRIPTION
closes #1682
closes #1622

## what's done

**sunburn (#1682)**
- zombies and skeletons now catch fire when exposed to daylight (time 0–12000)
- checks: not in water, no helmet, sky is visible (mob y >= top block at that xz)
- implemented as `tick_sunburn` helper in the `Mob` trait, called from `mob_tick` in `ZombieEntity` and `SkeletonEntity`
- husk, stray, wither skeleton, bogged — not affected (they override separately)

**crit particles (#1622)**
- sends `EntityStatus::KineticAttack` (status 2) to the victim on a critical hit
- clients render the crit particle effect on the target