### PR TITLE
feat(command): implement `Vec3` argument type

### DIFF
--- a/pumpkin-util/src/math/vector3.rs
+++ b/pumpkin-util/src/math/vector3.rs
@@ -90,7 +90,7 @@ impl<T: Copy> Vector3<T> {
     }
 }
 
-impl<T: Math + PartialOrd + Copy> Vector3<T> {
+impl<T> Vector3<T> {
     /// Creates a new `Vector3` with the given components.
     ///
     /// # Arguments
@@ -104,7 +104,9 @@ impl<T: Math + PartialOrd + Copy> Vector3<T> {
     pub const fn new(x: T, y: T, z: T) -> Self {
         Self { x, y, z }
     }
+}
 
+impl<T: Math + PartialOrd + Copy> Vector3<T> {
     /// Calculates the squared length (magnitude) of the vector.
     ///
     /// # Returns

--- a/pumpkin/src/command/argument_types/coordinates/mod.rs
+++ b/pumpkin/src/command/argument_types/coordinates/mod.rs
@@ -1,14 +1,17 @@
-use pumpkin_data::translation;
 use crate::command::context::command_source::CommandSource;
+use crate::command::errors::command_syntax_error::CommandSyntaxError;
+use crate::command::errors::error_types::{
+    CommandErrorType, READER_EXPECTED_DOUBLE, READER_EXPECTED_INT,
+};
+use crate::command::string_reader::StringReader;
+use pumpkin_data::translation;
 use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::{Axis, Vector3};
-use crate::command::errors::command_syntax_error::CommandSyntaxError;
-use crate::command::errors::error_types::{CommandErrorType, READER_EXPECTED_DOUBLE, READER_EXPECTED_INT};
-use crate::command::string_reader::StringReader;
 
 pub mod vec3;
 
-pub const MIXED_TYPE_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(translation::ARGUMENT_POS_MIXED);
+pub const MIXED_TYPE_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS_MIXED);
 
 /// Represents a single world coordinate.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -18,13 +21,13 @@ pub enum WorldCoordinate {
 }
 
 impl WorldCoordinate {
-
     /// Creates a new `WorldCoordinate`.
+    #[must_use]
     pub const fn new(is_relative: bool, value: f64) -> Self {
         if is_relative {
-            WorldCoordinate::Relative(value)
+            Self::Relative(value)
         } else {
-            WorldCoordinate::Absolute(value)
+            Self::Absolute(value)
         }
     }
 
@@ -61,11 +64,11 @@ impl WorldCoordinate {
         }
     }
 
-    /// Tries to parse a [`WorldCoordinate`] from a single number, expecting an `f64`.
+    /// Tries to parse a [`WorldCoordinate`] from a single number.
     ///
     /// # Arguments
     /// * `reader` - The `StringReader` to parse the coordinate from.
-    /// * `correct_center` - Whether to correct integral coordinates by adding `+0.5` to them
+    /// * `center_integers` - Whether to correct integral coordinates by adding `+0.5` to them
     ///   (as mentioned by [`Vec3ArgumentType::Default`]).
     ///
     /// # Returns
@@ -73,8 +76,11 @@ impl WorldCoordinate {
     /// - A [`CommandSyntaxError`] describing an error if it could not be correctly parsed,
     ///   wrapped in an `Err`.
     ///
-    /// [`Vec3ArgumentType::Default`]: vec3::Vec3ArgumentType::Default
-    pub fn parse_world_f64(&self, reader: &mut StringReader, correct_center: bool) -> Result<WorldCoordinate, CommandSyntaxError> {
+    /// [`Vec3ArgumentType::Default`]: Vec3ArgumentType::Default
+    pub fn parse(
+        reader: &mut StringReader,
+        center_integers: bool,
+    ) -> Result<Self, CommandSyntaxError> {
         if reader.peek() == Some('^') {
             Err(MIXED_TYPE_ERROR_TYPE.create(reader))
         } else if !reader.can_read_char() {
@@ -91,7 +97,7 @@ impl WorldCoordinate {
             if is_relative && slice.is_empty() {
                 Ok(Self::Relative(0.0))
             } else {
-                if !slice.contains('.') && !is_relative && correct_center {
+                if !slice.contains('.') && !is_relative && center_integers {
                     value += 0.5;
                 }
                 Ok(Self::new(is_relative, value))
@@ -99,7 +105,8 @@ impl WorldCoordinate {
         }
     }
 
-    /// Tries to parse a [`WorldCoordinate`] from a single number, expecting an integral position.
+    /// Tries to parse a [`WorldCoordinate`] from a single number, expecting an integral non-relative coordinate
+    /// or any relative coordinate.
     ///
     /// # Arguments
     /// * `reader` - The `StringReader` to parse the coordinate from.
@@ -108,9 +115,7 @@ impl WorldCoordinate {
     /// - The `WorldCoordinate` if it was correctly parsed, wrapped in an `Ok`.
     /// - A [`CommandSyntaxError`] describing an error if it could not be correctly parsed,
     ///   wrapped in an `Err`.
-    ///
-    /// [`Vec3ArgumentType::Default`]: vec3::Vec3ArgumentType::Default
-    pub fn parse_world_i32(&self, reader: &mut StringReader) -> Result<WorldCoordinate, CommandSyntaxError> {
+    pub fn parse_integer(reader: &mut StringReader) -> Result<Self, CommandSyntaxError> {
         if reader.peek() == Some('^') {
             Err(MIXED_TYPE_ERROR_TYPE.create(reader))
         } else if !reader.can_read_char() {
@@ -131,7 +136,9 @@ impl WorldCoordinate {
     }
 }
 
-/// An object represents some command coordinates.
+/// An object representing some command coordinates.
+///
+/// A set of [`Coordinates`] can be *resolved* via the [`Coordinates::resolve`] method.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Coordinates {
     /// Normal coordinates (each coordinate can be *absolute* or *relative*.)
@@ -140,19 +147,33 @@ pub enum Coordinates {
     Local { left: f64, up: f64, forward: f64 },
 }
 
+macro_rules! check_for_space_char {
+    ($reader:ident, $i:ident, $value:ident) => {
+        if $reader.peek() == Some(' ') {
+            $reader.skip();
+            Ok($value)
+        } else {
+            $reader.set_cursor($i);
+            Err(vec3::INCOMPLETE_ERROR_TYPE.create($reader))
+        }
+    };
+}
+
 impl Coordinates {
-    /// Returns whether a coordinate of these [`Coordinates`] is relative.
+    /// Returns whether a coordinate (of the given [`Axis`]) of these [`Coordinates`] is relative.
+    ///
+    /// This also returns `true` for a *local coordinate*.
     #[must_use]
     pub const fn is_relative(&self, axis: Axis) -> bool {
         match self {
             Self::World(vector) => vector.get_axis(axis).is_relative(),
-            Self::Local { .. } => false,
+            Self::Local { .. } => true,
         }
     }
 
     /// Returns the physical position that these [`Coordinates`] represent.
     #[must_use]
-    pub fn position(&self, source: &CommandSource) -> Vector3<f64> {
+    pub fn resolve(&self, source: &CommandSource) -> Vector3<f64> {
         match self {
             Self::World(vector) => {
                 let pos = source.position;
@@ -165,6 +186,113 @@ impl Coordinates {
             Self::Local { left, up, forward } => {
                 convert_local_coordinates(*left, *up, *forward, source.rotation)
             }
+        }
+    }
+
+    /// Tries to parse a set of world [`Coordinates`], expecting coordinates, each either being
+    /// an integral non-relative coordinate or any relative coordinate.
+    ///
+    /// # Arguments
+    /// * `reader` - The `StringReader` to parse the coordinates from.
+    /// * `center_integers` - Whether to correct integral coordinates by adding `+0.5` to them
+    ///   (as mentioned by [`Vec3ArgumentType::Default`]).
+    ///
+    /// # Returns
+    /// - The world `Coordinates` if they were correctly parsed, wrapped in an `Ok`.
+    /// - A [`CommandSyntaxError`] describing an error if they could not be correctly parsed,
+    ///   wrapped in an `Err`.
+    ///
+    /// [`Vec3ArgumentType::Default`]: Vec3ArgumentType::Default
+    pub fn parse_world(
+        reader: &mut StringReader,
+        center_integers: bool,
+    ) -> Result<Self, CommandSyntaxError> {
+        let i = reader.cursor();
+        let coordinate_1 = Self::parse_world_single(i, reader, center_integers)?;
+        // The Y coordinate is never centered.
+        let coordinate_2 = Self::parse_world_single(i, reader, false)?;
+        let coordinate_3 = WorldCoordinate::parse(reader, center_integers)?;
+        Ok(Self::World(Vector3::new(
+            coordinate_1,
+            coordinate_2,
+            coordinate_3,
+        )))
+    }
+
+    fn parse_world_single(
+        i: usize,
+        reader: &mut StringReader,
+        center_integers: bool,
+    ) -> Result<WorldCoordinate, CommandSyntaxError> {
+        let coordinate = WorldCoordinate::parse(reader, center_integers)?;
+        check_for_space_char!(reader, i, coordinate)
+    }
+
+    /// Tries to parse a set of world [`Coordinates`].
+    ///
+    /// # Arguments
+    /// * `reader` - The `StringReader` to parse the coordinate from.
+    ///
+    /// # Returns
+    /// - The world `Coordinates` if they were correctly parsed, wrapped in an `Ok`.
+    /// - A [`CommandSyntaxError`] describing an error if they could not be correctly parsed,
+    ///   wrapped in an `Err`.
+    pub fn parse_world_integers(reader: &mut StringReader) -> Result<Self, CommandSyntaxError> {
+        let i = reader.cursor();
+        let coordinate_1 = Self::parse_world_single_integer(i, reader)?;
+        let coordinate_2 = Self::parse_world_single_integer(i, reader)?;
+        let coordinate_3 = WorldCoordinate::parse_integer(reader)?;
+        Ok(Self::World(Vector3::new(
+            coordinate_1,
+            coordinate_2,
+            coordinate_3,
+        )))
+    }
+
+    fn parse_world_single_integer(
+        i: usize,
+        reader: &mut StringReader,
+    ) -> Result<WorldCoordinate, CommandSyntaxError> {
+        let coordinate = WorldCoordinate::parse_integer(reader)?;
+        check_for_space_char!(reader, i, coordinate)
+    }
+
+    /// Tries to parse a set of local [`Coordinates`].
+    ///
+    /// # Arguments
+    /// * `reader` - The `StringReader` to parse the coordinate from.
+    ///
+    /// # Returns
+    /// - The local `Coordinates` if they were correctly parsed, wrapped in an `Ok`.
+    /// - A [`CommandSyntaxError`] describing an error if they could not be correctly parsed,
+    ///   wrapped in an `Err`.
+    pub fn parse_local(reader: &mut StringReader) -> Result<Self, CommandSyntaxError> {
+        let i = reader.cursor();
+        let left = Self::parse_local_single(i, reader)?;
+        let up = Self::parse_local_single(i, reader)?;
+        let forward = Self::parse_local_number(i, reader)?;
+        Ok(Self::Local { left, up, forward })
+    }
+
+    fn parse_local_single(i: usize, reader: &mut StringReader) -> Result<f64, CommandSyntaxError> {
+        let number = Self::parse_local_number(i, reader)?;
+        check_for_space_char!(reader, i, number)
+    }
+
+    fn parse_local_number(i: usize, reader: &mut StringReader) -> Result<f64, CommandSyntaxError> {
+        if !reader.can_read_char() {
+            Err(READER_EXPECTED_DOUBLE.create(reader))
+        } else if reader.peek() != Some('^') {
+            reader.set_cursor(i);
+            Err(MIXED_TYPE_ERROR_TYPE.create(reader))
+        } else {
+            reader.skip();
+            let number = if reader.can_read_char() && reader.peek() != Some(' ') {
+                reader.read_double()?
+            } else {
+                0.0
+            };
+            Ok(number)
         }
     }
 }
@@ -181,7 +309,7 @@ impl Coordinates {
 /// # Returns
 /// The physical position represented by the local coordinates.
 #[must_use]
-pub(super) fn convert_local_coordinates(
+fn convert_local_coordinates(
     left: f64,
     up: f64,
     forward: f64,

--- a/pumpkin/src/command/argument_types/coordinates/vec3.rs
+++ b/pumpkin/src/command/argument_types/coordinates/vec3.rs
@@ -1,11 +1,12 @@
-use pumpkin_data::translation;
 use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
 use crate::command::argument_types::coordinates::Coordinates;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::errors::error_types::CommandErrorType;
 use crate::command::string_reader::StringReader;
+use pumpkin_data::translation;
 
-pub const INCOMPLETE_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(translation::ARGUMENT_POS3D_INCOMPLETE);
+pub const INCOMPLETE_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS3D_INCOMPLETE);
 
 /// An argument type for a 3-dimensional vector.
 pub enum Vec3ArgumentType {
@@ -20,14 +21,26 @@ pub enum Vec3ArgumentType {
     ///
     Default,
     /// No center correction occurs for this `Vec3ArgumentType` variant.
-    Uncorrected
+    Uncorrected,
+}
+
+impl Vec3ArgumentType {
+    /// Returns whether this argument type centers integers.\
+    #[must_use]
+    pub const fn centers_integers(&self) -> bool {
+        matches!(self, Self::Default)
+    }
 }
 
 impl ArgumentType for Vec3ArgumentType {
     type Item = Coordinates;
 
     fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
-        todo!()
+        if reader.peek() == Some('^') {
+            Coordinates::parse_local(reader)
+        } else {
+            Coordinates::parse_world(reader, self.centers_integers())
+        }
     }
 
     fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
@@ -36,5 +49,114 @@ impl ArgumentType for Vec3ArgumentType {
 
     fn examples(&self) -> Vec<String> {
         examples!("1 1 1", "3 ~34 ~-2", "40 50 60", "^ ^4 ^3")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::command::argument_types::argument_type::ArgumentType;
+    use crate::command::argument_types::coordinates::vec3::{
+        INCOMPLETE_ERROR_TYPE, Vec3ArgumentType,
+    };
+    use crate::command::argument_types::coordinates::{
+        Coordinates, MIXED_TYPE_ERROR_TYPE, WorldCoordinate,
+    };
+    use crate::command::string_reader::StringReader;
+    use pumpkin_util::math::vector3::Vector3;
+
+    macro_rules! world_coordinate {
+        ($( ($variant:ident, $value:expr) ),+) => {
+            Coordinates::World(Vector3::new(
+                $( WorldCoordinate::$variant($value), )+
+            ))
+        };
+    }
+
+    #[test]
+    fn parse_test() {
+        let mut reader = StringReader::new("0 0 0");
+
+        // The default type centers both the X and Z coordinates.
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Default,
+            world_coordinate!((Absolute, 0.5), (Absolute, 0.0), (Absolute, 0.5))
+        );
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Uncorrected,
+            world_coordinate!((Absolute, 0.0), (Absolute, 0.0), (Absolute, 0.0))
+        );
+
+        let mut reader = StringReader::new("~ ~4 8");
+
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Default,
+            world_coordinate!(
+                (Relative, 0.0),
+                (Relative, 4.0),
+                // Only the Z coordinate is centered.
+                (Absolute, 8.5)
+            )
+        );
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Uncorrected,
+            world_coordinate!((Relative, 0.0), (Relative, 4.0), (Absolute, 8.0))
+        );
+
+        let mut reader = StringReader::new("~-1 ~-2.5 ~-3");
+
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Default,
+            world_coordinate!((Relative, -1.0), (Relative, -2.5), (Relative, -3.0))
+        );
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Uncorrected,
+            world_coordinate!((Relative, -1.0), (Relative, -2.5), (Relative, -3.0))
+        );
+
+        let mut reader = StringReader::new("-3 4 5");
+
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Default,
+            world_coordinate!((Absolute, -2.5), (Absolute, 4.0), (Absolute, 5.5))
+        );
+
+        let mut reader = StringReader::new("1000 2000");
+
+        assert_parse_err_reset!(reader, Vec3ArgumentType::Default, &INCOMPLETE_ERROR_TYPE);
+    }
+
+    #[test]
+    fn parse_local_coordinates() {
+        let mut reader = StringReader::new("^1 ^10 ^30");
+
+        assert_parse_ok_reset!(
+            reader,
+            Vec3ArgumentType::Default,
+            Coordinates::Local {
+                left: 1.0,
+                up: 10.0,
+                forward: 30.0
+            }
+        );
+
+        // We can't mix world & local coordinates.
+        let mut reader = StringReader::new("^1 ^10 ~20");
+
+        assert_parse_err_reset!(reader, Vec3ArgumentType::Default, &MIXED_TYPE_ERROR_TYPE);
+
+        let mut reader = StringReader::new("^-3 ^-7 10");
+
+        assert_parse_err_reset!(reader, Vec3ArgumentType::Default, &MIXED_TYPE_ERROR_TYPE);
+
+        let mut reader = StringReader::new("^1 ^2");
+
+        assert_parse_err_reset!(reader, Vec3ArgumentType::Default, &INCOMPLETE_ERROR_TYPE);
     }
 }

--- a/pumpkin/src/command/argument_types/mod.rs
+++ b/pumpkin/src/command/argument_types/mod.rs
@@ -42,5 +42,5 @@ macro_rules! assert_parse_err_reset {
 }
 
 pub mod argument_type;
-mod coordinates;
+pub mod coordinates;
 pub mod core;


### PR DESCRIPTION
## Description

Adds the `Vec3` argument type, which specifies a 3-dimensional vector. It also adds `Coordinates`, both *world* and *local* ones. 

- *world*: Accepts fixed (no prefix) and relative coordinates (starting with `~`)
- *local*: Accepts local coordinates (starting with `^`)

The implemented methods will be useful for other coordinate-like argument types.

## Testing

Added tests for the `Vec3` argument type, which all pass.