### PR TITLE
fix: sync item entity position while moving to prevent client desync

### DIFF
--- a/pumpkin/src/entity/item.rs
+++ b/pumpkin/src/entity/item.rs
@@ -346,8 +346,15 @@ impl ItemEntity {
             || entity.touching_lava.load(Ordering::SeqCst)
             || entity.velocity.load().sub(&original_velo).length_squared() > 0.1;
 
-        if velocity_dirty {
+        // Always sync position while the item is moving to prevent client-server desync.
+        // Without this, items appear to float at their spawn point on the client while the
+        // server has them on the ground, making pickup impossible.
+        let moved = entity.pos.load().sub(&entity.last_pos.load()).length_squared() > 1.0e-8;
+
+        if velocity_dirty || moved {
             entity.send_pos_rot().await;
+        }
+        if velocity_dirty {
             entity.send_velocity().await;
         }
     }


### PR DESCRIPTION
## Summary
- Item entities only synced position to clients when `velocity_dirty` was set or velocity changed by more than 0.1 (squared). Normal gravity (0.04/tick) never exceeds this threshold, so clients never receive position updates as items fall after being dropped from broken blocks.
- This causes items to appear floating at their spawn point on the client while the server has them on the ground, making pickup impossible since the server-side collision check doesn't match the client-visible position.
- Fix: also sync position whenever the item has actually moved (`pos != last_pos`), independent of the velocity threshold.

## Details
The root cause is in `sync_motion_if_dirty` in `pumpkin/src/entity/item.rs`. The condition for sending position updates required either `velocity_dirty` to be set (only happens on knockback/`set_velocity`) or a velocity change exceeding 0.1 squared. For gravity-dropped items, the per-tick velocity change (~0.04) squared is only ~0.0016, far below the threshold. After the initial spawn packet, the client never receives position updates as the item falls.

This is the same underlying issue as #963 — client-server position desync for item entities.

## Test plan
- [ ] Break a block in survival mode and verify the dropped item visually falls to the ground
- [ ] Walk over the dropped item and verify it can be picked up
- [ ] Test with blocks broken at height (e.g. tree leaves) to confirm items fall correctly on the client
- [ ] Verify items in water/lava still behave correctly