### PR TITLE
feat(config): hide verbose log metadata by default

### DIFF
--- a/pumpkin-config/src/logging.rs
+++ b/pumpkin-config/src/logging.rs
@@ -8,8 +8,10 @@ use serde::{Deserialize, Serialize};
 pub struct LoggingConfig {
     /// Whether logging is enabled.
     pub enabled: bool,
-    /// Whether to include thread names in log output.
+    /// Whether to include thread names and IDs in log output.
     pub threads: bool,
+    /// Whether to include module paths in log output.
+    pub target: bool,
     /// Whether to enable coloured log output.
     pub color: bool,
     /// Whether to include timestamps in log entries.
@@ -22,7 +24,8 @@ impl Default for LoggingConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            threads: true,
+            threads: false,
+            target: false,
             color: true,
             timestamp: true,
             file: "latest.log".to_string(),

--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -48,6 +48,7 @@ pub mod world;
 pub struct LoggingConfig {
     pub color: bool,
     pub threads: bool,
+    pub target: bool,
     pub timestamp: bool,
 }
 
@@ -119,7 +120,7 @@ pub fn init_logger(advanced_config: &AdvancedConfiguration) {
         let fmt_layer = fmt::layer()
             .with_writer(std::sync::Mutex::new(logger))
             .with_ansi(advanced_config.logging.color)
-            .with_target(true)
+            .with_target(advanced_config.logging.target)
             .with_thread_names(advanced_config.logging.threads)
             .with_thread_ids(advanced_config.logging.threads);
 
@@ -150,6 +151,7 @@ pub fn init_logger(advanced_config: &AdvancedConfiguration) {
         let logging_config = LoggingConfig {
             color: advanced_config.logging.color,
             threads: advanced_config.logging.threads,
+            target: advanced_config.logging.target,
             timestamp: advanced_config.logging.timestamp,
         };
 


### PR DESCRIPTION
## Summary
- add `target` config option to control module path display in logs
- default both `threads` and `target` to `false` for clean log output
- users can re-enable in `features.toml` under `[logging]`