### PR TITLE
feat(data-components): add StoredEnchantments

### DIFF
--- a/pumpkin-data/src/data_component_impl.rs
+++ b/pumpkin-data/src/data_component_impl.rs
@@ -5,7 +5,8 @@ use crate::data_component::DataComponent;
 use crate::data_component::DataComponent::{
     AttributeModifiers, BlocksAttacks, Consumable, CustomData, CustomName, Damage, DamageResistant,
     DeathProtection, Enchantments, Equippable, FireworkExplosion, Fireworks, Food, ItemModel,
-    ItemName, JukeboxPlayable, MaxDamage, MaxStackSize, PotionContents, Tool, Unbreakable, Weapon,
+    ItemName, JukeboxPlayable, MaxDamage, MaxStackSize, PotionContents, StoredEnchantments, Tool,
+    Unbreakable, Weapon,
 };
 use crate::effect::{self, StatusEffect};
 use crate::entity_type::EntityType;
@@ -63,6 +64,7 @@ pub fn read_data(id: DataComponent, data: &NbtTag) -> Option<Box<dyn DataCompone
         ItemModel => Some(ItemModelImpl::read_data(data)?.to_dyn()),
         Consumable => Some(ConsumableImpl::read_data(data)?.to_dyn()),
         Equippable => Some(EquippableImpl::read_data(data)?.to_dyn()),
+        StoredEnchantments => Some(StoredEnchantmentsImpl::read_data(data)?.to_dyn()),
         _ => None,
     }
 }
@@ -698,7 +700,7 @@ pub enum DamageResistantType {
     NoKnockback,
     PanicCauses,
     PanicEnvironmentalCauses,
-    /// Reducese damage dealt to witches by 85%
+    /// Reduces damage dealt to witches by 85%
     WitchResistantTo,
     WitherImmuneTo,
     /// Generic fallback
@@ -1383,7 +1385,44 @@ impl DataComponentImpl for BlocksAttacksImpl {
     default_impl!(BlocksAttacks);
 }
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct StoredEnchantmentsImpl;
+pub struct StoredEnchantmentsImpl {
+    pub enchantment: Cow<'static, [(&'static Enchantment, i32)]>,
+}
+
+impl StoredEnchantmentsImpl {
+    fn read_data(data: &NbtTag) -> Option<Self> {
+        let data = &data.extract_compound()?.child_tags;
+        let mut enc = Vec::with_capacity(data.len());
+        for (name, level) in data {
+            enc.push((Enchantment::from_name(name.as_str())?, level.extract_int()?));
+        }
+        Some(Self {
+            enchantment: Cow::from(enc),
+        })
+    }
+}
+impl DataComponentImpl for StoredEnchantmentsImpl {
+    fn write_data(&self) -> NbtTag {
+        let mut data = NbtCompound::new();
+        for (enc, level) in self.enchantment.iter() {
+            data.put_int(enc.name, *level);
+        }
+        NbtTag::Compound(data)
+    }
+    fn get_hash(&self) -> i32 {
+        let mut digest = Digest::new(Crc32Iscsi);
+        digest.update(&[2u8]);
+        for (enc, level) in self.enchantment.iter() {
+            digest.update(&get_str_hash(enc.name).to_le_bytes());
+            digest.update(&get_i32_hash(*level).to_le_bytes());
+        }
+        digest.update(&[3u8]);
+        digest.finalize() as i32
+    }
+
+    default_impl!(StoredEnchantments);
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DyedColorImpl;
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/pumpkin-data/src/data_component_impl.rs
+++ b/pumpkin-data/src/data_component_impl.rs
@@ -1384,7 +1384,7 @@ pub struct BlocksAttacksImpl;
 impl DataComponentImpl for BlocksAttacksImpl {
     default_impl!(BlocksAttacks);
 }
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct StoredEnchantmentsImpl {
     pub enchantment: Cow<'static, [(&'static Enchantment, i32)]>,
 }

--- a/pumpkin-data/src/generated/enchantment.rs
+++ b/pumpkin-data/src/generated/enchantment.rs
@@ -8,6 +8,8 @@ use pumpkin_util::text::TextComponent;
 use pumpkin_util::text::color::NamedColor;
 use std::hash::{Hash, Hasher};
 use std::slice::Iter;
+
+#[derive(Debug)]
 pub struct Enchantment {
     pub id: u8,
     pub name: &'static str,

--- a/pumpkin-data/src/generated/enchantment.rs
+++ b/pumpkin-data/src/generated/enchantment.rs
@@ -9,7 +9,6 @@ use pumpkin_util::text::color::NamedColor;
 use std::hash::{Hash, Hasher};
 use std::slice::Iter;
 
-#[derive(Debug)]
 pub struct Enchantment {
     pub id: u8,
     pub name: &'static str,

--- a/pumpkin-data/src/generated/enchantment.rs
+++ b/pumpkin-data/src/generated/enchantment.rs
@@ -8,7 +8,6 @@ use pumpkin_util::text::TextComponent;
 use pumpkin_util::text::color::NamedColor;
 use std::hash::{Hash, Hasher};
 use std::slice::Iter;
-
 pub struct Enchantment {
     pub id: u8,
     pub name: &'static str,

--- a/pumpkin-protocol/src/codec/data_component.rs
+++ b/pumpkin-protocol/src/codec/data_component.rs
@@ -7,7 +7,7 @@ use pumpkin_data::data_component_impl::{
     ConsumableImpl, ConsumeAnimation, ConsumeEffect, DamageImpl, DataComponentImpl,
     EnchantmentsImpl, EquipmentSlot, EquippableImpl, FireworkExplosionImpl, FireworkExplosionShape,
     FireworksImpl, IDSet, IDSetContent, IdOr, ItemModelImpl, MaxStackSizeImpl, PotionContentsImpl,
-    SoundEvent, StatusEffectInstance, UnbreakableImpl, get,
+    SoundEvent, StatusEffectInstance, StoredEnchantmentsImpl, UnbreakableImpl, get,
 };
 use pumpkin_data::effect::StatusEffect;
 use pumpkin_data::entity::EntityType;
@@ -762,6 +762,45 @@ impl DataComponentCodec<Self> for FireworksImpl {
     }
 }
 
+impl DataComponentCodec<Self> for StoredEnchantmentsImpl {
+    fn serialize<T: SerializeStruct>(&self, seq: &mut T) -> Result<(), T::Error> {
+        seq.serialize_field::<VarInt>("", &VarInt::from(self.enchantment.len() as i32))?;
+        for (enc, level) in self.enchantment.iter() {
+            seq.serialize_field::<VarInt>("", &VarInt::from(enc.id))?;
+            seq.serialize_field::<VarInt>("", &VarInt::from(*level))?;
+        }
+        Ok(())
+    }
+
+    fn deserialize<'a, A: SeqAccess<'a>>(seq: &mut A) -> Result<Self, A::Error> {
+        let len = seq
+            .next_element::<VarInt>()?
+            .ok_or(de::Error::custom("No StoredEnchantmentsImpl len VarInt!"))?
+            .0 as usize;
+
+        let mut stored_enchantments = Vec::with_capacity(len);
+        for _ in 0..len {
+            let id = seq
+                .next_element::<VarInt>()?
+                .ok_or(de::Error::custom("No StoredEnchantmentsImpl id VarInt!"))?
+                .0 as u8;
+            let level = seq
+                .next_element::<VarInt>()?
+                .ok_or(de::Error::custom("No StoredEnchantmentsImpl level VarInt!"))?
+                .0;
+            stored_enchantments.push((
+                Enchantment::from_id(id).ok_or(de::Error::custom(
+                    "StoredEnchantmentsImpl Enchantment VarInt Incorrect!",
+                ))?,
+                level,
+            ));
+        }
+        Ok(Self {
+            enchantment: Cow::from(stored_enchantments),
+        })
+    }
+}
+
 pub fn deserialize<'a, A: SeqAccess<'a>>(
     id: DataComponent,
     seq: &mut A,
@@ -777,7 +816,8 @@ pub fn deserialize<'a, A: SeqAccess<'a>>(
         DataComponent::ItemModel => Ok(ItemModelImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Consumable => Ok(ConsumableImpl::deserialize(seq)?.to_dyn()),
         DataComponent::Equippable => Ok(EquippableImpl::deserialize(seq)?.to_dyn()),
-        _ => Err(serde::de::Error::custom("TODO")),
+        DataComponent::StoredEnchantments => Ok(StoredEnchantmentsImpl::deserialize(seq)?.to_dyn()),
+        _ => Err(serde::de::Error::custom(format!("{id:?} (TODO)"))),
     }
 }
 pub fn serialize<T: SerializeStruct>(
@@ -796,6 +836,7 @@ pub fn serialize<T: SerializeStruct>(
         DataComponent::ItemModel => get::<ItemModelImpl>(value).serialize(seq),
         DataComponent::Consumable => get::<ConsumableImpl>(value).serialize(seq),
         DataComponent::Equippable => get::<EquippableImpl>(value).serialize(seq),
+        DataComponent::StoredEnchantments => get::<StoredEnchantmentsImpl>(value).serialize(seq),
         _ => todo!("{} not yet implemented", id.to_name()),
     }
 }

--- a/pumpkin-protocol/src/codec/data_component.rs
+++ b/pumpkin-protocol/src/codec/data_component.rs
@@ -773,10 +773,16 @@ impl DataComponentCodec<Self> for StoredEnchantmentsImpl {
     }
 
     fn deserialize<'a, A: SeqAccess<'a>>(seq: &mut A) -> Result<Self, A::Error> {
+        const MAX_ENCHANTMENTS: usize = 256;
+
         let len = seq
             .next_element::<VarInt>()?
             .ok_or(de::Error::custom("No StoredEnchantmentsImpl len VarInt!"))?
             .0 as usize;
+
+        if len > MAX_ENCHANTMENTS {
+            return Err(de::Error::custom("Too many enchantments"));
+        }
 
         let mut stored_enchantments = Vec::with_capacity(len);
         for _ in 0..len {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Part of #716: add `StoredEnchantments` to data components (basically the same implementation as `Enchantments` since they share the same data component format).

## Testing
- `cargo test` passes
- `cargo clippy --all-targets`: no warnings 
- client no longer gets disconnected when getting an enchanted book in his inventory (tested in `26.1.2`).

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)