### PR TITLE
feat: add register permission to wasm

### DIFF
--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -13,7 +13,7 @@ pub mod command {
 
 pub use wit::pumpkin::plugin::{
     context::{Context, Server},
-    text,
+    permission, text,
 };
 
 pub mod logging;

--- a/pumpkin-plugin-wit/v0.1.0/context.wit
+++ b/pumpkin-plugin-wit/v0.1.0/context.wit
@@ -2,10 +2,12 @@ interface context {
     use server.{server};
     use event.{event-type, event-priority};
     use command.{command};
+    use permission.{permission};
 
     resource context {
         register-event: func(handler-id: u32, event-type: event-type, event-priority: event-priority, blocking: bool);
         register-command: func(command: command, permission: string);
+        register-permission: func(permission: permission) -> result<_, string>;
         get-server: func() -> server;
     }
 }

--- a/pumpkin-plugin-wit/v0.1.0/permission.wit
+++ b/pumpkin-plugin-wit/v0.1.0/permission.wit
@@ -1,0 +1,46 @@
+interface permission {
+    /// Represents the player's permission level
+    ///
+    /// Permission levels determine the player's access to commands and server operations.
+    /// Each numeric level corresponds to a specific role:
+    /// - `Zero`: `normal`: Player can use basic commands.
+    /// - `One`: `moderator`: Player can bypass spawn protection.
+    /// - `Two`: `gamemaster`: Player or executor can use more commands and player can use command blocks.
+    /// - `Three`:  `admin`: Player or executor can use commands related to multiplayer management.
+    /// - `Four`: `owner`: Player or executor can use all of the commands, including commands related to server management.
+    enum permission-level {
+        zero,
+        one,
+        two,
+        three,
+        four,
+    }
+
+    /// Describes the default behavior for permissions
+    variant permission-default {
+        /// Permission is not granted by default
+        deny,
+        /// Permission is granted by default
+        allow,
+        /// Permission is granted by default to operators
+        op(permission-level),
+    }
+
+    /// A child permission entry
+    record permission-child {
+        node: string,
+        value: bool,
+    }
+
+    /// Defines a permission node in the system
+    record permission {
+        /// The full node name (e.g., "minecraft:command.gamemode")
+        node: string,
+        /// Description of what this permission does
+        description: string,
+        /// The default value of this permission
+        default: permission-default,
+        /// Children nodes that are affected by this permission
+        children: list<permission-child>,
+    }
+}

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
-
+use std::{collections::HashMap, sync::Arc};
 use wasmtime::component::Resource;
 
 use crate::plugin::loader::wasm::wasm_host::{
+    DowncastResourceExt,
     state::{CommandResource, ContextResource, PluginHostState},
     wit::v0_1_0::{
         events::WasmPluginV0_1_0EventHandler,
@@ -12,11 +12,39 @@ use crate::plugin::loader::wasm::wasm_host::{
                 command::Command,
                 context::Context,
                 event::{EventPriority, EventType},
+                permission::{Permission, PermissionDefault, PermissionLevel},
                 server::Server,
             },
         },
     },
 };
+
+impl DowncastResourceExt<ContextResource> for Resource<Context> {
+    fn downcast_ref<'a>(&'a self, state: &'a mut PluginHostState) -> &'a ContextResource {
+        state
+            .resource_table
+            .get_any_mut(self.rep())
+            .expect("invalid context resource handle")
+            .downcast_ref()
+            .expect("resource type mismatch")
+    }
+
+    fn downcast_mut<'a>(&'a self, state: &'a mut PluginHostState) -> &'a mut ContextResource {
+        state
+            .resource_table
+            .get_any_mut(self.rep())
+            .expect("invalid context resource handle")
+            .downcast_mut()
+            .expect("resource type mismatch")
+    }
+
+    fn consume(self, state: &mut PluginHostState) -> ContextResource {
+        state
+            .resource_table
+            .delete(Resource::new_own(self.rep()))
+            .expect("invalid context resource handle")
+    }
+}
 
 impl pumpkin::plugin::context::Host for PluginHostState {}
 
@@ -115,5 +143,41 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             .provider
             .register_command(command, permission)
             .await;
+    }
+
+    async fn register_permission(
+        &mut self,
+        context: Resource<Context>,
+        permission: Permission,
+    ) -> Result<(), String> {
+        let mut children: HashMap<String, bool> = HashMap::with_capacity(permission.children.len());
+        for child in permission.children {
+            children.insert(child.node, child.value);
+        }
+
+        let permission = pumpkin_util::permission::Permission {
+            node: permission.node,
+            description: permission.description,
+            default: match permission.default {
+                PermissionDefault::Deny => pumpkin_util::permission::PermissionDefault::Deny,
+                PermissionDefault::Allow => pumpkin_util::permission::PermissionDefault::Allow,
+                PermissionDefault::Op(permission_level) => {
+                    pumpkin_util::permission::PermissionDefault::Op(match permission_level {
+                        PermissionLevel::Zero => pumpkin_util::permission::PermissionLvl::Zero,
+                        PermissionLevel::One => pumpkin_util::permission::PermissionLvl::One,
+                        PermissionLevel::Two => pumpkin_util::permission::PermissionLvl::Two,
+                        PermissionLevel::Three => pumpkin_util::permission::PermissionLvl::Three,
+                        PermissionLevel::Four => pumpkin_util::permission::PermissionLvl::Four,
+                    })
+                }
+            },
+            children,
+        };
+
+        context
+            .downcast_mut(self)
+            .provider
+            .register_permission(permission)
+            .await
     }
 }

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/mod.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/mod.rs
@@ -12,6 +12,7 @@ pub mod context;
 pub mod entity;
 pub mod events;
 pub mod logging;
+pub mod permission;
 pub mod player;
 pub mod server;
 pub mod text;

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/permission.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/permission.rs
@@ -1,0 +1,3 @@
+use crate::plugin::loader::wasm::wasm_host::{state::PluginHostState, wit::v0_1_0::pumpkin};
+
+impl pumpkin::plugin::permission::Host for PluginHostState {}


### PR DESCRIPTION
## Description

Adds the `register_permission` function to `Context`.
```rust
fn register_permission(&self, permission: &Permission) -> Result<(), String>
```

## Testing

Run on a test server to verify that it works