### PR TITLE
fix: reset terminal to initial state after stop command

### DIFF
--- a/pumpkin/src/lib.rs
+++ b/pumpkin/src/lib.rs
@@ -20,6 +20,7 @@ use std::io::{Cursor, ErrorKind, IsTerminal, stdin};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::thread::JoinHandle;
 use std::time::Duration;
 use std::{net::SocketAddr, sync::LazyLock};
 use tokio::net::{TcpListener, UdpSocket};
@@ -185,6 +186,7 @@ pub struct PumpkinServer {
     pub server: Arc<Server>,
     pub tcp_listener: Option<TcpListener>,
     pub udp_socket: Option<Arc<UdpSocket>>,
+    pub console_handle: Option<JoinHandle<()>>,
 }
 
 impl PumpkinServer {
@@ -201,11 +203,12 @@ impl PumpkinServer {
 
         let rcon = server.advanced_config.networking.rcon.clone();
 
+        let mut console_handle = None;
         if server.advanced_config.commands.use_console
             && let Some((wrapper, _, _)) = LOGGER_IMPL.wait()
         {
             if let Some(rl) = wrapper.take_readline() {
-                setup_console(rl, server.clone());
+                console_handle = Some(setup_console(rl, server.clone()));
             } else {
                 if server.advanced_config.commands.use_tty {
                     warn!(
@@ -302,6 +305,7 @@ impl PumpkinServer {
             server,
             tcp_listener,
             udp_socket,
+            console_handle,
         }
     }
 
@@ -549,7 +553,10 @@ fn setup_stdin_console(server: Arc<Server>) {
     });
 }
 
-fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: Arc<Server>) {
+fn setup_console(
+    mut rl: Editor<PumpkinCommandCompleter, FileHistory>,
+    server: Arc<Server>,
+) -> JoinHandle<()> {
     let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 
     if let Some(helper) = rl.helper_mut() {
@@ -559,13 +566,14 @@ fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: A
         let _ = helper.rt.set(tokio::runtime::Handle::current());
     }
 
-    std::thread::spawn(move || {
+    let handle = std::thread::spawn(move || {
         while !SHOULD_STOP.load(Ordering::Relaxed) {
             let readline = rl.readline("$ ");
             match readline {
                 Ok(line) => {
                     let _ = rl.add_history_entry(line.clone());
-                    if tx.blocking_send(line).is_err() {
+                    let is_stop = &line == "stop";
+                    if tx.blocking_send(line).is_err() || is_stop {
                         break;
                     }
                 }
@@ -617,6 +625,8 @@ fn setup_console(mut rl: Editor<PumpkinCommandCompleter, FileHistory>, server: A
         }
         debug!("Stopped console commands task");
     });
+
+    handle
 }
 
 fn scrub_address(ip: &str) -> String {

--- a/pumpkin/src/main.rs
+++ b/pumpkin/src/main.rs
@@ -156,6 +156,10 @@ async fn main() {
             .color_named(NamedColor::Red)
             .to_pretty_console()
     );
+
+    if let Some(console_handle) = pumpkin_server.console_handle {
+        console_handle.join().ok();
+    }
 }
 fn print_support_links_and_warning() {
     warn!(


### PR DESCRIPTION
## Description
This is my attempt to fix a bug where, when using rustyline, the terminal will not echo after the stop command is executed, because the console thread is not stopped before the program exits. Frankly, it's a janky solution, mainly because I can't interrupt the readline call, the solution I used was to look for the special case of the stop command and break out of the cycle, which is not so elegant, but it works. I also stored the join handle for the console thread wrapped by an Option in the Pumpkin Server instance, so the main function could join it.
## Testing
I ran it on my machine in debug mode and release mode and the fix worked.

Thank you for your attention and sorry that I couldn't do something better, it's mainly something I did for myself, but I opened this PR in case you found it useful.