### PR TITLE
refactor(PalettedContainer): replace for_each() with iter()

### DIFF
--- a/pumpkin-world/src/chunk/mod.rs
+++ b/pumpkin-world/src/chunk/mod.rs
@@ -114,27 +114,23 @@ impl ChunkSections {
     #[cfg(test)]
     #[must_use]
     pub fn dump_blocks(&self) -> Vec<u16> {
-        // TODO: this is not optimal, we could use rust iters
-        let mut dump = Vec::new();
-        for section in self.block_sections.read().unwrap().iter() {
-            section.for_each(|raw_id| {
-                dump.push(raw_id);
-            });
-        }
-        dump
+        self.block_sections
+            .read()
+            .unwrap()
+            .iter()
+            .flat_map(|section| section.iter().copied())
+            .collect()
     }
 
     #[cfg(test)]
     #[must_use]
     pub fn dump_biomes(&self) -> Vec<u8> {
-        // TODO: this is not optimal, we could use rust iters
-        let mut dump = Vec::new();
-        for section in self.biome_sections.read().unwrap().iter() {
-            section.for_each(|raw_id| {
-                dump.push(raw_id);
-            });
-        }
-        dump
+        self.biome_sections
+            .read()
+            .unwrap()
+            .iter()
+            .flat_map(|section| section.iter().copied())
+            .collect()
     }
 }
 

--- a/pumpkin-world/src/chunk/palette.rs
+++ b/pumpkin-world/src/chunk/palette.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, hash::Hash};
+use std::{collections::HashMap, hash::Hash, iter::repeat_n};
 
 use pumpkin_data::{Block, BlockState, block_properties::is_air, chunk::Biome};
 use pumpkin_util::encompassing_bits;
@@ -245,25 +245,10 @@ impl<V: Hash + Eq + Copy + Default, const DIM: usize> PalettedContainer<V, DIM> 
         }
     }
 
-    pub fn for_each<F>(&self, mut f: F)
-    where
-        F: FnMut(V),
-    {
+    pub fn iter(&self) -> Box<dyn Iterator<Item = &V> + '_> {
         match self {
-            Self::Homogeneous(registry_id) => {
-                for _ in 0..Self::VOLUME {
-                    f(*registry_id);
-                }
-            }
-            Self::Heterogeneous(data) => {
-                data.cube
-                    .as_flattened()
-                    .as_flattened()
-                    .iter()
-                    .for_each(|value| {
-                        f(*value);
-                    });
-            }
+            Self::Homogeneous(registry_id) => Box::new(repeat_n(registry_id, Self::VOLUME)),
+            Self::Heterogeneous(data) => Box::new(data.cube.as_flattened().as_flattened().iter()),
         }
     }
 


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

This PR replaces the `for_each()` method of `PalettedContainer` with the `iter()` method, fulfilling the TODO described in `ChunkSections`'s `dump_blocks()` and `dump_biomes()`.

Since `PalettedContainer.iter()` returns a `Box` for type erasure, it may lead to a heap allocation bottleneck in high-frequency call scenarios.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
