### PR TITLE
fix: dying entity not ticking for movement (#1623)

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -1393,7 +1393,11 @@ impl EntityBase for LivingEntity {
 
             // Only tick movement if the entity is alive. This prevents a dead "corpse"
             // from continuing to be simulated (accumulating fall_distance/velocity).
-            if !self.dead.load(Relaxed) && self.health.load() > 0.0 {
+            // We allow movement during death animation (20 ticks) so knockback is applied.
+            let is_alive = !self.dead.load(Relaxed) && self.health.load() > 0.0;
+            let in_death_animation =
+                self.health.load() <= 0.0 && self.death_time.load(Relaxed) < 20;
+            if is_alive || (in_death_animation && self.entity.entity_type != &EntityType::PLAYER) {
                 self.tick_movement(server, caller.clone()).await;
             }
 


### PR DESCRIPTION
What was changed? Allowed an entity to continue ticking for 20
Why were these changes necessary? This allows you to see the knockback during death animation
What is the impact of this change? Allows an entity to continue ticking for 20 during death animation
Are there any known issues or limitations? No
