### PR TITLE
fix: allow lava to flow when above water block (#1618)

### DIFF
--- a/pumpkin/src/block/fluid/lava.rs
+++ b/pumpkin/src/block/fluid/lava.rs
@@ -42,6 +42,9 @@ impl FlowingLava {
         for dir in BlockDirection::all() {
             let neighbor_pos = block_pos.offset(dir.to_offset());
             if world.get_block(&neighbor_pos).await == &Block::WATER {
+                if dir == BlockDirection::Down {
+                    return true;
+                }
                 let block = if is_still {
                     Block::OBSIDIAN
                 } else {


### PR DESCRIPTION
What was changed? Allow lava to flow if water is below.
Why were these changes necessary? Lava turning to obsidian when above water, not flowing.
What is the impact of this change? Mimics vanilla mechanic
Are there any known issues or limitations? No
