### PR TITLE
fix(plugin-api) Fix the method chaining in `text#text-component`

### DIFF
--- a/pumpkin-plugin-wit/v0.1/text.wit
+++ b/pumpkin-plugin-wit/v0.1/text.wit
@@ -5,34 +5,37 @@ interface text {
         text: static func(plain: string) -> text-component;
         translate: static func(key: string, %with: list<text-component>) -> text-component;
 
-        add-child: func(child: text-component) -> text-component;
-        add-text: func(text: string) -> text-component;
+        add-child: func(child: text-component);
+        add-text: func(text: string);
         get-text: func() -> string;
         encode: func() -> list<u8>;
 
         // Style
-        color-named: func(color: named-color) -> text-component;
-        color-rgb: func(color: rgb-color) -> text-component;
-        bold: func(value: bool) -> text-component;
-        italic: func(value: bool) -> text-component;
-        underlined: func(value: bool) -> text-component;
-        strikethrough: func(value: bool) -> text-component;
-        obfuscated: func(value: bool) -> text-component;
+
+        color-named: func(color: named-color);
+        color-rgb: func(color: rgb-color);
+        bold: func(value: bool);
+        italic: func(value: bool);
+        underlined: func(value: bool);
+        strikethrough: func(value: bool);
+        obfuscated: func(value: bool);
         /// Text inserted into chat when shift-clicked
-        insertion: func(text: string) -> text-component;
-        font: func(font: string) -> text-component;
-        shadow-color: func(color: argb-color) -> text-component;
+        insertion: func(text: string);
+        font: func(font: string);
+        shadow-color: func(color: argb-color);
 
         // Click events
-        click-open-url: func(url: string) -> text-component;
-        click-run-command: func(command: string) -> text-component;
-        click-suggest-command: func(command: string) -> text-component;
-        click-copy-to-clipboard: func(text: string) -> text-component;
+
+        click-open-url: func(url: string);
+        click-run-command: func(command: string);
+        click-suggest-command: func(command: string);
+        click-copy-to-clipboard: func(text: string);
 
         // Hover events
-        hover-show-text: func(text: text-component) -> text-component;
+
+        hover-show-text: func(text: text-component);
         /// Item data as SNBT string
-        hover-show-item: func(item: string) -> text-component;
-        hover-show-entity: func(entity-type: string, id: string, name: option<text-component>) -> text-component;
+        hover-show-item: func(item: string);
+        hover-show-entity: func(entity-type: string, id: string, name: option<text-component>);
     }
 }

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/text.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/text.rs
@@ -101,21 +101,22 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         &mut self,
         text_component: Resource<TextComponent>,
         child: Resource<TextComponent>,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         let child_tc = self.take_text(&child)?.provider;
         let parent = self.get_text_mut(&text_component)?;
+        // Cloning here as noted in your TODO until builder pattern supports &mut self
         parent.provider = parent.provider.clone().add_child(child_tc);
-        Ok(text_component)
+        Ok(())
     }
 
     async fn add_text(
         &mut self,
         text_component: Resource<TextComponent>,
         text: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         let parent = self.get_text_mut(&text_component)?;
         parent.provider = parent.provider.clone().add_text(text);
-        Ok(text_component)
+        Ok(())
     }
 
     async fn get_text(
@@ -144,161 +145,149 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         &mut self,
         res: Resource<TextComponent>,
         color: NamedColor,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.color =
             Some(Color::Named(map_named_color(color)));
-        Ok(res)
+        Ok(())
     }
 
     async fn color_rgb(
         &mut self,
         res: Resource<TextComponent>,
         color: RgbColor,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.color =
             Some(Color::Rgb(color::RGBColor::new(color.r, color.g, color.b)));
-        Ok(res)
+        Ok(())
     }
 
-    async fn bold(
-        &mut self,
-        res: Resource<TextComponent>,
-        value: bool,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    async fn bold(&mut self, res: Resource<TextComponent>, value: bool) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.bold = Some(value);
-        Ok(res)
+        Ok(())
     }
 
-    async fn italic(
-        &mut self,
-        res: Resource<TextComponent>,
-        value: bool,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    async fn italic(&mut self, res: Resource<TextComponent>, value: bool) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.italic = Some(value);
-        Ok(res)
+        Ok(())
     }
 
     async fn underlined(
         &mut self,
         res: Resource<TextComponent>,
         value: bool,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.underlined = Some(value);
-        Ok(res)
+        Ok(())
     }
 
     async fn strikethrough(
         &mut self,
         res: Resource<TextComponent>,
         value: bool,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.strikethrough = Some(value);
-        Ok(res)
+        Ok(())
     }
 
     async fn obfuscated(
         &mut self,
         res: Resource<TextComponent>,
         value: bool,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.obfuscated = Some(value);
-        Ok(res)
+        Ok(())
     }
 
     async fn insertion(
         &mut self,
         res: Resource<TextComponent>,
         text: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.insertion = Some(text);
-        Ok(res)
+        Ok(())
     }
 
-    async fn font(
-        &mut self,
-        res: Resource<TextComponent>,
-        font: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    async fn font(&mut self, res: Resource<TextComponent>, font: String) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.font = Some(font);
-        Ok(res)
+        Ok(())
     }
 
     async fn shadow_color(
         &mut self,
         res: Resource<TextComponent>,
         color: ArgbColor,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.shadow_color =
             Some(color::ARGBColor::new(color.a, color.r, color.g, color.b));
-        Ok(res)
+        Ok(())
     }
 
     async fn click_open_url(
         &mut self,
         res: Resource<TextComponent>,
         url: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::OpenUrl {
             url: Cow::Owned(url),
         });
-        Ok(res)
+        Ok(())
     }
 
     async fn click_run_command(
         &mut self,
         res: Resource<TextComponent>,
         command: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::RunCommand {
             command: Cow::Owned(command),
         });
-        Ok(res)
+        Ok(())
     }
 
     async fn click_suggest_command(
         &mut self,
         res: Resource<TextComponent>,
         command: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::SuggestCommand {
             command: Cow::Owned(command),
         });
-        Ok(res)
+        Ok(())
     }
 
     async fn click_copy_to_clipboard(
         &mut self,
         res: Resource<TextComponent>,
         text: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.click_event = Some(ClickEvent::CopyToClipboard {
             value: Cow::Owned(text),
         });
-        Ok(res)
+        Ok(())
     }
 
     async fn hover_show_text(
         &mut self,
         res: Resource<TextComponent>,
         text: Resource<TextComponent>,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         let hover_tc = self.take_text(&text)?.provider;
         self.get_text_mut(&res)?.provider.0.style.hover_event = Some(HoverEvent::ShowText {
             value: vec![hover_tc.0],
         });
-        Ok(res)
+        Ok(())
     }
 
     async fn hover_show_item(
         &mut self,
         res: Resource<TextComponent>,
         item: String,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         self.get_text_mut(&res)?.provider.0.style.hover_event = Some(HoverEvent::ShowItem {
             id: Cow::Owned(item),
             count: None,
         });
-        Ok(res)
+        Ok(())
     }
 
     async fn hover_show_entity(
@@ -307,7 +296,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
         entity_type: String,
         id: String,
         name: Option<Resource<TextComponent>>,
-    ) -> wasmtime::Result<Resource<TextComponent>> {
+    ) -> wasmtime::Result<()> {
         let name_val = match name {
             Some(r) => Some(vec![self.take_text(&r)?.provider.0]),
             None => None,
@@ -317,7 +306,7 @@ impl pumpkin::plugin::text::HostTextComponent for PluginHostState {
             uuid: Cow::Owned(id),
             name: name_val,
         });
-        Ok(res)
+        Ok(())
     }
 
     async fn drop(&mut self, rep: Resource<TextComponent>) -> wasmtime::Result<()> {


### PR DESCRIPTION
## Description

Undoes the erroneous parts of https://github.com/Pumpkin-MC/Pumpkin/commit/2b4e3bb332cfb75c71016f0dc7914d10f4a07686. `enable_method_chaining` does not require modifying the WIT. Those changes were invalid (trying to return `borrow<text-component>` as `text-component`) rendering the `text-component` system largely unusable.

## Testing

`cargo {clippy,fmt,test}` all pass.

Changes were verified by making use of them in [QuantumSegfault/pumpkin-fly-plugin](https://github.com/QuantumSegfault/pumpkin-fly-plugin)