### PR TITLE
feat(wasm-api): port block grow event

### DIFF
--- a/pumpkin-plugin-wit/v0.1.0/event.wit
+++ b/pumpkin-plugin-wit/v0.1.0/event.wit
@@ -156,6 +156,16 @@ interface event {
         cancelled: bool
     }
 
+    record block-grow-event-data {
+        target-world: %world,
+        old-block: string,
+        old-state-id: u16,
+        new-block: string,
+        new-state-id: u16,
+        block-position: block-position,
+        cancelled: bool
+    }
+
     record block-place-event-data {
         player: player,
         block-placed: string,
@@ -205,6 +215,7 @@ interface event {
         block-break-event,
         block-burn-event,
         block-can-build-event,
+        block-grow-event,
         block-place-event,
         server-command-event,
         spawn-change-event,
@@ -231,6 +242,7 @@ interface event {
         block-break-event(block-break-event-data),
         block-burn-event(block-burn-event-data),
         block-can-build-event(block-can-build-event-data),
+        block-grow-event(block-grow-event-data),
         block-place-event(block-place-event-data),
         server-command-event(server-command-event-data),
         spawn-change-event(spawn-change-event-data),

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
@@ -147,8 +147,8 @@ async fn register_block_event(
 ) {
     use crate::plugin::block::{
         block_break::BlockBreakEvent, block_burn::BlockBurnEvent,
-        block_can_build::BlockCanBuildEvent, block_place::BlockPlaceEvent,
-        block_redstone::BlockRedstoneEvent,
+        block_can_build::BlockCanBuildEvent, block_grow::BlockGrowEvent,
+        block_place::BlockPlaceEvent, block_redstone::BlockRedstoneEvent,
     };
 
     match event_type {
@@ -163,6 +163,9 @@ async fn register_block_event(
         }
         EventType::BlockCanBuildEvent => {
             register_typed_event::<BlockCanBuildEvent>(resource, handler, priority, blocking).await;
+        }
+        EventType::BlockGrowEvent => {
+            register_typed_event::<BlockGrowEvent>(resource, handler, priority, blocking).await;
         }
         EventType::BlockPlaceEvent => {
             register_typed_event::<BlockPlaceEvent>(resource, handler, priority, blocking).await;
@@ -260,6 +263,7 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             | EventType::BlockBreakEvent
             | EventType::BlockBurnEvent
             | EventType::BlockCanBuildEvent
+            | EventType::BlockGrowEvent
             | EventType::BlockPlaceEvent) => {
                 register_block_event(resource, &handler, priority, blocking, event_type).await;
             }

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/block.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/block.rs
@@ -1,8 +1,8 @@
 use crate::plugin::{
     block::{
         block_break::BlockBreakEvent, block_burn::BlockBurnEvent,
-        block_can_build::BlockCanBuildEvent, block_place::BlockPlaceEvent,
-        block_redstone::BlockRedstoneEvent,
+        block_can_build::BlockCanBuildEvent, block_grow::BlockGrowEvent,
+        block_place::BlockPlaceEvent, block_redstone::BlockRedstoneEvent,
     },
     loader::wasm::wasm_host::{
         state::PluginHostState,
@@ -13,7 +13,7 @@ use crate::plugin::{
             },
             pumpkin::plugin::event::{
                 BlockBreakEventData, BlockBurnEventData, BlockCanBuildEventData,
-                BlockPlaceEventData, BlockRedstoneEventData, Event,
+                BlockGrowEventData, BlockPlaceEventData, BlockRedstoneEventData, Event,
             },
         },
     },
@@ -126,6 +126,39 @@ impl ToFromV0_1_0WasmEvent for BlockCanBuildEvent {
                 buildable: data.buildable,
                 player: consume_player(state, &data.player),
                 block: from_wasm_block_name(&data.block),
+                cancelled: data.cancelled,
+            },
+            _ => panic!("unexpected event type"),
+        }
+    }
+}
+
+impl ToFromV0_1_0WasmEvent for BlockGrowEvent {
+    fn to_v0_1_0_wasm_event(&self, state: &mut PluginHostState) -> Event {
+        let target_world = state
+            .add_world(self.world.clone())
+            .expect("failed to add world resource");
+
+        Event::BlockGrowEvent(BlockGrowEventData {
+            target_world,
+            old_block: to_wasm_block_name(self.old_block),
+            old_state_id: self.old_state_id,
+            new_block: to_wasm_block_name(self.new_block),
+            new_state_id: self.new_state_id,
+            block_position: to_wasm_block_position(self.block_pos),
+            cancelled: self.cancelled,
+        })
+    }
+
+    fn from_v0_1_0_wasm_event(event: Event, state: &mut PluginHostState) -> Self {
+        match event {
+            Event::BlockGrowEvent(data) => Self {
+                world: consume_world(state, &data.target_world),
+                old_block: from_wasm_block_name(&data.old_block),
+                old_state_id: data.old_state_id,
+                new_block: from_wasm_block_name(&data.new_block),
+                new_state_id: data.new_state_id,
+                block_pos: from_wasm_block_position(data.block_position),
                 cancelled: data.cancelled,
             },
             _ => panic!("unexpected event type"),


### PR DESCRIPTION
## Summary

Ports `BlockGrowEvent` to the WASM plugin API as a single-event PR.

## What changed

- Added `block-grow-event` to `pumpkin-plugin-wit/v0.1.0/event.wit`
- Registered `BlockGrowEvent` in the WASM host context
- Implemented Rust <-> WASM conversions for `BlockGrowEvent`

## Verification

```sh
cargo +1.94.0-x86_64-pc-windows-msvc fmt --check
cargo +1.94.0-x86_64-pc-windows-msvc clippy --all-targets --all-features
cargo +1.94.0-x86_64-pc-windows-msvc test --verbose
cargo +1.94.0-x86_64-pc-windows-msvc test --doc --verbose
```
