### PR TITLE
feat(wasm-api): port block place event

### DIFF
--- a/pumpkin-plugin-wit/v0.1.0/event.wit
+++ b/pumpkin-plugin-wit/v0.1.0/event.wit
@@ -155,6 +155,15 @@ interface event {
         block: string,
         cancelled: bool
     }
+
+    record block-place-event-data {
+        player: player,
+        block-placed: string,
+        block-placed-against: string,
+        block-position: block-position,
+        can-build: bool,
+        cancelled: bool
+    }
     record server-command-event-data {
         command: string,
         cancelled: bool
@@ -196,6 +205,7 @@ interface event {
         block-break-event,
         block-burn-event,
         block-can-build-event,
+        block-place-event,
         server-command-event,
         spawn-change-event,
         server-broadcast-event,
@@ -221,6 +231,7 @@ interface event {
         block-break-event(block-break-event-data),
         block-burn-event(block-burn-event-data),
         block-can-build-event(block-can-build-event-data),
+        block-place-event(block-place-event-data),
         server-command-event(server-command-event-data),
         spawn-change-event(spawn-change-event-data),
         server-broadcast-event(server-broadcast-event-data),

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
@@ -147,7 +147,8 @@ async fn register_block_event(
 ) {
     use crate::plugin::block::{
         block_break::BlockBreakEvent, block_burn::BlockBurnEvent,
-        block_can_build::BlockCanBuildEvent, block_redstone::BlockRedstoneEvent,
+        block_can_build::BlockCanBuildEvent, block_place::BlockPlaceEvent,
+        block_redstone::BlockRedstoneEvent,
     };
 
     match event_type {
@@ -162,6 +163,9 @@ async fn register_block_event(
         }
         EventType::BlockCanBuildEvent => {
             register_typed_event::<BlockCanBuildEvent>(resource, handler, priority, blocking).await;
+        }
+        EventType::BlockPlaceEvent => {
+            register_typed_event::<BlockPlaceEvent>(resource, handler, priority, blocking).await;
         }
         _ => unreachable!("non-block event should not be routed to register_block_event"),
     }
@@ -255,7 +259,8 @@ impl pumpkin::plugin::context::HostContext for PluginHostState {
             event_type @ (EventType::BlockRedstoneEvent
             | EventType::BlockBreakEvent
             | EventType::BlockBurnEvent
-            | EventType::BlockCanBuildEvent) => {
+            | EventType::BlockCanBuildEvent
+            | EventType::BlockPlaceEvent) => {
                 register_block_event(resource, &handler, priority, blocking, event_type).await;
             }
             event_type => {

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/block.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/block.rs
@@ -1,7 +1,8 @@
 use crate::plugin::{
     block::{
         block_break::BlockBreakEvent, block_burn::BlockBurnEvent,
-        block_can_build::BlockCanBuildEvent, block_redstone::BlockRedstoneEvent,
+        block_can_build::BlockCanBuildEvent, block_place::BlockPlaceEvent,
+        block_redstone::BlockRedstoneEvent,
     },
     loader::wasm::wasm_host::{
         state::PluginHostState,
@@ -12,7 +13,7 @@ use crate::plugin::{
             },
             pumpkin::plugin::event::{
                 BlockBreakEventData, BlockBurnEventData, BlockCanBuildEventData,
-                BlockRedstoneEventData, Event,
+                BlockPlaceEventData, BlockRedstoneEventData, Event,
             },
         },
     },
@@ -125,6 +126,37 @@ impl ToFromV0_1_0WasmEvent for BlockCanBuildEvent {
                 buildable: data.buildable,
                 player: consume_player(state, &data.player),
                 block: from_wasm_block_name(&data.block),
+                cancelled: data.cancelled,
+            },
+            _ => panic!("unexpected event type"),
+        }
+    }
+}
+
+impl ToFromV0_1_0WasmEvent for BlockPlaceEvent {
+    fn to_v0_1_0_wasm_event(&self, state: &mut PluginHostState) -> Event {
+        let player = state
+            .add_player(self.player.clone())
+            .expect("failed to add player resource");
+
+        Event::BlockPlaceEvent(BlockPlaceEventData {
+            player,
+            block_placed: to_wasm_block_name(self.block_placed),
+            block_placed_against: to_wasm_block_name(self.block_placed_against),
+            block_position: to_wasm_block_position(self.block_position),
+            can_build: self.can_build,
+            cancelled: self.cancelled,
+        })
+    }
+
+    fn from_v0_1_0_wasm_event(event: Event, state: &mut PluginHostState) -> Self {
+        match event {
+            Event::BlockPlaceEvent(data) => Self {
+                player: consume_player(state, &data.player),
+                block_placed: from_wasm_block_name(&data.block_placed),
+                block_placed_against: from_wasm_block_name(&data.block_placed_against),
+                block_position: from_wasm_block_position(data.block_position),
+                can_build: data.can_build,
                 cancelled: data.cancelled,
             },
             _ => panic!("unexpected event type"),


### PR DESCRIPTION
## Summary

This PR ports `BlockPlaceEvent` to the WASM plugin API as a single-event batch.

## What changed

- added `block-place-event` to `pumpkin-plugin-wit/v0.1.0/event.wit`
- registered `BlockPlaceEvent` in the WASM host context
- implemented Rust <-> WASM conversions for `BlockPlaceEvent`

## Verification

```sh
cargo +1.94.0-x86_64-pc-windows-msvc fmt --check
cargo +1.94.0-x86_64-pc-windows-msvc clippy --all-targets --all-features
cargo +1.94.0-x86_64-pc-windows-msvc test --verbose
cargo +1.94.0-x86_64-pc-windows-msvc test --doc --verbose
```