### PR TITLE
chore: add license to Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ struct_excessive_bools = "allow"
 version = "0.1.0-dev+1.21.11"
 edition = "2024"
 rust-version = "1.94"
+license = "GPL-3.0"
 
 [profile.release]
 lto = true

--- a/pumpkin-api-macros/Cargo.toml
+++ b/pumpkin-api-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-api-macros"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/pumpkin-codecs/Cargo.toml
+++ b/pumpkin-codecs/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-codecs"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 serde_json.workspace = true

--- a/pumpkin-codegen/Cargo.toml
+++ b/pumpkin-codegen/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-codegen"
 version = "0.1.0-dev+1.21.11"
 edition = "2024"
 rust-version = "1.89"
+license.workspace = true
 
 [dependencies]
 indexmap = { version = "2.7", features = ["serde"] }

--- a/pumpkin-config/Cargo.toml
+++ b/pumpkin-config/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-config"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 pumpkin-util.workspace = true

--- a/pumpkin-data/Cargo.toml
+++ b/pumpkin-data/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-data"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [features]
 default = [

--- a/pumpkin-inventory/Cargo.toml
+++ b/pumpkin-inventory/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-inventory"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 pumpkin-protocol.workspace = true

--- a/pumpkin-macros/Cargo.toml
+++ b/pumpkin-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-macros"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [lib]
 proc-macro = true

--- a/pumpkin-nbt/Cargo.toml
+++ b/pumpkin-nbt/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-nbt"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 pumpkin-codecs.workspace = true

--- a/pumpkin-plugin-api/Cargo.toml
+++ b/pumpkin-plugin-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-plugin-api"
 # This should be different from the pumpkin server version.
 version = "0.1.0"
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 wit-bindgen = { workspace = true }

--- a/pumpkin-protocol/Cargo.toml
+++ b/pumpkin-protocol/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-protocol"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [features]
 default = ["query"]

--- a/pumpkin-util/Cargo.toml
+++ b/pumpkin-util/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-util"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 pumpkin-nbt.workspace = true

--- a/pumpkin-world/Cargo.toml
+++ b/pumpkin-world/Cargo.toml
@@ -3,6 +3,7 @@ name = "pumpkin-world"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 pumpkin-nbt.workspace = true

--- a/pumpkin/Cargo.toml
+++ b/pumpkin/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "Empowering everyone to host fast and efficient Minecraft servers."
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
 
 [package.metadata.tauri-winres]
 # FileDescription is handled as the Program name by Windows!


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

I've developed a project depending on Pumpkin. When I use `cargo license` to check licenses, I found `N/A (1): pumpkin-nbt`. I hope this pr would fix it.

