### PR TITLE
Fix drowning damage and air supply handling

### DIFF
--- a/pumpkin/src/entity/breath.rs
+++ b/pumpkin/src/entity/breath.rs
@@ -74,6 +74,7 @@ impl BreathManager {
                 .fetch_sub(AIR_DEPLETION_RATE, Ordering::Relaxed);
             let new_air = (prev - AIR_DEPLETION_RATE).max(0);
             if new_air != prev {
+                self.air_supply.store(new_air, Ordering::Relaxed);
                 self.send_air_supply(player).await;
             }
 

--- a/pumpkin/src/entity/breath.rs
+++ b/pumpkin/src/entity/breath.rs
@@ -13,6 +13,12 @@ use pumpkin_util::math::position::BlockPos;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI32, Ordering};
 
+pub const MAX_AIR: i32 = 300;
+pub const AIR_RECOVERY_RATE: i32 = 4;
+pub const AIR_DEPLETION_RATE: i32 = 1;
+pub const DROWNING_INTERVAL: i32 = 20;
+pub const DROWNING_DAMAGE: f32 = 2.0;
+
 pub struct BreathManager {
     pub air_supply: AtomicI32,
     pub drowning_tick: AtomicI32,
@@ -21,7 +27,7 @@ pub struct BreathManager {
 impl Default for BreathManager {
     fn default() -> Self {
         Self {
-            air_supply: AtomicI32::new(300),
+            air_supply: AtomicI32::new(MAX_AIR),
             drowning_tick: AtomicI32::new(0),
         }
     }
@@ -32,10 +38,8 @@ impl BreathManager {
         let mode = player.gamemode.load();
 
         if matches!(mode, GameMode::Creative | GameMode::Spectator) {
-            let prev = self.air_supply.load(Ordering::Relaxed);
-            let new_air = (prev + 4).min(300);
-            if new_air != prev {
-                self.air_supply.store(new_air, Ordering::Relaxed);
+            if self.air_supply.load(Ordering::Relaxed) != MAX_AIR {
+                self.air_supply.store(MAX_AIR, Ordering::Relaxed);
                 self.send_air_supply(player).await;
             }
             self.drowning_tick.store(0, Ordering::Relaxed);
@@ -51,16 +55,20 @@ impl BreathManager {
             .has_effect(&StatusEffect::WATER_BREATHING)
             .await
         {
-            if self.air_supply.swap(300, Ordering::Relaxed) != 300 {
+            if self.air_supply.swap(MAX_AIR, Ordering::Relaxed) != MAX_AIR {
                 self.send_air_supply(player).await;
             }
             self.drowning_tick.store(0, Ordering::Relaxed);
             return;
         }
 
-        if self.is_eye_in_water(player).await {
-            let prev = self.air_supply.fetch_sub(1, Ordering::Relaxed);
-            let new_air = (prev - 1).max(0);
+        let in_water = self.is_eye_in_water(player).await;
+
+        if in_water {
+            let prev = self
+                .air_supply
+                .fetch_sub(AIR_DEPLETION_RATE, Ordering::Relaxed);
+            let new_air = (prev - AIR_DEPLETION_RATE).max(0);
             if new_air != prev {
                 self.send_air_supply(player).await;
             }
@@ -68,17 +76,17 @@ impl BreathManager {
             if new_air <= 0 {
                 let t = self.drowning_tick.fetch_add(1, Ordering::Relaxed) + 1;
 
-                if t >= 20 {
+                if t >= DROWNING_INTERVAL {
                     self.drowning_tick.store(0, Ordering::Relaxed);
                     player
                         .living_entity
-                        .damage(player.as_ref(), 2.0, DamageType::DROWN)
+                        .damage(player.as_ref(), DROWNING_DAMAGE, DamageType::DROWN)
                         .await;
                 }
             }
         } else {
             let prev = self.air_supply.load(Ordering::Relaxed);
-            let new_air = (prev + 4).min(300);
+            let new_air = (prev + AIR_RECOVERY_RATE).min(MAX_AIR);
             if new_air != prev {
                 self.air_supply.store(new_air, Ordering::Relaxed);
                 self.send_air_supply(player).await;
@@ -141,7 +149,7 @@ impl BreathManager {
     }
 
     pub async fn send_air_supply(&self, player: &Player) {
-        let air = self.air_supply.load(Ordering::Relaxed).clamp(0, 300);
+        let air = self.air_supply.load(Ordering::Relaxed).clamp(0, MAX_AIR);
 
         player
             .living_entity
@@ -155,7 +163,7 @@ impl BreathManager {
     }
 
     pub async fn reset(&self, player: &Player) {
-        self.air_supply.store(300, Ordering::Relaxed);
+        self.air_supply.store(MAX_AIR, Ordering::Relaxed);
         self.send_air_supply(player).await;
         self.drowning_tick.store(0, Ordering::Relaxed);
     }

--- a/pumpkin/src/entity/breath.rs
+++ b/pumpkin/src/entity/breath.rs
@@ -50,6 +50,10 @@ impl BreathManager {
             return;
         }
 
+        if player.living_entity.dead.load(Ordering::Relaxed) {
+            return;
+        }
+
         if player
             .living_entity
             .has_effect(&StatusEffect::WATER_BREATHING)

--- a/pumpkin/src/entity/breath.rs
+++ b/pumpkin/src/entity/breath.rs
@@ -50,10 +50,6 @@ impl BreathManager {
             return;
         }
 
-        if player.living_entity.dead.load(Ordering::Relaxed) {
-            return;
-        }
-
         if player
             .living_entity
             .has_effect(&StatusEffect::WATER_BREATHING)


### PR DESCRIPTION
## Description
This PR fixes several issues with the breath/drowning system in breath.rs.
Such as magic numbers, dead entities still being handled, and air supply going far beyond 0.

### What was changed

- Introduced named constants (`MAX_AIR`, `AIR_RECOVERY_RATE`, `AIR_DEPLETION_RATE`, `DROWNING_INTERVAL`, `DROWNING_DAMAGE`) to replace magic numbers throughout the breath tick logic.
- Added an early return to skip breath processing entirely for dead entities.
- Fixed a bug where `air_supply` was never stored back after being clamped to `0`, causing `fetch_sub` to drive it arbitrarily negative. This meant recovery after leaving the water would take far longer than intended. 
- Updated air metadata serialization type to `INT` for Minecraft 26_1 protocol compatibility.

### Why were these changes necessary?
Players were instantly drowning after death. The root cause was that `air_supply` was going negative during drowning, meaning that when they left the water, it would first have to count back all the way to the positive before actually being restored. Additionally, dead players were unnecessarily running through breath logic.

Together, these two would lead to a situation where, if a player were to drown and not respawn, the `air_supply` would continue to go far into the negative.  

**Impact:**

Drowning damage now applies correctly. Air supply recovers immediately from `0` upon leaving water.

**Known issues/limitations:**

None.

Closes #2029 
