### PR TITLE
fix: Skip deactivated plugins during server startup

### DIFF
--- a/pumpkin/src/plugin/mod.rs
+++ b/pumpkin/src/plugin/mod.rs
@@ -311,6 +311,14 @@ impl PluginManager {
                 continue;
             }
 
+            if path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("deactivated"))
+            {
+                continue;
+            }
+
             // Start loading plugin concurrently
             match self.start_loading_plugin(&path).await {
                 Ok(task) => load_tasks.push(task),


### PR DESCRIPTION
## Summary

  - Skip files with `.deactivated` extension in `PluginManager::load_plugins()` before attempting loader matching
  - Prevents `PluginNotFound` errors being logged for intentionally disabled plugins
  - Deactivated files are never added to the `unloaded_files` retry queue

  Fixes #1929. When plugins are disabled, the server logged errors on every restart instead of silently skipping them.

  ## Test plan

  - `cargo clippy --all-targets` passes
  - Place a `.deactivated` file in `./plugins/`, start the server, no error logged
  - Active plugins still load normally