### PR TITLE
fix: make 256-character limit apply on UTF-16 chars instead of bytes

### DIFF
--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -162,9 +162,9 @@ impl<R: Read> NetworkReadExt for R {
         // 1 Java `char` takes a maximum of 3 bytes in UTF-8:
         let maximum_utf8_bytes = bound.saturating_mul(3);
         if bytes_len > maximum_utf8_bytes {
-            return Err(ReadingError::TooLarge(
-                format!("string has too many bytes ({bytes_len} > {maximum_utf8_bytes})"),
-            ));
+            return Err(ReadingError::TooLarge(format!(
+                "string has too many bytes ({bytes_len} > {maximum_utf8_bytes})"
+            )));
         }
 
         let data = self.read_boxed_slice(bytes_len)?;
@@ -173,9 +173,9 @@ impl<R: Read> NetworkReadExt for R {
 
         // Next, if we're able to find the (bound + 1)th UTF-16 character, the string is too big.
         if string.encode_utf16().nth(bound).is_some() {
-            return Err(ReadingError::TooLarge(
-                format!("string has too many UTF-16 characters (more than the maximum limit {bound})"),
-            ));
+            return Err(ReadingError::TooLarge(format!(
+                "string has too many UTF-16 characters (more than the maximum limit {bound})"
+            )));
         }
 
         Ok(string)

--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -155,15 +155,26 @@ impl<R: Read> NetworkReadExt for R {
 
     fn get_string_bounded(&mut self, bound: usize) -> Result<String, ReadingError> {
         let bytes_len = self.get_var_uint()?.0 as usize;
+
+        // We treat `bound` as the maximum number of Java `char`s allowed.
+
+        // First, check if there are too many bytes to even fit in the UTF-16 bound.
+        // 1 Java `char` takes a maximum of 3 bytes in UTF-8:
+        let maximum_utf8_bytes = bound.saturating_mul(3);
+        if bytes_len > maximum_utf8_bytes {
+            return Err(ReadingError::TooLarge(
+                format!("string has too many bytes ({bytes_len} > {maximum_utf8_bytes})"),
+            ));
+        }
+
         let data = self.read_boxed_slice(bytes_len)?;
         let string =
             String::from_utf8(data.into()).map_err(|e| ReadingError::Message(e.to_string()))?;
 
-        // Treat `bound` as the maximum number of UTF-16 characters allowed.
-        // If we're able to find the (bound + 1)th UTF-16 character, the string is too big.
+        // Next, if we're able to find the (bound + 1)th UTF-16 character, the string is too big.
         if string.encode_utf16().nth(bound).is_some() {
             return Err(ReadingError::TooLarge(
-                "string has too many UTF-16 characters".to_string(),
+                format!("string has too many UTF-16 characters (more than the maximum limit {bound})"),
             ));
         }
 

--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -154,13 +154,23 @@ impl<R: Read> NetworkReadExt for R {
     }
 
     fn get_string_bounded(&mut self, bound: usize) -> Result<String, ReadingError> {
-        let size = self.get_var_uint()?.0 as usize;
-        if size > bound {
-            return Err(ReadingError::TooLarge("string".to_string()));
+        let bytes_len = self.get_var_uint()?.0 as usize;
+        let data = self.read_boxed_slice(bytes_len)?;
+        let string = String::from_utf8(data.into()).map_err(|e| ReadingError::Message(e.to_string()))?;
+
+        // Treat bound as the maximum number of UTF-16 characters allowed.
+
+        // 1. Check number of bytes
+        if bytes_len > bound * 2 {
+            return Err(ReadingError::TooLarge("string has too many bytes".to_string()));
         }
 
-        let data = self.read_boxed_slice(size)?;
-        String::from_utf8(data.into()).map_err(|e| ReadingError::Message(e.to_string()))
+        // 2. Count number of UTF-16 characters
+        if string.encode_utf16().count() > bound {
+            return Err(ReadingError::TooLarge("string has too many UTF-16 characters".to_string()));
+        }
+
+        Ok(string)
     }
 
     fn get_string(&mut self) -> Result<String, ReadingError> {

--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -156,18 +156,15 @@ impl<R: Read> NetworkReadExt for R {
     fn get_string_bounded(&mut self, bound: usize) -> Result<String, ReadingError> {
         let bytes_len = self.get_var_uint()?.0 as usize;
         let data = self.read_boxed_slice(bytes_len)?;
-        let string = String::from_utf8(data.into()).map_err(|e| ReadingError::Message(e.to_string()))?;
+        let string =
+            String::from_utf8(data.into()).map_err(|e| ReadingError::Message(e.to_string()))?;
 
-        // Treat bound as the maximum number of UTF-16 characters allowed.
-
-        // 1. Check number of bytes
-        if bytes_len > bound * 2 {
-            return Err(ReadingError::TooLarge("string has too many bytes".to_string()));
-        }
-
-        // 2. Count number of UTF-16 characters
-        if string.encode_utf16().count() > bound {
-            return Err(ReadingError::TooLarge("string has too many UTF-16 characters".to_string()));
+        // Treat `bound` as the maximum number of UTF-16 characters allowed.
+        // If we're able to find the (bound + 1)th UTF-16 character, the message is too big.
+        if string.encode_utf16().nth(bound).is_some() {
+            return Err(ReadingError::TooLarge(
+                "string has too many UTF-16 characters".to_string(),
+            ));
         }
 
         Ok(string)

--- a/pumpkin-protocol/src/ser/mod.rs
+++ b/pumpkin-protocol/src/ser/mod.rs
@@ -160,7 +160,7 @@ impl<R: Read> NetworkReadExt for R {
             String::from_utf8(data.into()).map_err(|e| ReadingError::Message(e.to_string()))?;
 
         // Treat `bound` as the maximum number of UTF-16 characters allowed.
-        // If we're able to find the (bound + 1)th UTF-16 character, the message is too big.
+        // If we're able to find the (bound + 1)th UTF-16 character, the string is too big.
         if string.encode_utf16().nth(bound).is_some() {
             return Err(ReadingError::TooLarge(
                 "string has too many UTF-16 characters".to_string(),

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -984,7 +984,8 @@ impl JavaClient {
         chat_message: &SChatMessage,
     ) -> Result<(), ChatError> {
         // Check for oversized messages
-        if chat_message.message.encode_utf16().count() > 256 {
+        // If we're able to find the 257th UTF-16 character, the message is too big.
+        if chat_message.message.encode_utf16().nth(256).is_some() {
             return Err(ChatError::OversizedMessage);
         }
         // Check for illegal characters

--- a/pumpkin/src/net/java/play.rs
+++ b/pumpkin/src/net/java/play.rs
@@ -984,7 +984,7 @@ impl JavaClient {
         chat_message: &SChatMessage,
     ) -> Result<(), ChatError> {
         // Check for oversized messages
-        if chat_message.message.len() > 256 {
+        if chat_message.message.encode_utf16().count() > 256 {
             return Err(ChatError::OversizedMessage);
         }
         // Check for illegal characters


### PR DESCRIPTION
## Description

Fixes #2002 

Vanilla checks if the string exceeds a length of 256 UTF-16 characters instead of bytes, so we should replicate that behavior.

## Testing

It now shows that I chatted the 65 pumpkin symbols to everyone without kicking me out of the server.