### PR TITLE
Fix: Preserve lit state when adding candles to an already lit candle (#1853)

### DIFF
--- a/pumpkin/src/block/blocks/candles.rs
+++ b/pumpkin/src/block/blocks/candles.rs
@@ -61,7 +61,6 @@ impl BlockBehaviour for CandleBlock {
                 id if (Item::CANDLE.id..=Item::BLACK_CANDLE.id).contains(&id)
                     && item.id == args.block.id =>
                 {
-                    
                     let was_lit = properties.lit;
 
                     if properties.candles.to_index() < 3 {


### PR DESCRIPTION

Fix candle blocks losing their lit state when adding another candle.


## Description
When adding a candle to an already lit candle, the block was recreated without keeping the lit value, which caused the candle to go out. The fix simply stores the previous properties.lit value and restores it after increasing the candle count. This matches vanilla behavior — adding a candle no longer extinguishes it.

