### PR TITLE
fix(plugin-api): get_data_folder() wrong path

### DIFF
--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -227,7 +227,9 @@ impl Context {
         let permission_manager = self.permission_manager.read().await;
 
         // If the player isn't online, we need to find their op level
-        let player_op_level = (self.server.get_player_by_uuid(*player_uuid))
+        let player_op_level = self
+            .server
+            .get_player_by_uuid(*player_uuid)
             .map_or(PermissionLvl::Zero, |player| player.permission_lvl.load());
 
         permission_manager


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description

fixes get_data_folder() returning:
./plugins/<plugin_name>
instead of:
plugins/<plugin_name>

the ./ prefix creates a file not found error upon server plugin load.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
