### PR TITLE
feat(event): add BlockRedstoneEvent for pressure plates

### DIFF
--- a/pumpkin/src/plugin/api/events/block/block_redstone.rs
+++ b/pumpkin/src/plugin/api/events/block/block_redstone.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use pumpkin_data::Block;
+use pumpkin_macros::{Event, cancellable};
+use pumpkin_util::math::position::BlockPos;
+use pumpkin_world::BlockStateId;
+
+use crate::world::World;
+
+use super::BlockEvent;
+
+/// An event that occurs when a block's redstone level changes.
+#[cancellable]
+#[derive(Event, Clone)]
+pub struct BlockRedstoneEvent {
+    /// The world where the redstone level changed.
+    pub world: Arc<World>,
+
+    /// The block state id whose redstone power changed.
+    pub block_state_id: BlockStateId,
+
+    /// The position of the block.
+    pub block_pos: BlockPos,
+
+    /// The old redstone current.
+    pub old_current: i32,
+
+    /// The new redstone current.
+    pub new_current: i32,
+}
+
+impl BlockRedstoneEvent {
+    /// Creates a new `BlockRedstoneEvent`.
+    #[must_use]
+    pub const fn new(
+        world: Arc<World>,
+        block_state_id: BlockStateId,
+        block_pos: BlockPos,
+        old_current: i32,
+        new_current: i32,
+    ) -> Self {
+        Self {
+            world,
+            block_state_id,
+            block_pos,
+            old_current,
+            new_current,
+            cancelled: false,
+        }
+    }
+}
+
+impl BlockEvent for BlockRedstoneEvent {
+    fn get_block(&self) -> &Block {
+        Block::from_state_id(self.block_state_id)
+    }
+}

--- a/pumpkin/src/plugin/api/events/block/mod.rs
+++ b/pumpkin/src/plugin/api/events/block/mod.rs
@@ -2,6 +2,7 @@ pub mod block_break;
 pub mod block_burn;
 pub mod block_can_build;
 pub mod block_place;
+pub mod block_redstone;
 
 use pumpkin_data::Block;
 


### PR DESCRIPTION
﻿## Title
This PR adds missing "BlockRedstoneEvent for pressure plates" to the pumpkinmc.

## Changes
- Adds `BlockRedstoneEvent` on pressure plate power transitions.
- Redstone output updates now respect event cancellation.

## Notes
- Scope is limited to this event branch.



revived from #1641
