### PR TITLE
fix(command): fix java client argument type for `BlockPos` and correct `EntityArgumentType` docs

### DIFF
--- a/pumpkin/src/command/argument_types/coordinates/block_pos.rs
+++ b/pumpkin/src/command/argument_types/coordinates/block_pos.rs
@@ -40,7 +40,7 @@ impl ArgumentType for BlockPosArgumentType {
     }
 
     fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
-        JavaClientArgumentType::Vec3
+        JavaClientArgumentType::BlockPos
     }
 
     fn examples(&self) -> Vec<String> {

--- a/pumpkin/src/command/argument_types/entity.rs
+++ b/pumpkin/src/command/argument_types/entity.rs
@@ -32,7 +32,20 @@ pub const NOT_SINGLE_PLAYER_ERROR_TYPE: CommandErrorType<0> =
 
 pub const ENTITY_SELECTOR_PERMISSION: &str = "minecraft:command.selector";
 
-/// Represents an argument type parsing an [`EntitySelector`]. This argument type is used to target entities.
+/// Represents an argument type used to select entities.
+///
+/// The following variants of this argument type are:
+/// - [`EntityArgumentType::Entity`]: for a single entity.
+/// - [`EntityArgumentType::Entities`]: for any number of entities.
+/// - [`EntityArgumentType::Player`]: for a single player.
+/// - [`EntityArgumentType::Players`]: for any number of players.
+///
+/// Though this argument type does parse an `EntitySelector`, it should not be used directly.
+/// Instead, use one of these helpers accepting a [`CommandContext`] and your argument's name:
+/// - [`EntityArgumentType::get_entity`]
+/// - [`EntityArgumentType::get_entities`]
+/// - [`EntityArgumentType::get_player`]
+/// - [`EntityArgumentType::get_players`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EntityArgumentType {
     Entity,

--- a/pumpkin/src/command/argument_types/entity.rs
+++ b/pumpkin/src/command/argument_types/entity.rs
@@ -32,8 +32,7 @@ pub const NOT_SINGLE_PLAYER_ERROR_TYPE: CommandErrorType<0> =
 
 pub const ENTITY_SELECTOR_PERMISSION: &str = "minecraft:command.selector";
 
-/// Represents an argument type parsing a [`TargetSelector`]. This argument type is used
-/// to target entities.
+/// Represents an argument type parsing an [`EntitySelector`]. This argument type is used to target entities.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EntityArgumentType {
     Entity,

--- a/pumpkin/src/command/argument_types/entity.rs
+++ b/pumpkin/src/command/argument_types/entity.rs
@@ -35,10 +35,10 @@ pub const ENTITY_SELECTOR_PERMISSION: &str = "minecraft:command.selector";
 /// Represents an argument type used to select entities.
 ///
 /// The following variants of this argument type are:
-/// - [`EntityArgumentType::Entity`]: for a single entity.
-/// - [`EntityArgumentType::Entities`]: for any number of entities.
-/// - [`EntityArgumentType::Player`]: for a single player.
-/// - [`EntityArgumentType::Players`]: for any number of players.
+/// - [`EntityArgumentType::Entity`], for a single entity.
+/// - [`EntityArgumentType::Entities`], for any number of entities.
+/// - [`EntityArgumentType::Player`], for a single player.
+/// - [`EntityArgumentType::Players`], for any number of players.
 ///
 /// Though this argument type does parse an `EntitySelector`, it should not be used directly.
 /// Instead, use one of these helpers accepting a [`CommandContext`] and your argument's name:

--- a/pumpkin/src/command/argument_types/entity.rs
+++ b/pumpkin/src/command/argument_types/entity.rs
@@ -41,7 +41,8 @@ pub const ENTITY_SELECTOR_PERMISSION: &str = "minecraft:command.selector";
 /// - [`EntityArgumentType::Players`], for any number of players.
 ///
 /// Though this argument type does parse an `EntitySelector`, it should not be used directly.
-/// Instead, use one of these helpers accepting a [`CommandContext`] and your argument's name:
+/// Instead, use one of these associated functions accepting a [`CommandContext`]
+/// and your argument's name:
 /// - [`EntityArgumentType::get_entity`]
 /// - [`EntityArgumentType::get_entities`]
 /// - [`EntityArgumentType::get_player`]


### PR DESCRIPTION
## Description
In #1194, I put the wrong `JavaClientArgumentType` for the `BlockPosArgumentType`, and in #1925, I accidentally mentioned `TargetSelector` (instead of `EntitySelector`) in the documentation of the `EntityArgumentType`.

This PR fixes both of these mistakes:
- `BlockPosArgumentType` now uses the correct `JavaClientArgumentType::BlockPos` variant.
- `EntityArgumentType` now has more correct documentation, which mentions `EntitySelector`.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
