### PR TITLE
fix: (player) potion effect crash

### DIFF
--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -357,8 +357,7 @@ impl LivingEntity {
                 .attributes
                 .iter()
                 .find(|a| a.0.id == attribute.id)
-                .map(|a| a.1)
-                .unwrap_or(attribute.default_value);
+                .map_or(attribute.default_value, |a| a.1);
             AttributeInstance::new(base)
         });
 
@@ -388,8 +387,7 @@ impl LivingEntity {
             .attributes
             .iter()
             .find(|a| a.0.id == attribute.id)
-            .map(|a| a.1)
-            .unwrap_or(attribute.default_value)
+            .map_or(attribute.default_value, |a| a.1)
     }
 
     /// Update or insert the base value for an attribute on this entity.

--- a/pumpkin/src/entity/living.rs
+++ b/pumpkin/src/entity/living.rs
@@ -357,8 +357,8 @@ impl LivingEntity {
                 .attributes
                 .iter()
                 .find(|a| a.0.id == attribute.id)
-                .unwrap()
-                .1;
+                .map(|a| a.1)
+                .unwrap_or(attribute.default_value);
             AttributeInstance::new(base)
         });
 
@@ -388,8 +388,8 @@ impl LivingEntity {
             .attributes
             .iter()
             .find(|a| a.0.id == attribute.id)
-            .unwrap()
-            .1
+            .map(|a| a.1)
+            .unwrap_or(attribute.default_value)
     }
 
     /// Update or insert the base value for an attribute on this entity.


### PR DESCRIPTION
## Description
- Falls back to the `attribute.default_value` if no attribute base is found for a `LivingEntity`, preventing a panic.

## Testing
- Doesn't crash, but the default speed attribute (0.7) is used for players rn, causing extreme speed effects (instead of the correct 0.1). The right attribute defaults aren't present for players (in `entity_type.rs`) atm.