### PR TITLE
fix: wrong blockupdate checking for torches

### DIFF
--- a/pumpkin/src/block/blocks/torches.rs
+++ b/pumpkin/src/block/blocks/torches.rs
@@ -112,8 +112,12 @@ impl BlockBehaviour for TorchBlock {
             if args.block == &Block::WALL_TORCH || args.block == &Block::SOUL_WALL_TORCH {
                 let props = WallTorchProps::from_state_id(args.state_id, args.block);
                 if props.facing.to_block_direction().opposite() == args.direction
-                    && !can_place_at(args.world, args.position, props.facing.to_block_direction())
-                        .await
+                    && !can_place_at(
+                        args.world,
+                        args.position,
+                        props.facing.to_block_direction().opposite(),
+                    )
+                    .await
                 {
                     return 0;
                 }


### PR DESCRIPTION
## Description
Fixed a typo in torch BlockBehaviour. 
(change 
props.facing.to_block_direction()
props.facing.to_block_direction().opposite())
Fixes this bug:
https://github.com/user-attachments/assets/cde1053b-39fc-4127-aa28-3c0f63f74024

