### PR TITLE
feat(plugin-api) Add fine-grained player permission control to plugin API.

### DIFF
--- a/pumpkin-plugin-wit/v0.1/player.wit
+++ b/pumpkin-plugin-wit/v0.1/player.wit
@@ -59,6 +59,10 @@ interface player {
         get-permission-level: func () -> permission-level;
         /// Sets the player's permission level.
         set-permission-level: func (level: permission-level);
+        /// Grants or denies a specific permission node for the player.
+	    set-permission: func(node: string, value: bool);
+	    /// Removes an explicitly set permission node from the player.
+	    unset-permission: func(node: string);
         /// Checks if the player has a specific permission node.
         has-permission: func (node: string) -> bool;
         /// Returns the player's display name, which may include formatting.

--- a/pumpkin-plugin-wit/v0.1/player.wit
+++ b/pumpkin-plugin-wit/v0.1/player.wit
@@ -63,6 +63,8 @@ interface player {
 	    set-permission: func(node: string, value: bool);
 	    /// Removes an explicitly set permission node from the player.
 	    unset-permission: func(node: string);
+        /// Returns `Some(true)` if granted, `Some(false)` if denied, or `None` if not set.
+        has-permission-set: func (node: string) -> option<bool>
         /// Checks if the player has a specific permission node.
         has-permission: func (node: string) -> bool;
         /// Returns the player's display name, which may include formatting.

--- a/pumpkin-plugin-wit/v0.1/player.wit
+++ b/pumpkin-plugin-wit/v0.1/player.wit
@@ -64,7 +64,7 @@ interface player {
 	    /// Removes an explicitly set permission node from the player.
 	    unset-permission: func(node: string);
         /// Returns `Some(true)` if granted, `Some(false)` if denied, or `None` if not set.
-        has-permission-set: func (node: string) -> option<bool>
+        has-permission-set: func (node: string) -> option<bool>;
         /// Checks if the player has a specific permission node.
         has-permission: func (node: string) -> bool;
         /// Returns the player's display name, which may include formatting.

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -263,6 +263,21 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         Ok(())
     }
 
+    async fn has_permission_set(
+        &mut self,
+        player: Resource<Player>,
+        node: String,
+    ) -> wasmtime::Result<Option<bool>> {
+        let player = player_from_resource(self, &player)?;
+        let server = self.server.as_ref().expect("server not available");
+    
+        let perm_manager = server.permission_manager.read().await;
+        let attachment = perm_manager.get_attachment(player.gameprofile.id);
+        drop(perm_manager);
+    
+        Ok(attachment.read().await.has_permission_set(&node))
+    }
+
     async fn has_permission(
         &mut self,
         player: Resource<Player>,

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -271,7 +271,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         let player = player_from_resource(self, &player)?;
         let server = self.server.as_ref().expect("server not available");
     
-        let perm_manager = server.permission_manager.read().await;
+        let perm_manager = server.permission_manager.write().await;
         let attachment = perm_manager.get_attachment(player.gameprofile.id);
         drop(perm_manager);
     

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -270,11 +270,11 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<Option<bool>> {
         let player = player_from_resource(self, &player)?;
         let server = self.server.as_ref().expect("server not available");
-    
+
         let mut perm_manager = server.permission_manager.write().await;
         let attachment = perm_manager.get_attachment(player.gameprofile.id);
         drop(perm_manager);
-    
+
         Ok(attachment.read().await.has_permission_set(&node))
     }
 

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -271,7 +271,7 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         let player = player_from_resource(self, &player)?;
         let server = self.server.as_ref().expect("server not available");
     
-        let perm_manager = server.permission_manager.write().await;
+        let mut perm_manager = server.permission_manager.write().await;
         let attachment = perm_manager.get_attachment(player.gameprofile.id);
         drop(perm_manager);
     

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -228,6 +228,41 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         Ok(())
     }
 
+    async fn set_permission(
+        &mut self,
+        player: Resource<Player>,
+        node: String,
+        value: bool,
+    ) -> wasmtime::Result<()> {
+        let player = player_from_resource(self, &player)?;
+        let server = self.server.as_ref().expect("server not available");
+
+        let mut perm_manager = server.permission_manager.write().await;
+        let attachment = perm_manager.get_attachment(player.gameprofile.id);
+        drop(perm_manager);
+
+        attachment.write().await.set_permission(&node, value);
+
+        Ok(())
+    }
+
+    async fn unset_permission(
+        &mut self,
+        player: Resource<Player>,
+        node: String,
+    ) -> wasmtime::Result<()> {
+        let player = player_from_resource(self, &player)?;
+        let server = self.server.as_ref().expect("server not available");
+
+        let mut perm_manager = server.permission_manager.write().await;
+        let attachment = perm_manager.get_attachment(player.gameprofile.id);
+        drop(perm_manager);
+
+        attachment.write().await.unset_permission(&node);
+
+        Ok(())
+    }
+
     async fn has_permission(
         &mut self,
         player: Resource<Player>,


### PR DESCRIPTION
## Description
Adds `set_permission`, `unset_permission`, and `has_permission_set` methods on the Player resource, allowing plugins to control and get the values of specific permission nodes for players.

These methods were implemented using the already existing methods from `PermissionAttachment`.

## Testing
I tested each of the new methods by making a simple permissions plugin and they all seem to work as expected.

`cargo clippy --all-targets` :white_check_mark: 
`cargo test` :white_check_mark: