### PR TITLE
fix: armor stand death particles, server kick on empty sign line

### DIFF
--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -103,10 +103,13 @@ impl<R: Read> NetworkReadExt for R {
 
     fn read_boxed_slice(&mut self, length: usize) -> Result<Box<[u8]>, ReadingError> {
         const MAX_SLICE_LENGTH: usize = 2 * 1024 * 64; // 64KB, largest valid MC packet
-        if !(1..=MAX_SLICE_LENGTH).contains(&length) {
+        if length > MAX_SLICE_LENGTH {
             return Err(ReadingError::Message(format!(
                 "read_boxed_slice: length {length} out of bounds"
             )));
+        }
+        if length == 0 {
+            return Ok(Box::new([]));
         }
         let mut buf = vec![0u8; length];
         self.read_exact(&mut buf)

--- a/pumpkin/src/entity/decoration/armor_stand.rs
+++ b/pumpkin/src/entity/decoration/armor_stand.rs
@@ -355,7 +355,7 @@ impl EntityBase for ArmorStandEntity {
                 damage_type == DamageType::OUT_OF_WORLD || damage_type == DamageType::GENERIC_KILL;
 
             if bypasses_invulnerability {
-                entity.kill(caller).await;
+                self.kill(caller).await;
                 return false;
             }
 
@@ -370,7 +370,7 @@ impl EntityBase for ArmorStandEntity {
 
             if is_explosion {
                 self.on_break(entity).await;
-                entity.kill(caller).await;
+                self.kill(caller).await;
                 return false;
             }
 
@@ -400,7 +400,7 @@ impl EntityBase for ArmorStandEntity {
                     return false;
                 } else if player.is_creative() {
                     self.spawn_break_particles(entity).await;
-                    entity.kill(caller).await;
+                    self.kill(caller).await;
                     return true;
                 }
             }
@@ -429,7 +429,7 @@ impl EntityBase for ArmorStandEntity {
                     )
                     .await;
                 self.break_and_drop_items().await;
-                entity.kill(caller).await;
+                self.kill(caller).await;
             }
 
             true


### PR DESCRIPTION
closes #1621
closes #1711

## what's done

**armor stand death particles (#1621)**
- armor stand was calling `entity.kill()` (on the `Entity` struct) instead of `self.kill()` (the overridden `EntityBase::kill` on `ArmorStandEntity`)
- default `kill` calls `damage(MAX, GENERIC_KILL)` → `on_death` → sends `PlayDeathSoundOrAddProjectileHitParticles`
- `ArmorStandEntity::kill` just calls `entity.remove()` with no death sound/particles
- fixed by replacing all `entity.kill(caller)` with `self.kill(caller)` in `damage_with_context`

**sign kick on empty line (#1711)**
- `read_boxed_slice` rejected length 0, causing a kick when a sign line was left empty
- client sends empty string (varint 0 + no bytes) for blank lines, which is valid
- fixed by allowing length 0 and returning an empty slice immediately