### PR TITLE
chore(plugin-api) expose some wit interfaces to plugin devs

### DIFF
--- a/pumpkin-plugin-api/src/lib.rs
+++ b/pumpkin-plugin-api/src/lib.rs
@@ -40,8 +40,9 @@ pub mod command {
 }
 
 pub use wit::pumpkin::plugin::{
+    command as command_wit, common,
     context::{Context, Server},
-    permission, text,
+    permission, server, text, world,
 };
 
 pub mod logging;


### PR DESCRIPTION
## Description
Previously, enums like `GameMode`, `BlockPos`, etc. weren't actually available to the plugin developer, so you were unable to do anything that required those as an argument. This worked as a fix for my friend and I so far, and we haven't noticed any immediate issues with it. 

This PR makes it so everything in `server.wit`, `command.wit`, `world.wit`, and `common.wit` are exposed to the developer. I apologize in advance if this was a dumb thing to do but it seems fine to me :sob: 

## Testing
Formatted with `cargo fmt`.
 `cargo clippy --all-targets`, and `cargo test` were both good.