### PR TITLE
fix(lighting): check y in LightPropagator.propagate

### DIFF
--- a/pumpkin-world/src/chunk_system/generation.rs
+++ b/pumpkin-world/src/chunk_system/generation.rs
@@ -70,3 +70,46 @@ pub fn generate_single_chunk(
     let mid = ((cache.size * cache.size) >> 1) as usize;
     cache.chunks.swap_remove(mid)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::biome::hash_seed;
+    use crate::chunk_system::{StagedChunkEnum, generate_single_chunk};
+    use crate::generation::get_world_gen;
+    use crate::world::BlockRegistryExt;
+    use pumpkin_data::dimension::Dimension;
+    use pumpkin_util::world_seed::Seed;
+    use std::sync::Arc;
+
+    struct BlockRegistry;
+    impl BlockRegistryExt for BlockRegistry {
+        fn can_place_at(
+            &self,
+            _block: &pumpkin_data::Block,
+            _state: &pumpkin_data::BlockState,
+            _block_accessor: &dyn crate::world::BlockAccessor,
+            _block_pos: &pumpkin_util::math::position::BlockPos,
+        ) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn generate_chunk_should_return() {
+        let dimension = Dimension::OVERWORLD;
+        let seed = Seed(42);
+        let block_registry = Arc::new(BlockRegistry);
+        let world_gen = get_world_gen(seed, dimension);
+        let biome_mixer_seed = hash_seed(world_gen.random_config.seed);
+
+        let _ = generate_single_chunk(
+            &dimension,
+            biome_mixer_seed,
+            &world_gen,
+            block_registry.as_ref(),
+            0,
+            0,
+            StagedChunkEnum::Full,
+        );
+    }
+}

--- a/pumpkin-world/src/lighting/engine.rs
+++ b/pumpkin-world/src/lighting/engine.rs
@@ -145,10 +145,16 @@ impl<P: LightProvider> LightPropagator<P> {
                     continue;
                 }
 
+                // Skip neighbor if it's outside world bounds
+                let min_y = cache.bottom_y() as i32;
+                let max_y = min_y + cache.height() as i32;
+                if neighbor_pos.0.y < min_y || neighbor_pos.0.y >= max_y {
+                    continue;
+                }
+
                 let (cx, _rel) = neighbor_pos.chunk_and_chunk_relative_position();
                 let rel_x = cx.x - cache_x;
                 let rel_z = cx.y - cache_z;
-
                 if rel_x < 0 || rel_x >= cache_size || rel_z < 0 || rel_z >= cache_size {
                     continue;
                 }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

`LightPropagator.propagate` used to not check block y in BFS, which caused endless loop. This PR fixes this.

## Testing

Try to reproduce issue #1789.

close #1789 