### PR TITLE
feat(command): implement game profile argument type

### DIFF
--- a/pumpkin/src/command/argument_types/entity.rs
+++ b/pumpkin/src/command/argument_types/entity.rs
@@ -32,7 +32,7 @@ pub const NOT_SINGLE_PLAYER_ERROR_TYPE: CommandErrorType<0> =
 
 pub const ENTITY_SELECTOR_PERMISSION: &str = "minecraft:command.selector";
 
-/// Represents an argument type parsing an [`EntitySelector`]. This argument type is used
+/// Represents an argument type parsing a [`TargetSelector`]. This argument type is used
 /// to target entities.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EntityArgumentType {

--- a/pumpkin/src/command/argument_types/entity.rs
+++ b/pumpkin/src/command/argument_types/entity.rs
@@ -32,7 +32,7 @@ pub const NOT_SINGLE_PLAYER_ERROR_TYPE: CommandErrorType<0> =
 
 pub const ENTITY_SELECTOR_PERMISSION: &str = "minecraft:command.selector";
 
-/// Represents an argument type parsing a [`TargetSelector`]. This argument type is used
+/// Represents an argument type parsing an [`EntitySelector`]. This argument type is used
 /// to target entities.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EntityArgumentType {

--- a/pumpkin/src/command/argument_types/game_profile.rs
+++ b/pumpkin/src/command/argument_types/game_profile.rs
@@ -1,0 +1,108 @@
+use uuid::Uuid;
+use pumpkin_data::translation;
+use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
+use crate::command::argument_types::entity::ONLY_PLAYERS_ALLOWED_ERROR_TYPE;
+use crate::command::argument_types::entity_selector::EntitySelector;
+use crate::command::argument_types::entity_selector::parser::EntitySelectorParser;
+use crate::command::context::command_source::CommandSource;
+use crate::command::errors::command_syntax_error::CommandSyntaxError;
+use crate::command::errors::error_types::CommandErrorType;
+use crate::command::string_reader::StringReader;
+use crate::net::GameProfile;
+
+pub const UNKNOWN_PLAYER_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(translation::ARGUMENT_PLAYER_UNKNOWN);
+
+/// A result from the [`GameProfileArgumentType`], which can be resolved into
+/// one or more [`GameProfile`]s, successfully or not.
+pub enum GameProfileResult {
+    Selector(EntitySelector),
+    Name(String),
+    Uuid(Uuid),
+}
+
+impl GameProfileResult {
+    /// Resolves this result with the help of a [`CommandSource`].
+    pub async fn resolve(self, source: &CommandSource) -> Result<Vec<GameProfile>, CommandSyntaxError> {
+        let players = match self {
+            Self::Selector(selector) => selector.find_players(source).await,
+            Self::Name(name) => source.server()
+                    .get_player_by_name(name.as_str())
+                    .map_or_else(
+                        || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
+                        |p| Ok(vec![p])
+                    ),
+            Self::Uuid(uuid) => source.server()
+                .get_player_by_uuid(uuid)
+                .map_or_else(
+                    || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
+                    |p| Ok(vec![p])
+                )
+        }?;
+
+        Ok(
+            players.iter()
+            .map(|p| &p.gameprofile)
+            .cloned()
+            .collect()
+        )
+    }
+}
+
+/// An argument type to parse one or more [`GameProfile`]s.
+///
+/// The intermediate object returned by this argument type can
+/// be resolved during command execution, successfully or not.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct GameProfileArgumentType;
+
+impl ArgumentType for GameProfileArgumentType {
+    type Item = GameProfileResult;
+
+    fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
+        self.parse_with_allow_selectors(reader, true)
+    }
+
+    fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
+        JavaClientArgumentType::GameProfile
+    }
+
+    fn examples(&self) -> Vec<String> {
+        examples!(
+            "Herobrine",
+            "98765",
+            "@a",
+            "@p[limit=2]"
+        )
+    }
+}
+
+impl GameProfileArgumentType {
+    fn parse_with_allow_selectors(
+        self,
+        reader: &mut StringReader,
+        allow_selectors: bool,
+    ) -> Result<<Self as ArgumentType>::Item, CommandSyntaxError> {
+        if reader.peek() == Some('@') {
+            // We read a selector variable.
+            let parser = EntitySelectorParser::new(reader, allow_selectors);
+            let selector = parser.parse()?;
+            if selector.includes_entities {
+                Err(ONLY_PLAYERS_ALLOWED_ERROR_TYPE.create(reader))
+            } else {
+                Ok(GameProfileResult::Selector(selector))
+            }
+        } else {
+            // We read a UUID or player name.
+            let i = reader.cursor();
+            while reader.can_read_char() && reader.peek() != Some(' ') {
+                reader.skip();
+            }
+            let string = &reader.string()[i..reader.cursor()];
+            if let Ok(uuid) = Uuid::try_parse(string) {
+                Ok(GameProfileResult::Uuid(uuid))
+            } else {
+                Ok(GameProfileResult::Name(string.to_owned()))
+            }
+        }
+    }
+}

--- a/pumpkin/src/command/argument_types/game_profile.rs
+++ b/pumpkin/src/command/argument_types/game_profile.rs
@@ -4,6 +4,7 @@ use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgu
 use crate::command::argument_types::entity::ONLY_PLAYERS_ALLOWED_ERROR_TYPE;
 use crate::command::argument_types::entity_selector::EntitySelector;
 use crate::command::argument_types::entity_selector::parser::EntitySelectorParser;
+use crate::command::context::command_context::CommandContext;
 use crate::command::context::command_source::CommandSource;
 use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::errors::error_types::CommandErrorType;
@@ -22,7 +23,7 @@ pub enum GameProfileResult {
 
 impl GameProfileResult {
     /// Resolves this result with the help of a [`CommandSource`].
-    pub async fn resolve(self, source: &CommandSource) -> Result<Vec<GameProfile>, CommandSyntaxError> {
+    pub async fn resolve(&self, source: &CommandSource) -> Result<Vec<GameProfile>, CommandSyntaxError> {
         let players = match self {
             Self::Selector(selector) => selector.find_players(source).await,
             Self::Name(name) => source.server()
@@ -32,7 +33,7 @@ impl GameProfileResult {
                         |p| Ok(vec![p])
                     ),
             Self::Uuid(uuid) => source.server()
-                .get_player_by_uuid(uuid)
+                .get_player_by_uuid(*uuid)
                 .map_or_else(
                     || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
                     |p| Ok(vec![p])
@@ -104,5 +105,11 @@ impl GameProfileArgumentType {
                 Ok(GameProfileResult::Name(string.to_owned()))
             }
         }
+    }
+
+    /// Tries to get any number of [`GameProfile`]s from a parsed argument of the provided [`CommandContext`].
+    pub async fn get(context: &CommandContext<'_>, name: &str) -> Result<Vec<GameProfile>, CommandSyntaxError> {
+        context.get_argument::<GameProfileResult>(name)?
+            .resolve(context.source.as_ref()).await
     }
 }

--- a/pumpkin/src/command/argument_types/game_profile.rs
+++ b/pumpkin/src/command/argument_types/game_profile.rs
@@ -51,8 +51,9 @@ impl GameProfileResult {
 
 /// An argument type to parse one or more [`GameProfile`]s.
 ///
-/// The intermediate object returned by this argument type can
-/// be resolved during command execution, successfully or not.
+/// Use [`GameProfileArgumentType::get`] to automatically get a `Vec` of
+/// [`GameProfile`]s for an argument by providing a [`CommandContext`] and the
+/// argument's name.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct GameProfileArgumentType;
 

--- a/pumpkin/src/command/argument_types/game_profile.rs
+++ b/pumpkin/src/command/argument_types/game_profile.rs
@@ -1,5 +1,3 @@
-use uuid::Uuid;
-use pumpkin_data::translation;
 use crate::command::argument_types::argument_type::{ArgumentType, JavaClientArgumentType};
 use crate::command::argument_types::entity::ONLY_PLAYERS_ALLOWED_ERROR_TYPE;
 use crate::command::argument_types::entity_selector::EntitySelector;
@@ -10,42 +8,42 @@ use crate::command::errors::command_syntax_error::CommandSyntaxError;
 use crate::command::errors::error_types::CommandErrorType;
 use crate::command::string_reader::StringReader;
 use crate::net::GameProfile;
+use pumpkin_data::translation;
+use uuid::Uuid;
 
-pub const UNKNOWN_PLAYER_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new(translation::ARGUMENT_PLAYER_UNKNOWN);
+pub const UNKNOWN_PLAYER_ERROR_TYPE: CommandErrorType<0> =
+    CommandErrorType::new(translation::ARGUMENT_PLAYER_UNKNOWN);
 
 /// A result from the [`GameProfileArgumentType`], which can be resolved into
 /// one or more [`GameProfile`]s, successfully or not.
 pub enum GameProfileResult {
-    Selector(EntitySelector),
+    Selector(Box<EntitySelector>),
     Name(String),
     Uuid(Uuid),
 }
 
 impl GameProfileResult {
     /// Resolves this result with the help of a [`CommandSource`].
-    pub async fn resolve(&self, source: &CommandSource) -> Result<Vec<GameProfile>, CommandSyntaxError> {
+    pub async fn resolve(
+        &self,
+        source: &CommandSource,
+    ) -> Result<Vec<GameProfile>, CommandSyntaxError> {
         let players = match self {
             Self::Selector(selector) => selector.find_players(source).await,
-            Self::Name(name) => source.server()
-                    .get_player_by_name(name.as_str())
-                    .map_or_else(
-                        || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
-                        |p| Ok(vec![p])
-                    ),
-            Self::Uuid(uuid) => source.server()
-                .get_player_by_uuid(*uuid)
+            Self::Name(name) => source
+                .server()
+                .get_player_by_name(name.as_str())
                 .map_or_else(
                     || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
-                    |p| Ok(vec![p])
-                )
+                    |p| Ok(vec![p]),
+                ),
+            Self::Uuid(uuid) => source.server().get_player_by_uuid(*uuid).map_or_else(
+                || Err(UNKNOWN_PLAYER_ERROR_TYPE.create_without_context()),
+                |p| Ok(vec![p]),
+            ),
         }?;
 
-        Ok(
-            players.iter()
-            .map(|p| &p.gameprofile)
-            .cloned()
-            .collect()
-        )
+        Ok(players.iter().map(|p| &p.gameprofile).cloned().collect())
     }
 }
 
@@ -61,7 +59,7 @@ impl ArgumentType for GameProfileArgumentType {
     type Item = GameProfileResult;
 
     fn parse(&self, reader: &mut StringReader) -> Result<Self::Item, CommandSyntaxError> {
-        self.parse_with_allow_selectors(reader, true)
+        Self::parse_with_allow_selectors(reader, true)
     }
 
     fn client_side_parser(&'_ self) -> JavaClientArgumentType<'_> {
@@ -69,18 +67,12 @@ impl ArgumentType for GameProfileArgumentType {
     }
 
     fn examples(&self) -> Vec<String> {
-        examples!(
-            "Herobrine",
-            "98765",
-            "@a",
-            "@p[limit=2]"
-        )
+        examples!("Herobrine", "98765", "@a", "@p[limit=2]")
     }
 }
 
 impl GameProfileArgumentType {
     fn parse_with_allow_selectors(
-        self,
         reader: &mut StringReader,
         allow_selectors: bool,
     ) -> Result<<Self as ArgumentType>::Item, CommandSyntaxError> {
@@ -91,7 +83,7 @@ impl GameProfileArgumentType {
             if selector.includes_entities {
                 Err(ONLY_PLAYERS_ALLOWED_ERROR_TYPE.create(reader))
             } else {
-                Ok(GameProfileResult::Selector(selector))
+                Ok(GameProfileResult::Selector(Box::new(selector)))
             }
         } else {
             // We read a UUID or player name.
@@ -100,17 +92,21 @@ impl GameProfileArgumentType {
                 reader.skip();
             }
             let string = &reader.string()[i..reader.cursor()];
-            if let Ok(uuid) = Uuid::try_parse(string) {
-                Ok(GameProfileResult::Uuid(uuid))
-            } else {
-                Ok(GameProfileResult::Name(string.to_owned()))
-            }
+            Ok(Uuid::try_parse(string).map_or_else(
+                |_| GameProfileResult::Name(string.to_owned()),
+                GameProfileResult::Uuid,
+            ))
         }
     }
 
     /// Tries to get any number of [`GameProfile`]s from a parsed argument of the provided [`CommandContext`].
-    pub async fn get(context: &CommandContext<'_>, name: &str) -> Result<Vec<GameProfile>, CommandSyntaxError> {
-        context.get_argument::<GameProfileResult>(name)?
-            .resolve(context.source.as_ref()).await
+    pub async fn get(
+        context: &CommandContext<'_>,
+        name: &str,
+    ) -> Result<Vec<GameProfile>, CommandSyntaxError> {
+        context
+            .get_argument::<GameProfileResult>(name)?
+            .resolve(context.source.as_ref())
+            .await
     }
 }

--- a/pumpkin/src/command/argument_types/mod.rs
+++ b/pumpkin/src/command/argument_types/mod.rs
@@ -192,3 +192,4 @@ pub mod entity;
 pub mod entity_selector;
 pub mod range;
 pub mod time;
+pub mod game_profile;

--- a/pumpkin/src/command/argument_types/mod.rs
+++ b/pumpkin/src/command/argument_types/mod.rs
@@ -190,6 +190,6 @@ pub mod coordinates;
 pub mod core;
 pub mod entity;
 pub mod entity_selector;
+pub mod game_profile;
 pub mod range;
 pub mod time;
-pub mod game_profile;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Implements the *game profile* argument type with the previously made `EntitySelector`s.

Note that no `GameProfileSuggestionMode` object was added for this argument (as was in the `args`' `GameProfileArgumentConsumer`) because custom suggestions can be controlled by *custom suggestion providers* (#2004).

## Testing

Created the test command locally, which printed the resulting `GameProfile`s to the command source, and it works!