### PR TITLE
feat: add player-related functions in server wasm api

### DIFF
--- a/pumpkin-plugin-wit/v0.1.0/server.wit
+++ b/pumpkin-plugin-wit/v0.1.0/server.wit
@@ -1,4 +1,6 @@
 interface server {
+    use player.{player};
+
     enum difficulty {
         peaceful,
         easy,
@@ -18,5 +20,14 @@ interface server {
 
         /// Returns the effective Ticks Per Second (TPS)
         get-tps: func() -> f64;
+
+        /// Returns all online players from all worlds on the server.
+        get-all-players: func() -> list<player>;
+
+        /// Searches for a player by their name across all worlds.
+        get-player-by-name: func(name: string) -> option<player>;
+
+        /// Searches for a player by their UUID across all worlds.
+        get-player-by-uuid: func(id: string) -> option<player>;
     }
 }

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/server.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/server.rs
@@ -1,10 +1,14 @@
+use uuid::Uuid;
 use wasmtime::component::Resource;
 
 use crate::plugin::loader::wasm::wasm_host::{
     state::{PluginHostState, ServerResource},
     wit::v0_1_0::pumpkin::{
         self,
-        plugin::server::{Difficulty, Server},
+        plugin::{
+            player::Player,
+            server::{Difficulty, Server},
+        },
     },
 };
 
@@ -52,6 +56,61 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
         Ok(server.get_tps())
+    }
+
+    async fn get_all_players(
+        &mut self,
+        _res: Resource<Server>,
+    ) -> wasmtime::Result<Vec<Resource<Player>>> {
+        let server = self
+            .server
+            .as_ref()
+            .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
+
+        Ok(server
+            .get_all_players()
+            .into_iter()
+            .map(|player| {
+                self.add_player(player)
+                    .expect("failed to add player resource")
+            })
+            .collect())
+    }
+
+    async fn get_player_by_name(
+        &mut self,
+        _rep: Resource<Server>,
+        name: String,
+    ) -> wasmtime::Result<Option<Resource<Player>>> {
+        let server = self
+            .server
+            .as_ref()
+            .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
+
+        Ok(server
+            .get_player_by_name(&name)
+            .map(|player| self.add_player(player))
+            .transpose()?)
+    }
+
+    async fn get_player_by_uuid(
+        &mut self,
+        _rep: Resource<Server>,
+        id: String,
+    ) -> wasmtime::Result<Option<Resource<Player>>> {
+        let Ok(uuid) = Uuid::parse_str(&id) else {
+            return Ok(None);
+        };
+
+        let server = self
+            .server
+            .as_ref()
+            .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
+
+        Ok(server
+            .get_player_by_uuid(uuid)
+            .map(|player| self.add_player(player))
+            .transpose()?)
     }
 
     async fn drop(&mut self, rep: Resource<Server>) -> wasmtime::Result<()> {

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/server.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1_0/server.rs
@@ -87,10 +87,10 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
 
-        Ok(server
+        server
             .get_player_by_name(&name)
             .map(|player| self.add_player(player))
-            .transpose()?)
+            .transpose()
     }
 
     async fn get_player_by_uuid(
@@ -107,10 +107,10 @@ impl pumpkin::plugin::server::HostServer for PluginHostState {
             .as_ref()
             .ok_or_else(|| wasmtime::Error::msg("Server not available"))?;
 
-        Ok(server
+        server
             .get_player_by_uuid(uuid)
             .map(|player| self.add_player(player))
-            .transpose()?)
+            .transpose()
     }
 
     async fn drop(&mut self, rep: Resource<Server>) -> wasmtime::Result<()> {


### PR DESCRIPTION
## Description

Adds three methods to the server in the new WASM API, all related to players:
- `get_all_players`: Gets all players online in all worlds.
- `get_player_by_name`: Gets a player by their name.
- `get_player_by_uuid`: Gets a player by their UUID.

## Testing
The new methods work as expected.