### PR TITLE
fix(play): use force_tp for cancelled move events to prevent kick

### DIFF
--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -391,14 +391,7 @@ impl JavaClient {
             }
 
             'cancelled: {
-                self.enqueue_packet(&CPlayerPosition::new(
-                    player.teleport_id_count.load(Ordering::Relaxed).into(),
-                    player.living_entity.entity.pos.load(),
-                    Vector3::new(0.0, 0.0, 0.0),
-                    player.living_entity.entity.yaw.load(),
-                    player.living_entity.entity.pitch.load(),
-                    Vec::new(),
-                )).await;
+                self.force_tp(player, player.living_entity.entity.pos.load()).await;
             }
         }}
     }


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
  - When a plugin cancels a `PlayerMoveEvent`, the position-only move handler (`handle_position`) sent `CPlayerPosition` using the current `teleport_id_count` without incrementing it
  - The client then responded with a teleport confirm for that ID, but the server wasn't expecting it, causing a "Send Teleport confirm, but we did not teleport" kick
  - Fix: use `force_tp()` (which properly increments the teleport ID and sets `awaiting_teleport`) - matching how the position+rotation handler (`handle_position_rotation`) already does it, and consistent with vanilla Minecraft's `teleport()` method for rejecting movement

## Testing
  - Load a plugin that cancels `PlayerMoveEvent` for a player
  - Verify the player stays in place without being kicked
  - Verify normal movement still works when events are not cancelled