### PR TITLE
fix chunk issues

### DIFF
--- a/pumpkin-world/src/chunk_system/chunk_state.rs
+++ b/pumpkin-world/src/chunk_system/chunk_state.rs
@@ -106,9 +106,14 @@ impl StagedChunkEnum {
 
     /// Total number of state values (0 = None … 9 = Full).
     pub const COUNT: usize = Self::Full as usize + 1;
-    pub const FULL_DEPENDENCIES: &'static [Self] =
-        &[Self::Full, Self::Lighting, Self::Features, Self::Surface];
-    pub const FULL_RADIUS: i32 = 3;
+    pub const FULL_DEPENDENCIES: &'static [Self] = &[
+        Self::Full,
+        Self::Lighting,
+        Self::Features,
+        Self::Surface,
+        Self::Noise,
+    ];
+    pub const FULL_RADIUS: i32 = 4;
     #[must_use]
     pub const fn get_direct_radius(self) -> i32 {
         // self exclude
@@ -118,7 +123,7 @@ impl StagedChunkEnum {
             Self::StructureReferences => 0,
             Self::Biomes => 0,
             Self::Noise => 0,
-            Self::Surface => 0,
+            Self::Surface => 1,
             Self::Features => 1,
             Self::Lighting => 1,
             Self::Full => 1,
@@ -134,7 +139,7 @@ impl StagedChunkEnum {
             Self::StructureReferences => 0,
             Self::Biomes => 0,
             Self::Noise => 0,
-            Self::Surface => 0,
+            Self::Surface => 1,
             Self::Features => 1,
             Self::Lighting => 1,
             Self::Full => 0,
@@ -160,7 +165,7 @@ impl StagedChunkEnum {
                 Self::StructureStart,
             ],
             Self::Noise => &[Self::StructureReferences],
-            Self::Surface => &[Self::Noise],
+            Self::Surface => &[Self::Noise, Self::Noise],
             Self::Features => &[Self::Surface, Self::Surface],
             Self::Lighting => &[Self::Features, Self::Features],
             Self::Full => &[Self::Lighting, Self::Lighting],

--- a/pumpkin-world/src/chunk_system/generation.rs
+++ b/pumpkin-world/src/chunk_system/generation.rs
@@ -8,6 +8,45 @@ use pumpkin_config::lighting::LightingEngineConfig;
 
 use super::{Cache, Chunk, StagedChunkEnum};
 
+fn prepare_proto_chunk_to_noise(
+    proto_chunk: &mut ProtoChunk,
+    dimension: &Dimension,
+    settings: &GenerationSettings,
+    generator: &VanillaGenerator,
+) {
+    proto_chunk.set_structure_starts(
+        &generator.random_config,
+        settings,
+        dimension,
+        &generator.base_router,
+        &generator.global_structure_cache,
+    );
+    proto_chunk.set_structure_references(
+        &generator.random_config,
+        settings,
+        dimension,
+        &generator.base_router,
+        &generator.global_structure_cache,
+    );
+    proto_chunk.step_to_biomes(*dimension, &generator.base_router);
+    proto_chunk.step_to_noise(settings, &generator.random_config, &generator.base_router);
+}
+
+fn prepare_proto_chunk_to_surface(
+    proto_chunk: &mut ProtoChunk,
+    dimension: &Dimension,
+    settings: &GenerationSettings,
+    generator: &VanillaGenerator,
+) {
+    prepare_proto_chunk_to_noise(proto_chunk, dimension, settings, generator);
+    proto_chunk.step_to_surface(
+        settings,
+        &generator.random_config,
+        &generator.terrain_cache,
+        &generator.base_router,
+    );
+}
+
 pub fn generate_single_chunk(
     dimension: &Dimension,
     biome_mixer_seed: i64,
@@ -39,6 +78,18 @@ pub fn generate_single_chunk(
         }
     }
 
+    let pre_surface_cache = radius > 0 && target_stage as u8 >= StagedChunkEnum::Surface as u8;
+    if pre_surface_cache {
+        for chunk in &mut cache.chunks {
+            prepare_proto_chunk_to_surface(
+                chunk.get_proto_chunk_mut(),
+                dimension,
+                settings,
+                generator,
+            );
+        }
+    }
+
     let stages = [
         StagedChunkEnum::StructureStart,
         StagedChunkEnum::StructureReferences,
@@ -53,6 +104,9 @@ pub fn generate_single_chunk(
     for &stage in &stages {
         if stage as u8 > target_stage as u8 {
             break;
+        }
+        if pre_surface_cache && stage as u8 <= StagedChunkEnum::Surface as u8 {
+            continue;
         }
 
         cache.advance(
@@ -74,10 +128,14 @@ pub fn generate_single_chunk(
 
 #[cfg(test)]
 mod tests {
+    use super::prepare_proto_chunk_to_noise;
+    use crate::ProtoChunk;
     use crate::biome::hash_seed;
-    use crate::chunk_system::{StagedChunkEnum, generate_single_chunk};
+    use crate::chunk_system::{Cache, Chunk, StagedChunkEnum, generate_single_chunk};
     use crate::generation::get_world_gen;
     use crate::world::BlockRegistryExt;
+    use pumpkin_config::lighting::LightingEngineConfig;
+    use pumpkin_data::chunk_gen_settings::GenerationSettings;
     use pumpkin_data::dimension::Dimension;
     use pumpkin_util::world_seed::Seed;
     use std::sync::Arc;
@@ -112,5 +170,57 @@ mod tests {
             0,
             StagedChunkEnum::Full,
         );
+    }
+
+    #[test]
+    fn surface_stage_advances_neighbor_chunks() {
+        let dimension = Dimension::OVERWORLD;
+        let seed = Seed(42);
+        let block_registry = Arc::new(BlockRegistry);
+        let world_gen = get_world_gen(seed, dimension);
+        let biome_mixer_seed = hash_seed(world_gen.random_config.seed);
+        let settings = GenerationSettings::from_dimension(&dimension);
+
+        let mut cache = Cache::new(-1, -1, 3);
+        for dx in -1..=1 {
+            for dz in -1..=1 {
+                cache.chunks.push(Chunk::Proto(Box::new(ProtoChunk::new(
+                    dx,
+                    dz,
+                    &dimension,
+                    world_gen.default_block,
+                    biome_mixer_seed,
+                ))));
+            }
+        }
+
+        for chunk in &mut cache.chunks {
+            prepare_proto_chunk_to_noise(
+                chunk.get_proto_chunk_mut(),
+                &dimension,
+                settings,
+                &world_gen,
+            );
+        }
+
+        for chunk in &cache.chunks {
+            assert_eq!(chunk.get_proto_chunk().stage, StagedChunkEnum::Noise);
+        }
+
+        cache.advance(
+            StagedChunkEnum::Surface,
+            &LightingEngineConfig::Default,
+            block_registry.as_ref(),
+            settings,
+            &world_gen.random_config,
+            &world_gen.terrain_cache,
+            &world_gen.base_router,
+            dimension,
+            &world_gen.global_structure_cache,
+        );
+
+        for chunk in &cache.chunks {
+            assert_eq!(chunk.get_proto_chunk().stage, StagedChunkEnum::Surface);
+        }
     }
 }

--- a/pumpkin-world/src/chunk_system/generation_cache.rs
+++ b/pumpkin-world/src/chunk_system/generation_cache.rs
@@ -382,12 +382,22 @@ impl Cache {
                 random_config,
                 noise_router,
             ),
-            StagedChunkEnum::Surface => self.chunks[mid].get_proto_chunk_mut().step_to_surface(
-                settings,
-                random_config,
-                terrain_cache,
-                noise_router,
-            ),
+            StagedChunkEnum::Surface => {
+                for chunk in &mut self.chunks {
+                    let Chunk::Proto(proto_chunk) = chunk else {
+                        continue;
+                    };
+
+                    if proto_chunk.stage == StagedChunkEnum::Noise {
+                        proto_chunk.step_to_surface(
+                            settings,
+                            random_config,
+                            terrain_cache,
+                            noise_router,
+                        );
+                    }
+                }
+            }
             StagedChunkEnum::Features => {
                 ProtoChunk::generate_features_and_structure(self, block_registry, random_config);
             }


### PR DESCRIPTION
## Description
Fixes an issue where chunk generation only did surface generation in 1 chunk and applied features after, causing exposed ores in the surface. This patch adds a test to make sure this isn't regressed in later patches, and rewrites pars of chunk_state.rs and generation.rs. So that it also generates surface of chunks with a radius of 1 thus being a closer match to minecraft.

DISCLAIMER, I USED OPENAI CODEX TO GENERATE THE TEST.
DISCLAIMER, I HAVE NO IDEA WHAT I'M DOING PLEASE DOUBLE CHECK.


## Testing
Comparing seed `-7057863872970073962` at cord `-1000 100 450` and looking for surface exposed ore features. Use `F3+G` to see it better.

