### PR TITLE
fix(enderman): remove server-side ambient portal particle generation

### DIFF
--- a/pumpkin/src/entity/mob/enderman.rs
+++ b/pumpkin/src/entity/mob/enderman.rs
@@ -450,30 +450,10 @@ impl Mob for EndermanEntity {
                     .await;
             }
 
-            let pos = entity.pos.load();
-            let world = entity.world.load();
-            let particles = {
-                let mut rng = self.get_random();
-                std::array::from_fn::<_, 2, _>(|_| {
-                    (
-                        Vector3::new(
-                            pos.x + rng.random_range(-0.5..0.5),
-                            pos.y + rng.random_range(0.0..2.9),
-                            pos.z + rng.random_range(-0.5..0.5),
-                        ),
-                        Vector3::new(
-                            (rng.random_range(0.0f32..1.0) - 0.5) * 2.0,
-                            -rng.random_range(0.0f32..1.0),
-                            (rng.random_range(0.0f32..1.0) - 0.5) * 2.0,
-                        ),
-                    )
-                })
-            };
-            for (particle_pos, offset) in particles {
-                world
-                    .spawn_particle(particle_pos, offset, 0.0, 1, Particle::Portal)
-                    .await;
-            }
+            // NOTE: Enderman ambient portal particles are intentionally NOT sent server-side.
+            // The vanilla Minecraft client generates these particles locally in the entity
+            // renderer. Sending them from the server would cause duplicate particles and
+            // massive network overhead (2 packets/tick/enderman = 40 packets/sec/enderman).
         })
     }
 


### PR DESCRIPTION
### Summary

Removes the server-side generation of enderman ambient portal particles from `EndermanEntity::mob_tick`. These particles are generated entirely by the vanilla client renderer and should never have been sent from the server. Sending them causes duplicate particles visible to nearby players and produces approximately 40 unnecessary packets per second per enderman.

---

### Problem

`EndermanEntity::mob_tick` was generating and broadcasting 2 portal particle packets on every tick for every living enderman:

```rust
let particles = {
    let mut rng = self.get_random();
    std::array::from_fn::<_, 2, _>(|_| {
        (
            Vector3::new(
                pos.x + rng.random_range(-0.5..0.5),
                pos.y + rng.random_range(0.0..2.9),
                pos.z + rng.random_range(-0.5..0.5),
            ),
            Vector3::new(
                (rng.random_range(0.0f32..1.0) - 0.5) * 2.0,
                -rng.random_range(0.0f32..1.0),
                (rng.random_range(0.0f32..1.0) - 0.5) * 2.0,
            ),
        )
    })
};
for (particle_pos, offset) in particles {
    world
        .spawn_particle(particle_pos, offset, 0.0, 1, Particle::Portal)
        .await;
}
```

This is wrong for two reasons:

**1. Vanilla never sends these from the server.**
In vanilla Minecraft, enderman ambient portal particles are generated entirely client-side inside the entity renderer (`EndermanRenderer` / `EndermanModel`). The server has no involvement. Pumpkin was generating them server-side in addition to the client already rendering them, resulting in every nearby player seeing **double the particles**.

**2. The packet cost is significant.**
At 20 ticks/second, 2 packets/tick = **40 packets/second per enderman**. With 10 endermen loaded that is 400 extra packets/second. With `broadcast_packet_all` (the state before PR 4/6), each of those 40 packets was sent to *every player on the server*, making the true cost `40 × player_count` packets/second per enderman. This is entirely wasted bandwidth with a net negative gameplay effect.

---

### Solution

Delete the particle generation block entirely and replace it with an explanatory comment:

```rust
// NOTE: Enderman ambient portal particles are intentionally NOT sent server-side.
// The vanilla Minecraft client generates these particles locally in the entity
// renderer. Sending them from the server would cause duplicate particles and
// massive network overhead (2 packets/tick/enderman = 40 packets/sec/enderman).
```

### Particle Packet Optimization Comparison

| Status | Preview | Description |
| :--- | :--- | :--- |
| **After** | <img width="2239" height="1263" alt="afbeelding" src="https://github.com/user-attachments/assets/06497341-944c-4279-8826-34b8d7bf3af3" width="400" /> | **Optimized:** Particles are still visible, but the packet spam has been eliminated. |
| **Before** | <img src="https://github.com/user-attachments/assets/29816a22-8a0e-4adc-a179-f5b37d856d3b" width="400" /> | **Issue:** Excessive particle packets being sent, causing unnecessary network load. |

---

### Changes

| File | What changed |
|---|---|
| `pumpkin/src/entity/mob/enderman.rs` | Removed portal particle generation loop from `mob_tick`, added explanatory comment |

---

### Verification

1. Spawn an enderman in a test world
2. Confirm portal particles still appear around it (client-generated)
3. Confirm particles are no longer doubled compared to vanilla
4. Confirm packet rate drops by ~40 packets/second per enderman using a packet counter or profiler

---

### Notes

- The `pos` and `world` variables that were only used for particle generation are also removed, cleaning up two unused bindings in that branch of `mob_tick`
- If server-side particle control for endermen is ever needed in the future (e.g. for a custom game mode), it should be gated behind a config flag and explicitly documented as non-vanilla behaviour