### PR TITLE
feat(command): implement block pos argument type and fix local coordinate resolution

### DIFF
--- a/pumpkin/src/command/argument_types/coordinates/block_pos.rs
+++ b/pumpkin/src/command/argument_types/coordinates/block_pos.rs
@@ -1,12 +1,19 @@
+use pumpkin_data::translation;
 use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
-use crate::command::argument_types::coordinates::{
-    Coordinates, NOT_LOADED_ERROR_TYPE, OUT_OF_BOUNDS_ERROR_TYPE,
-};
 use crate::command::context::command_context::CommandContext;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::string_reader::StringReader;
 use crate::world::World;
 use pumpkin_util::math::position::BlockPos;
+use crate::command::argument_types::coordinates::Coordinates;
+use crate::command::errors::error_types::CommandErrorType;
+
+pub const NOT_LOADED_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS_UNLOADED);
+pub const OUT_OF_WORLD_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS_OUTOFWORLD);
+pub const OUT_OF_BOUNDS_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS_OUTOFBOUNDS);
 
 /// An argument type for a 3-dimensional vector representing a block position.
 ///
@@ -99,7 +106,7 @@ impl BlockPosArgumentType {
         if world.level.try_get_chunk(&pos.chunk_position()).is_none() {
             Err(NOT_LOADED_ERROR_TYPE.create_without_context())
         } else if !world.is_in_build_limit(pos) {
-            Err(OUT_OF_BOUNDS_ERROR_TYPE.create_without_context())
+            Err(OUT_OF_WORLD_ERROR_TYPE.create_without_context())
         } else {
             Ok(pos)
         }

--- a/pumpkin/src/command/argument_types/coordinates/block_pos.rs
+++ b/pumpkin/src/command/argument_types/coordinates/block_pos.rs
@@ -1,0 +1,35 @@
+use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
+use crate::command::argument_types::coordinates::Coordinates;
+use crate::command::errors::command_syntax_error::CommandSyntaxError;
+use crate::command::string_reader::StringReader;
+
+/// An argument type for a 3-dimensional vector representing a block position.
+///
+/// The returned [`Coordinates`] can be converted to a [`BlockPos`] via one of the
+/// following methods:
+/// - [`Coordinates::to_block_pos`]: Normal conversion that always succeeds.
+/// - [`Coordinates::try_to_loaded_block_pos`]: Converts the coordinates to a *loaded* `BlockPos`.
+///   This may not succeed. This is what you want to use most of the time.
+/// - [`Coordinates::try_to_loaded_block_pos_in_world`]: Converts the coordinates to a *loaded* `BlockPos`.
+///   in the provided world. This may not succeed.
+pub struct BlockPosArgumentType;
+
+impl ArgumentType for BlockPosArgumentType {
+    type Item = Coordinates;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        if reader.peek() == Some('^') {
+            Coordinates::parse_local(reader)
+        } else {
+            Coordinates::parse_world_integers(reader)
+        }
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::Vec3
+    }
+
+    fn examples(&self) -> Vec<String> {
+        examples!("1 3 5", "-3 ~24 ~-1", "80 80 80", "^ ^9 ^56")
+    }
+}

--- a/pumpkin/src/command/argument_types/coordinates/block_pos.rs
+++ b/pumpkin/src/command/argument_types/coordinates/block_pos.rs
@@ -1,12 +1,12 @@
-use pumpkin_data::translation;
 use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
+use crate::command::argument_types::coordinates::Coordinates;
 use crate::command::context::command_context::CommandContext;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
+use crate::command::errors::error_types::CommandErrorType;
 use crate::command::string_reader::StringReader;
 use crate::world::World;
+use pumpkin_data::translation;
 use pumpkin_util::math::position::BlockPos;
-use crate::command::argument_types::coordinates::Coordinates;
-use crate::command::errors::error_types::CommandErrorType;
 
 pub const NOT_LOADED_ERROR_TYPE: CommandErrorType<0> =
     CommandErrorType::new(translation::ARGUMENT_POS_UNLOADED);

--- a/pumpkin/src/command/argument_types/coordinates/block_pos.rs
+++ b/pumpkin/src/command/argument_types/coordinates/block_pos.rs
@@ -1,17 +1,24 @@
 use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
-use crate::command::argument_types::coordinates::Coordinates;
+use crate::command::argument_types::coordinates::{
+    Coordinates, NOT_LOADED_ERROR_TYPE, OUT_OF_BOUNDS_ERROR_TYPE,
+};
+use crate::command::context::command_context::CommandContext;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::string_reader::StringReader;
+use crate::world::World;
+use pumpkin_util::math::position::BlockPos;
 
 /// An argument type for a 3-dimensional vector representing a block position.
 ///
-/// The returned [`Coordinates`] can be converted to a [`BlockPos`] via one of the
-/// following methods:
-/// - [`Coordinates::to_block_pos`]: Normal conversion that always succeeds.
-/// - [`Coordinates::try_to_loaded_block_pos`]: Converts the coordinates to a *loaded* `BlockPos`.
-///   This may not succeed. This is what you want to use most of the time.
-/// - [`Coordinates::try_to_loaded_block_pos_in_world`]: Converts the coordinates to a *loaded* `BlockPos`.
-///   in the provided world. This may not succeed.
+/// The parsed [`Coordinates`] can be converted to a [`BlockPos`] via one of the
+/// following associated methods:
+/// - [`BlockPosArgumentType::get_block_pos`]: Normal conversion.
+/// - [`BlockPosArgumentType::get_loaded_block_pos`]: Converts the coordinates to a *loaded* `BlockPos`.
+///   This is what you want to use most of the time (if you need to update the loaded position somehow).
+/// - [`BlockPosArgumentType::get_loaded_block_pos_in_world`]: Converts the coordinates to a *loaded* `BlockPos`
+///   in the provided world.
+/// - [`BlockPosArgumentType::get_spawnable_pos`]: Converts the coordinates to a `BlockPos` where
+///   a player can spawn.
 pub struct BlockPosArgumentType;
 
 impl ArgumentType for BlockPosArgumentType {
@@ -31,5 +38,92 @@ impl ArgumentType for BlockPosArgumentType {
 
     fn examples(&self) -> Vec<String> {
         examples!("1 3 5", "-3 ~24 ~-1", "80 80 80", "^ ^9 ^56")
+    }
+}
+
+impl BlockPosArgumentType {
+    /// Returns a [`CommandContext`]'s parsed coordinate argument in the form of a [`BlockPos`].
+    ///
+    /// # Arguments
+    /// * `context` - The [`CommandContext`] that has the parsed `Coordinates` with the provided argument name.
+    /// * `name` - The name of the argument that was parsed.
+    ///
+    /// # Returns
+    /// The loaded `BlockPos` containing the position represented by the parsed argument, wrapped in an `Ok`,
+    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
+    pub fn get_block_pos(
+        context: &CommandContext,
+        name: &str,
+    ) -> Result<BlockPos, CommandSyntaxError> {
+        Ok(BlockPos::floored_v(
+            context
+                .get_argument::<Coordinates>(name)?
+                .resolve(context.source.as_ref()),
+        ))
+    }
+
+    /// Returns a [`CommandContext`]'s parsed coordinate argument in the form of a loaded [`BlockPos`].
+    ///
+    /// # Arguments
+    /// * `context` - The [`CommandContext`] that has the parsed `Coordinates` with the provided argument name.
+    ///   Its `CommandSource` also decides the world to check the load status in.
+    /// * `name` - The name of the argument that was parsed.
+    ///
+    /// # Returns
+    /// The loaded `BlockPos` containing the position represented by the parsed argument, wrapped in an `Ok`,
+    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
+    pub fn get_loaded_block_pos(
+        context: &CommandContext,
+        name: &str,
+    ) -> Result<BlockPos, CommandSyntaxError> {
+        Self::get_loaded_block_pos_in_world(context, name, context.source.world())
+    }
+
+    /// Returns a [`CommandContext`]'s parsed coordinate argument in the form of a loaded [`BlockPos`]
+    /// in the provided world.
+    ///
+    /// # Arguments
+    /// * `context` - The [`CommandContext`] that has the parsed `Coordinates` with the provided argument name.
+    /// * `name` - The name of the argument that was parsed.
+    /// * `world` - The world to check the load status in.
+    ///
+    /// # Returns
+    /// The loaded `BlockPos` containing the position represented by the parsed argument, wrapped in an `Ok`,
+    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
+    pub fn get_loaded_block_pos_in_world(
+        context: &CommandContext,
+        name: &str,
+        world: &World,
+    ) -> Result<BlockPos, CommandSyntaxError> {
+        let pos = Self::get_block_pos(context, name)?;
+        if world.level.try_get_chunk(&pos.chunk_position()).is_none() {
+            Err(NOT_LOADED_ERROR_TYPE.create_without_context())
+        } else if !world.is_in_build_limit(pos) {
+            Err(OUT_OF_BOUNDS_ERROR_TYPE.create_without_context())
+        } else {
+            Ok(pos)
+        }
+    }
+
+    /// Returns a [`CommandContext`]'s parsed coordinate argument in the form of a [`BlockPos`]
+    /// where players can spawn.
+    ///
+    /// # Arguments
+    /// * `context` - The [`CommandContext`] that has the parsed `Coordinates` with the provided argument name.
+    /// * `name` - The name of the argument that was parsed.
+    ///
+    /// # Returns
+    /// The loaded `BlockPos` containing the position represented by the parsed argument, wrapped in an `Ok`,
+    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
+    pub fn get_spawnable_pos(
+        context: &CommandContext,
+        name: &str,
+    ) -> Result<BlockPos, CommandSyntaxError> {
+        let pos = Self::get_block_pos(context, name)?;
+        if World::is_valid(pos) {
+            Ok(pos)
+        } else {
+            Err(OUT_OF_BOUNDS_ERROR_TYPE.create_without_context())
+        }
     }
 }

--- a/pumpkin/src/command/argument_types/coordinates/mod.rs
+++ b/pumpkin/src/command/argument_types/coordinates/mod.rs
@@ -4,14 +4,24 @@ use crate::command::errors::error_types::{
     CommandErrorType, READER_EXPECTED_DOUBLE, READER_EXPECTED_INT,
 };
 use crate::command::string_reader::StringReader;
+use crate::world::World;
 use pumpkin_data::translation;
+use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::{Axis, Vector3};
 
+pub mod block_pos;
 pub mod vec3;
 
 pub const MIXED_TYPE_ERROR_TYPE: CommandErrorType<0> =
     CommandErrorType::new(translation::ARGUMENT_POS_MIXED);
+
+pub const NOT_LOADED_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS_UNLOADED);
+pub const OUT_OF_WORLD_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS_OUTOFWORLD);
+pub const OUT_OF_BOUNDS_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_POS_OUTOFBOUNDS);
 
 /// Represents a single world coordinate.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -293,6 +303,61 @@ impl Coordinates {
                 0.0
             };
             Ok(number)
+        }
+    }
+
+    // BlockPos methods
+
+    /// Converts these [`Coordinates`] to a [`BlockPos`] containing the position represented
+    /// by the `Coordinates`.
+    ///
+    /// # Arguments
+    /// * `source` - The [`CommandSource`] used to resolve the position of these `Coordinates`.
+    ///
+    /// # Returns
+    /// The `BlockPos` containing the position represented by these `Coordinates`.
+    #[must_use]
+    pub fn to_block_pos(&self, source: &CommandSource) -> BlockPos {
+        BlockPos::floored_v(self.resolve(source))
+    }
+
+    /// Converts these [`Coordinates`] to a loaded [`BlockPos`] (in the provided source's world) if one can be found.
+    ///
+    /// # Arguments
+    /// * `source` - The [`CommandSource`] used to resolve the position of these `Coordinates`.
+    ///   It also decides the world to check the load status in.
+    ///
+    /// # Returns
+    /// The loaded `BlockPos` containing the position represented by these `Coordinates`, wrapped in an `Ok`,
+    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
+    pub fn try_to_loaded_block_pos(
+        &self,
+        source: &CommandSource,
+    ) -> Result<BlockPos, CommandSyntaxError> {
+        self.try_to_loaded_block_pos_in_world(source, source.world())
+    }
+
+    /// Converts these [`Coordinates`] to a loaded [`BlockPos`], in the provided world, if one can be found.
+    ///
+    /// # Arguments
+    /// * `source` - The [`CommandSource`] used to resolve the position of these `Coordinates`.
+    /// * `world` - The world to check the load status in.
+    ///
+    /// # Returns
+    /// The loaded `BlockPos` containing the position represented by these `Coordinates`, wrapped in an `Ok`,
+    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
+    pub fn try_to_loaded_block_pos_in_world(
+        &self,
+        source: &CommandSource,
+        world: &World,
+    ) -> Result<BlockPos, CommandSyntaxError> {
+        let pos = self.to_block_pos(source);
+        if world.level.try_get_chunk(&pos.chunk_position()).is_none() {
+            Err(NOT_LOADED_ERROR_TYPE.create_without_context())
+        } else if !world.is_in_build_limit(pos) {
+            Err(OUT_OF_BOUNDS_ERROR_TYPE.create_without_context())
+        } else {
+            Ok(pos)
         }
     }
 }

--- a/pumpkin/src/command/argument_types/coordinates/mod.rs
+++ b/pumpkin/src/command/argument_types/coordinates/mod.rs
@@ -324,13 +324,16 @@ fn convert_local_coordinates(
     forward: f64,
     rotation: Vector2<f32>,
 ) -> Vector3<f64> {
-    let y = (rotation.y + 90.0).to_radians() as f64;
+    let pitch = rotation.x;
+    let yaw = rotation.y;
+
+    let y = (yaw + 90.0).to_radians() as f64;
     let y_cos = y.cos();
     let y_sin = y.sin();
-    let x = (-rotation.x).to_radians() as f64;
+    let x = (-pitch).to_radians() as f64;
     let x_cos = x.cos();
     let x_sin = x.sin();
-    let x_up = (-rotation.x + 90.0).to_radians() as f64;
+    let x_up = (-pitch + 90.0).to_radians() as f64;
     let x_up_cos = x_up.cos();
     let x_up_sin = x_up.sin();
 

--- a/pumpkin/src/command/argument_types/coordinates/mod.rs
+++ b/pumpkin/src/command/argument_types/coordinates/mod.rs
@@ -192,7 +192,8 @@ impl Coordinates {
                 )
             }
             Self::Local { left, up, forward } => {
-                convert_local_coordinates(*left, *up, *forward, source.rotation)
+                let start = source.entity_anchor.position_at_source(source);
+                convert_local_coordinates(*left, *up, *forward, source.rotation).add(&start)
             }
         }
     }

--- a/pumpkin/src/command/argument_types/coordinates/mod.rs
+++ b/pumpkin/src/command/argument_types/coordinates/mod.rs
@@ -4,9 +4,7 @@ use crate::command::errors::error_types::{
     CommandErrorType, READER_EXPECTED_DOUBLE, READER_EXPECTED_INT,
 };
 use crate::command::string_reader::StringReader;
-use crate::world::World;
 use pumpkin_data::translation;
-use pumpkin_util::math::position::BlockPos;
 use pumpkin_util::math::vector2::Vector2;
 use pumpkin_util::math::vector3::{Axis, Vector3};
 
@@ -303,61 +301,6 @@ impl Coordinates {
                 0.0
             };
             Ok(number)
-        }
-    }
-
-    // BlockPos methods
-
-    /// Converts these [`Coordinates`] to a [`BlockPos`] containing the position represented
-    /// by the `Coordinates`.
-    ///
-    /// # Arguments
-    /// * `source` - The [`CommandSource`] used to resolve the position of these `Coordinates`.
-    ///
-    /// # Returns
-    /// The `BlockPos` containing the position represented by these `Coordinates`.
-    #[must_use]
-    pub fn to_block_pos(&self, source: &CommandSource) -> BlockPos {
-        BlockPos::floored_v(self.resolve(source))
-    }
-
-    /// Converts these [`Coordinates`] to a loaded [`BlockPos`] (in the provided source's world) if one can be found.
-    ///
-    /// # Arguments
-    /// * `source` - The [`CommandSource`] used to resolve the position of these `Coordinates`.
-    ///   It also decides the world to check the load status in.
-    ///
-    /// # Returns
-    /// The loaded `BlockPos` containing the position represented by these `Coordinates`, wrapped in an `Ok`,
-    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
-    pub fn try_to_loaded_block_pos(
-        &self,
-        source: &CommandSource,
-    ) -> Result<BlockPos, CommandSyntaxError> {
-        self.try_to_loaded_block_pos_in_world(source, source.world())
-    }
-
-    /// Converts these [`Coordinates`] to a loaded [`BlockPos`], in the provided world, if one can be found.
-    ///
-    /// # Arguments
-    /// * `source` - The [`CommandSource`] used to resolve the position of these `Coordinates`.
-    /// * `world` - The world to check the load status in.
-    ///
-    /// # Returns
-    /// The loaded `BlockPos` containing the position represented by these `Coordinates`, wrapped in an `Ok`,
-    /// or an `Err` with the appropriate [`CommandSyntaxError`] if it could not be resolved.
-    pub fn try_to_loaded_block_pos_in_world(
-        &self,
-        source: &CommandSource,
-        world: &World,
-    ) -> Result<BlockPos, CommandSyntaxError> {
-        let pos = self.to_block_pos(source);
-        if world.level.try_get_chunk(&pos.chunk_position()).is_none() {
-            Err(NOT_LOADED_ERROR_TYPE.create_without_context())
-        } else if !world.is_in_build_limit(pos) {
-            Err(OUT_OF_BOUNDS_ERROR_TYPE.create_without_context())
-        } else {
-            Ok(pos)
         }
     }
 }

--- a/pumpkin/src/command/argument_types/coordinates/mod.rs
+++ b/pumpkin/src/command/argument_types/coordinates/mod.rs
@@ -14,13 +14,6 @@ pub mod vec3;
 pub const MIXED_TYPE_ERROR_TYPE: CommandErrorType<0> =
     CommandErrorType::new(translation::ARGUMENT_POS_MIXED);
 
-pub const NOT_LOADED_ERROR_TYPE: CommandErrorType<0> =
-    CommandErrorType::new(translation::ARGUMENT_POS_UNLOADED);
-pub const OUT_OF_WORLD_ERROR_TYPE: CommandErrorType<0> =
-    CommandErrorType::new(translation::ARGUMENT_POS_OUTOFWORLD);
-pub const OUT_OF_BOUNDS_ERROR_TYPE: CommandErrorType<0> =
-    CommandErrorType::new(translation::ARGUMENT_POS_OUTOFBOUNDS);
-
 /// Represents a single world coordinate.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum WorldCoordinate {

--- a/pumpkin/src/command/context/command_source.rs
+++ b/pumpkin/src/command/context/command_source.rs
@@ -521,24 +521,28 @@ impl EntityAnchor {
 
     fn transform_position(self, position: Vector3<f64>, entity: &dyn EntityBase) -> Vector3<f64> {
         match self {
-            EntityAnchor::Feet => position,
-            EntityAnchor::Eyes => position.add(&Vector3::new(0.0, entity.get_entity().get_eye_height(), 0.0))
+            Self::Feet => position,
+            Self::Eyes => position.add(&Vector3::new(
+                0.0,
+                entity.get_entity().get_eye_height(),
+                0.0,
+            )),
         }
     }
 
     /// Gets the position of an entity with respect to this anchor.
     pub fn position_at_entity(self, entity: &Arc<dyn EntityBase>) -> Vector3<f64> {
-        self.transform_position(entity.get_entity().pos.load(), entity)
+        self.transform_position(entity.get_entity().pos.load(), entity.as_ref())
     }
 
     /// Gets the position of a source with respect to this anchor.
     #[must_use]
     pub fn position_at_source(self, command_source: &CommandSource) -> Vector3<f64> {
         let pos = command_source.position;
-        command_source.entity
-            .map_or_else(
-                || pos, |e| self.position_at_entity(&e),
-            )
+        command_source
+            .entity
+            .as_ref()
+            .map_or_else(|| pos, |e| self.position_at_entity(e))
     }
 }
 

--- a/pumpkin/src/command/context/command_source.rs
+++ b/pumpkin/src/command/context/command_source.rs
@@ -519,23 +519,26 @@ impl EntityAnchor {
         }
     }
 
+    fn transform_position(self, position: Vector3<f64>, entity: &dyn EntityBase) -> Vector3<f64> {
+        match self {
+            EntityAnchor::Feet => position,
+            EntityAnchor::Eyes => position.add(&Vector3::new(0.0, entity.get_entity().get_eye_height(), 0.0))
+        }
+    }
+
     /// Gets the position of an entity with respect to this anchor.
     pub fn position_at_entity(self, entity: &Arc<dyn EntityBase>) -> Vector3<f64> {
-        let entity = entity.get_entity();
-        let mut pos = entity.pos.load();
-        pos.y = entity.get_entity().get_eye_y();
-        pos
+        self.transform_position(entity.get_entity().pos.load(), entity)
     }
 
     /// Gets the position of a source with respect to this anchor.
     #[must_use]
     pub fn position_at_source(self, command_source: &CommandSource) -> Vector3<f64> {
-        command_source
-            .entity
-            .as_ref()
-            .map_or(command_source.position, |entity| {
-                self.position_at_entity(entity)
-            })
+        let pos = command_source.position;
+        command_source.entity
+            .map_or_else(
+                || pos, |e| self.position_at_entity(&e),
+            )
     }
 }
 


### PR DESCRIPTION
## Description
This PR implements the argument type for `BlockPos` objects, `BlockPosArgumentType`. A normal, *loaded* or *spawnable* `BlockPos` can be taken from a `CommandContext` via the static helper functions.

This PR also fixes relative handling of local coordinate resolution and makes certain parts of the calculation clearer.

## Testing

Created a testing command (locally), and local coordinates and block positions seem to work fine.
