### PR TITLE
Replace {{server.allocations.default.port}} with {{server.build.default.port}} for pterodactyl Egg. Fix

### DIFF
--- a/egg-pumpkin.json
+++ b/egg-pumpkin.json
@@ -15,7 +15,7 @@
     "file_denylist": [],
     "startup": ".\/pumpkin",
     "config": {
-        "files": "{\r\n    \"config\/configuration.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"java_edition_address\": \"java_edition_address = '0.0.0.0:{{server.allocations.default.port}}'\"\r\n        }\r\n    },\r\n    \"config\/features.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"address\": \"address = '0.0.0.0:{{server.allocations.default.port}}'\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"config\/configuration.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"java_edition_address\": \"java_edition_address = '0.0.0.0:{{server.build.default.port}}'\"\r\n        }\r\n    },\r\n    \"config\/features.toml\": {\r\n        \"parser\": \"file\",\r\n        \"find\": {\r\n            \"address\": \"address = '0.0.0.0:{{server.build.default.port}}'\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server is now running.\"\r\n}",
         "logs": "{}",
         "stop": "stop"


### PR DESCRIPTION

---Description---
the placeholder for determining the port has been replaced with a more stable one.

{{server.build.default.port}} works more stable than {{server.allocations.default.port}}

In the previous version, an error occurred { message: "invalid socket address syntax", input: None, keys: ["java_edition_address"]
---Testing---
tested on my own server.
