### PR TITLE
fix(entity): You can now land while flying on elytra

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -337,7 +337,11 @@ impl JavaClient {
                     player.jump().await;
                 }
 
-                entity.on_ground.store(packet.collision & FLAG_ON_GROUND != 0, Ordering::Relaxed);
+                let new_on_ground = packet.collision & FLAG_ON_GROUND != 0;
+                entity.on_ground.store(new_on_ground, Ordering::Relaxed);
+                if new_on_ground && entity.fall_flying.load(Ordering::Relaxed) {
+                    entity.set_fall_flying(false).await;
+                }
                 let world = &player.world();
 
                 // TODO: Warn when player moves to quickly


### PR DESCRIPTION
# Not tested for Minecraft bedrock players 

## Description
fall_flying was set to true when elytra flight started but never reset to false when landing. Now fall_fling sets to false when landing.

## Testing
```sh
cargo fmt --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test
```
