### PR TITLE
feat(wasm-api): port player egg throw event

### DIFF
--- a/pumpkin-plugin-api/src/events/player/egg_throw.rs
+++ b/pumpkin-plugin-api/src/events/player/egg_throw.rs
@@ -1,0 +1,25 @@
+use crate::wit::pumpkin::plugin::event::{Event, EventType, PlayerEggThrowEventData};
+
+use super::super::FromIntoEvent;
+
+/// An event that occurs when a thrown egg resolves.
+///
+/// The associated [`PlayerEggThrowEventData`] contains the player, the egg entity UUID,
+/// whether the egg hatched, how many entities hatched, and the entity type to hatch.
+/// This event is cancellable.
+pub struct PlayerEggThrowEvent;
+impl FromIntoEvent for PlayerEggThrowEvent {
+    const EVENT_TYPE: EventType = EventType::PlayerEggThrowEvent;
+    type Data = PlayerEggThrowEventData;
+
+    fn data_from_event(event: Event) -> Self::Data {
+        match event {
+            Event::PlayerEggThrowEvent(data) => data,
+            _ => panic!("unexpected event"),
+        }
+    }
+
+    fn data_into_event(data: Self::Data) -> Event {
+        Event::PlayerEggThrowEvent(data)
+    }
+}

--- a/pumpkin-plugin-api/src/events/player/mod.rs
+++ b/pumpkin-plugin-api/src/events/player/mod.rs
@@ -1,4 +1,5 @@
 pub mod changed_main_hand;
+pub mod egg_throw;
 pub mod exp_change;
 pub mod fish;
 pub mod item_held;
@@ -15,6 +16,7 @@ pub mod player_permission_check;
 pub mod player_teleport;
 
 pub use changed_main_hand::*;
+pub use egg_throw::*;
 pub use exp_change::*;
 pub use fish::*;
 pub use item_held::*;

--- a/pumpkin-plugin-wit/v0.1.0/event.wit
+++ b/pumpkin-plugin-wit/v0.1.0/event.wit
@@ -124,6 +124,15 @@ interface event {
         cancelled: bool
     }
 
+    record player-egg-throw-event-data {
+        player: player,
+        egg-uuid: string,
+        hatching: bool,
+        num-hatches: u8,
+        hatching-type: string,
+        cancelled: bool
+    }
+
     record block-redstone-event-data {
         target-world: %world,
         state-id: u16,
@@ -211,6 +220,7 @@ interface event {
         player-gamemode-change-event,
         player-custom-payload-event,
         player-fish-event,
+        player-egg-throw-event,
         block-redstone-event,
         block-break-event,
         block-burn-event,
@@ -238,6 +248,7 @@ interface event {
         player-gamemode-change-event(player-gamemode-change-event-data),
         player-custom-payload-event(player-custom-payload-event-data),
         player-fish-event(player-fish-event-data),
+        player-egg-throw-event(player-egg-throw-event-data),
         block-redstone-event(block-redstone-event-data),
         block-break-event(block-break-event-data),
         block-burn-event(block-burn-event-data),

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/context.rs
@@ -45,8 +45,8 @@ async fn register_player_event(
     event_type: EventType,
 ) {
     use crate::plugin::player::{
-        changed_main_hand::PlayerChangedMainHandEvent, exp_change::PlayerExpChangeEvent,
-        fish::PlayerFishEvent, item_held::PlayerItemHeldEvent,
+        changed_main_hand::PlayerChangedMainHandEvent, egg_throw::PlayerEggThrowEvent,
+        exp_change::PlayerExpChangeEvent, fish::PlayerFishEvent, item_held::PlayerItemHeldEvent,
         player_change_world::PlayerChangeWorldEvent, player_chat::PlayerChatEvent,
         player_command_send::PlayerCommandSendEvent,
         player_custom_payload::PlayerCustomPayloadEvent,
@@ -116,6 +116,10 @@ async fn register_player_event(
         }
         EventType::PlayerFishEvent => {
             register_typed_event::<PlayerFishEvent>(resource, handler, priority, blocking).await;
+        }
+        EventType::PlayerEggThrowEvent => {
+            register_typed_event::<PlayerEggThrowEvent>(resource, handler, priority, blocking)
+                .await;
         }
         _ => unreachable!("non-player event should not be routed to register_player_event"),
     }

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/mod.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use pumpkin_data::Block;
+use pumpkin_data::{Block, entity::EntityType};
 use pumpkin_util::{
     GameMode, Hand,
     math::{position::BlockPos, vector3::Vector3},
@@ -74,6 +74,14 @@ pub(super) fn to_wasm_block_name(block: &'static Block) -> String {
 pub(super) fn from_wasm_block_name(block_name: &str) -> &'static Block {
     Block::from_registry_key(block_name.strip_prefix("minecraft:").unwrap_or(block_name))
         .expect("invalid block name")
+}
+
+pub(super) fn to_wasm_entity_type(entity_type: &'static EntityType) -> String {
+    format!("minecraft:{}", entity_type.resource_name)
+}
+
+pub(super) fn from_wasm_entity_type(entity_type: &str) -> &'static EntityType {
+    EntityType::from_name(entity_type).expect("invalid entity type")
 }
 
 pub(super) const fn to_wasm_hand(hand: Hand) -> pumpkin::plugin::common::Hand {

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/events/player.rs
@@ -4,13 +4,13 @@ use crate::plugin::{
         wit::v0_1_0::{
             events::{
                 ToFromV0_1_0WasmEvent, consume_player, consume_text_component, consume_world,
-                from_wasm_game_mode, from_wasm_hand, from_wasm_position, to_wasm_game_mode,
-                to_wasm_hand, to_wasm_position,
+                from_wasm_entity_type, from_wasm_game_mode, from_wasm_hand, from_wasm_position,
+                to_wasm_entity_type, to_wasm_game_mode, to_wasm_hand, to_wasm_position,
             },
             pumpkin::plugin::event::{
                 Event, PlayerChangeWorldEventData, PlayerChangedMainHandEventData,
                 PlayerChatEventData, PlayerCommandSendEventData, PlayerCustomPayloadEventData,
-                PlayerExpChangeEventData, PlayerFishEventData,
+                PlayerEggThrowEventData, PlayerExpChangeEventData, PlayerFishEventData,
                 PlayerFishState as WasmPlayerFishState, PlayerGamemodeChangeEventData,
                 PlayerItemHeldEventData, PlayerJoinEventData, PlayerLeaveEventData,
                 PlayerLoginEventData, PlayerMoveEventData, PlayerPermissionCheckEventData,
@@ -20,6 +20,7 @@ use crate::plugin::{
     },
     player::{
         changed_main_hand::PlayerChangedMainHandEvent,
+        egg_throw::PlayerEggThrowEvent,
         exp_change::PlayerExpChangeEvent,
         fish::{PlayerFishEvent, PlayerFishState},
         item_held::PlayerItemHeldEvent,
@@ -485,6 +486,37 @@ impl ToFromV0_1_0WasmEvent for PlayerFishEvent {
                 state: from_wasm_fish_state(data.state),
                 hand: from_wasm_hand(data.hand),
                 exp_to_drop: data.exp_to_drop,
+                cancelled: data.cancelled,
+            },
+            _ => panic!("unexpected event type"),
+        }
+    }
+}
+
+impl ToFromV0_1_0WasmEvent for PlayerEggThrowEvent {
+    fn to_v0_1_0_wasm_event(&self, state: &mut PluginHostState) -> Event {
+        let player = state
+            .add_player(self.player.clone())
+            .expect("failed to add player resource");
+
+        Event::PlayerEggThrowEvent(PlayerEggThrowEventData {
+            player,
+            egg_uuid: self.egg_uuid.to_string(),
+            hatching: self.hatching,
+            num_hatches: self.num_hatches,
+            hatching_type: to_wasm_entity_type(self.hatching_type),
+            cancelled: self.cancelled,
+        })
+    }
+
+    fn from_v0_1_0_wasm_event(event: Event, state: &mut PluginHostState) -> Self {
+        match event {
+            Event::PlayerEggThrowEvent(data) => Self {
+                player: consume_player(state, &data.player),
+                egg_uuid: uuid::Uuid::parse_str(&data.egg_uuid).expect("invalid egg UUID"),
+                hatching: data.hatching,
+                num_hatches: data.num_hatches,
+                hatching_type: from_wasm_entity_type(&data.hatching_type),
                 cancelled: data.cancelled,
             },
             _ => panic!("unexpected event type"),


### PR DESCRIPTION
## Summary

This PR ports PlayerEggThrowEvent to the WASM plugin API.

## What changed

- added player-egg-throw-event-data to pumpkin-plugin-wit/v0.1.0/event.wit
- registered PlayerEggThrowEvent in the WASM host event context
- added Rust <-> WASM conversions for PlayerEggThrowEvent
- serialized egg_uuid and hatching_type as strings for the WIT surface

## Verification

`sh
cargo +1.94.0-x86_64-pc-windows-msvc clippy --all-targets --all-features
cargo +1.94.0-x86_64-pc-windows-msvc test --verbose
cargo +1.94.0-x86_64-pc-windows-msvc test --doc --verbose
`
