### PR TITLE
Fix #1818

### DIFF
--- a/pumpkin-world/src/generation/feature/features/tree/trunk/fancy.rs
+++ b/pumpkin-world/src/generation/feature/features/tree/trunk/fancy.rs
@@ -37,7 +37,7 @@ impl FancyTrunkPlacer {
         let mut list: Vec<BranchPosition> = Vec::new();
         let mut logs = Vec::new();
 
-        list.push(BranchPosition::new(start_pos, m));
+        list.push(BranchPosition::new(start_pos.up_height(k), m));
 
         for n in (0..=(j - 5)).rev() {
             let f = Self::should_generate_branch(j, n);


### PR DESCRIPTION
## Description
Fixes issue #1818 
The old code atached the first node but  the first branch node used the trunk base position instead of using k.
Based upon straight.rs
```rust
 vec![TreeNode {
                center: start_pos.up_height(height as i32),
                foliage_radius: 0,
                giant_trunk: false,
            }],
```
Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5964238e-2ebc-47c0-9eb7-807188fbb1a5" />

After
<img width="2560" height="1440" alt="2026-03-31_20 28 57" src="https://github.com/user-attachments/assets/991f0615-6f6a-4558-8492-d8c4267b38b0" />


