### PR TITLE
fix: version-gate SlotDisplay type IDs for pre-26.1 clients in recipe_book_add 🤖🤖🤖

### DIFF
--- a/pumpkin-protocol/src/java/client/play/recipe_book_add.rs
+++ b/pumpkin-protocol/src/java/client/play/recipe_book_add.rs
@@ -26,10 +26,18 @@ const SLOT_DISPLAY_ANY_FUEL: i32 = 1;
 //   26.1+:          minecraft:item=4, minecraft:composite=10
 // Source: https://minecraft.wiki/w/Java_Edition_protocol/Recipes
 const fn slot_display_item(version: MinecraftVersion) -> i32 {
-    if version.protocol_version() < 775 { 2 } else { 4 }
+    if version.protocol_version() < 775 {
+        2
+    } else {
+        4
+    }
 }
 const fn slot_display_composite(version: MinecraftVersion) -> i32 {
-    if version.protocol_version() < 775 { 7 } else { 10 }
+    if version.protocol_version() < 775 {
+        7
+    } else {
+        10
+    }
 }
 
 // RecipeBookCategory IDs

--- a/pumpkin-protocol/src/java/client/play/recipe_book_add.rs
+++ b/pumpkin-protocol/src/java/client/play/recipe_book_add.rs
@@ -17,11 +17,20 @@ const RECIPE_DISPLAY_SHAPELESS: i32 = 0;
 const RECIPE_DISPLAY_SHAPED: i32 = 1;
 const RECIPE_DISPLAY_FURNACE: i32 = 2;
 
-// Slot Display type IDs
+// Slot Display type IDs (stable across all supported versions)
 const SLOT_DISPLAY_EMPTY: i32 = 0;
 const SLOT_DISPLAY_ANY_FUEL: i32 = 1;
-const SLOT_DISPLAY_ITEM: i32 = 4;
-const SLOT_DISPLAY_COMPOSITE: i32 = 10;
+
+// Slot Display type IDs that changed in 26.1:
+//   1.21.5–1.21.11: minecraft:item=2, minecraft:composite=7
+//   26.1+:          minecraft:item=4, minecraft:composite=10
+// Source: https://minecraft.wiki/w/Java_Edition_protocol/Recipes
+const fn slot_display_item(version: MinecraftVersion) -> i32 {
+    if version.protocol_version() < 775 { 2 } else { 4 }
+}
+const fn slot_display_composite(version: MinecraftVersion) -> i32 {
+    if version.protocol_version() < 775 { 7 } else { 10 }
+}
 
 // RecipeBookCategory IDs
 const CATEGORY_CRAFTING_BUILDING: i32 = 0;
@@ -59,7 +68,7 @@ fn write_item_slot_display(
     item: &Item,
     version: MinecraftVersion,
 ) -> Result<(), WritingError> {
-    write.write_var_int(&VarInt(SLOT_DISPLAY_ITEM))?;
+    write.write_var_int(&VarInt(slot_display_item(version)))?;
     write.write_var_int(&VarInt(item_id_versioned(item, version)))?;
     Ok(())
 }
@@ -107,7 +116,7 @@ fn write_ingredient_slot_display(
             } else if items.len() == 1 {
                 write_item_slot_display(write, items[0], version)?;
             } else {
-                write.write_var_int(&VarInt(SLOT_DISPLAY_COMPOSITE))?;
+                write.write_var_int(&VarInt(slot_display_composite(version)))?;
                 write.write_var_int(&VarInt(items.len() as i32))?;
                 for item in &items {
                     write_item_slot_display(write, item, version)?;

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -2078,6 +2078,7 @@ impl World {
 
         if let crate::net::ClientPlatform::Java(java_client) = &player.client
             && server.advanced_config.recipe.send_recipes
+            && java_client.version.load() >= pumpkin_util::version::MinecraftVersion::V_26_1
         {
             java_client
                 .send_packet_now(&CRecipeBookSettings::default_closed())

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -2078,7 +2078,6 @@ impl World {
 
         if let crate::net::ClientPlatform::Java(java_client) = &player.client
             && server.advanced_config.recipe.send_recipes
-            && java_client.version.load() >= pumpkin_util::version::MinecraftVersion::V_26_1
         {
             java_client
                 .send_packet_now(&CRecipeBookSettings::default_closed())


### PR DESCRIPTION
## Summary

Fixes #2010 — clients on 1.21.5–1.21.11 crash with a `DecoderException` on `clientbound/minecraft:recipe_book_add` immediately after login.

**Root cause:** The `SlotDisplay` type IDs for `minecraft:item` and `minecraft:composite` changed in 26.1 (Tiny Takeover). The `recipe_book_add` packet implementation (added in #1999) hardcoded the 26.1 values, so pre-26.1 clients misread them and failed to decode the packet.

| SlotDisplay type | 1.21.5–1.21.11 (protocol < 775) | 26.1+ (protocol 775) |
|---|---|---|
| `minecraft:item` | `2` | `4` |
| `minecraft:composite` | `7` | `10` |

**Fix:** Replaced the hardcoded constants with `const fn slot_display_item(version)` and `const fn slot_display_composite(version)` that return the correct ID based on protocol version.

## Test plan

- [x] Connect with a 26.1 client — recipe book loads correctly
- [x] Connect with a 1.21.11 client — no longer crashes with `DecoderException` on `recipe_book_add`
- [x] Connect with a 1.21.5 client — no longer crashes with `DecoderException` on `recipe_book_add`

Source for ID values: https://minecraft.wiki/w/Java_Edition_protocol/Recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)