### PR TITLE
fix: allow tall plants to place their upper half (#949)

### DIFF
--- a/pumpkin/src/block/blocks/plant/tall_plant.rs
+++ b/pumpkin/src/block/blocks/plant/tall_plant.rs
@@ -1,4 +1,4 @@
-use crate::block::PlacedArgs;
+use crate::block::{BrokenArgs, PlacedArgs};
 use pumpkin_data::Block;
 use pumpkin_data::BlockDirection;
 use pumpkin_data::block_properties::{
@@ -82,6 +82,38 @@ impl BlockBehaviour for TallPlantBlock {
                     BlockFlags::NOTIFY_ALL | BlockFlags::SKIP_BLOCK_ADDED_CALLBACK,
                 )
                 .await;
+        })
+    }
+
+    fn broken<'a>(&'a self, args: BrokenArgs<'a>) -> BlockFuture<'a, ()> {
+        Box::pin(async move {
+            // When one half of a tall plant is broken, break the other half too
+            let tall_plant_props =
+                TallSeagrassLikeProperties::from_state_id(args.state.id, args.block);
+            let other_block_pos = match tall_plant_props.half {
+                DoubleBlockHalf::Upper => args.position.down(),
+                DoubleBlockHalf::Lower => args.position.up(),
+            };
+            let (other_block, other_state_id) =
+                args.world.get_block_and_state_id(&other_block_pos).await;
+            if Self::ids().contains(&other_block.id) {
+                let other_props =
+                    TallSeagrassLikeProperties::from_state_id(other_state_id, other_block);
+                let opposite_half = match tall_plant_props.half {
+                    DoubleBlockHalf::Upper => DoubleBlockHalf::Lower,
+                    DoubleBlockHalf::Lower => DoubleBlockHalf::Upper,
+                };
+                if other_props.half == opposite_half {
+                    // Break the other half, using SKIP_DROPS to prevent double drops
+                    args.world
+                        .break_block(
+                            &other_block_pos,
+                            None,
+                            BlockFlags::SKIP_DROPS | BlockFlags::SKIP_BLOCK_ADDED_CALLBACK,
+                        )
+                        .await;
+                }
+            }
         })
     }
 }


### PR DESCRIPTION
What was changed? Implement "tall" variants top half placement
Why were these changes necessary? Previously did not place top half
What is the impact of this change? Allow tall plants to place their upper half 
Are there any known issues or limitations? No