### PR TITLE
fix(entity): use correct hurt sounds for shared dispatch families

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -128,6 +128,7 @@ impl LivingEntity {
 
     const fn hurt_sound_for_entity(entity_type: &'static EntityType) -> Sound {
         match entity_type.id {
+            id if id == EntityType::ENDERMAN.id => Sound::EntityEndermanHurt,
             id if id == EntityType::ZOMBIE.id => Sound::EntityZombieHurt,
             id if id == EntityType::DROWNED.id => Sound::EntityDrownedHurt,
             id if id == EntityType::HUSK.id => Sound::EntityHuskHurt,
@@ -2374,6 +2375,14 @@ mod tests {
         for (entity_type, expected) in cases {
             assert_eq!(LivingEntity::hurt_sound_for_entity(entity_type), expected);
         }
+    }
+
+    #[test]
+    fn hurt_sound_for_entity_uses_enderman_hurt_sound() {
+        assert_eq!(
+            LivingEntity::hurt_sound_for_entity(&EntityType::ENDERMAN),
+            Sound::EntityEndermanHurt
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- use one shared hurt-sound selector for enderman, zombie-family, and skeleton-family entities
- keep slime separate because its hurt sound depends on slime size state
- keep the scope limited to hurt sound parity plus mapping tests in pumpkin/src/entity/living.rs

## Testing
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test