### PR TITLE
fix: Jungle Tree Trunks generation

### DIFF
--- a/pumpkin-world/src/generation/feature/features/tree/decorator/trunk_vine.rs
+++ b/pumpkin-world/src/generation/feature/features/tree/decorator/trunk_vine.rs
@@ -1,6 +1,6 @@
 use crate::generation::proto_chunk::GenerationCache;
 use pumpkin_data::{
-    Block, BlockDirection, BlockState,
+    Block, BlockState,
     block_properties::{BlockProperties, VineLikeProperties},
 };
 use pumpkin_util::{
@@ -18,46 +18,38 @@ impl TrunkVineTreeDecorator {
         log_positions: &[BlockPos],
     ) {
         for pos in log_positions {
-            if random.next_bounded_i32(3) > 0
-                && chunk.is_air(&pos.offset(BlockDirection::West.to_offset()).0)
-            {
+            if random.next_bounded_i32(3) > 0 && chunk.is_air(&pos.west().0) {
                 let mut vine = VineLikeProperties::default(&Block::VINE);
                 vine.east = true;
                 chunk.set_block_state(
-                    &pos.offset(BlockDirection::West.to_offset()).0,
+                    &pos.west().0,
                     BlockState::from_id(vine.to_state_id(&Block::VINE)),
                 );
             }
 
-            if random.next_bounded_i32(3) > 0
-                && chunk.is_air(&pos.offset(BlockDirection::East.to_offset()).0)
-            {
+            if random.next_bounded_i32(3) > 0 && chunk.is_air(&pos.east().0) {
                 let mut vine = VineLikeProperties::default(&Block::VINE);
                 vine.west = true;
                 chunk.set_block_state(
-                    &pos.offset(BlockDirection::West.to_offset()).0,
+                    &pos.east().0,
                     BlockState::from_id(vine.to_state_id(&Block::VINE)),
                 );
             }
 
-            if random.next_bounded_i32(3) > 0
-                && chunk.is_air(&pos.offset(BlockDirection::North.to_offset()).0)
-            {
+            if random.next_bounded_i32(3) > 0 && chunk.is_air(&pos.north().0) {
                 let mut vine = VineLikeProperties::default(&Block::VINE);
                 vine.south = true;
                 chunk.set_block_state(
-                    &pos.offset(BlockDirection::West.to_offset()).0,
+                    &pos.north().0,
                     BlockState::from_id(vine.to_state_id(&Block::VINE)),
                 );
             }
 
-            if random.next_bounded_i32(3) > 0
-                && chunk.is_air(&pos.offset(BlockDirection::South.to_offset()).0)
-            {
+            if random.next_bounded_i32(3) > 0 && chunk.is_air(&pos.south().0) {
                 let mut vine = VineLikeProperties::default(&Block::VINE);
                 vine.north = true;
                 chunk.set_block_state(
-                    &pos.offset(BlockDirection::West.to_offset()).0,
+                    &pos.south().0,
                     BlockState::from_id(vine.to_state_id(&Block::VINE)),
                 );
             }

--- a/pumpkin-world/src/generation/feature/features/tree/trunk/giant.rs
+++ b/pumpkin-world/src/generation/feature/features/tree/trunk/giant.rs
@@ -1,8 +1,5 @@
-use pumpkin_data::{BlockDirection, BlockState};
-use pumpkin_util::{
-    math::{position::BlockPos, vector3::Vector3},
-    random::RandomGenerator,
-};
+use pumpkin_data::BlockState;
+use pumpkin_util::{math::position::BlockPos, random::RandomGenerator};
 
 use crate::generation::proto_chunk::GenerationCache;
 use crate::{
@@ -33,57 +30,41 @@ impl GiantTrunkPlacer {
             block_registry,
             chunk,
             random,
-            &pos.offset(BlockDirection::East.to_offset()),
+            &pos.east(),
             below_trunk_provider,
         );
         placer.set_dirt(
             block_registry,
             chunk,
             random,
-            &pos.offset(BlockDirection::South.to_offset()),
+            &pos.south(),
             below_trunk_provider,
         );
         placer.set_dirt(
             block_registry,
             chunk,
             random,
-            &pos.offset(BlockDirection::South.to_offset())
-                .offset(BlockDirection::South.to_offset()),
+            &pos.south().east(),
             below_trunk_provider,
         );
 
         let mut trunk_poses = Vec::new();
         for y in 0..height {
-            if placer.try_place(
-                chunk,
-                &pos.offset(Vector3::new(0, y as i32, 0)),
-                trunk_block,
-            ) {
-                trunk_poses.push(pos.offset(Vector3::new(0, y as i32, 0)));
+            if placer.try_place(chunk, &pos.up_height(y as i32), trunk_block) {
+                trunk_poses.push(pos.up_height(y as i32));
             }
             if y >= height - 1 {
                 continue;
             }
-            if placer.try_place(
-                chunk,
-                &pos.offset(Vector3::new(1, y as i32, 0)),
-                trunk_block,
-            ) {
-                trunk_poses.push(pos.offset(Vector3::new(1, y as i32, 0)));
+
+            if placer.try_place(chunk, &pos.east().up_height(y as i32), trunk_block) {
+                trunk_poses.push(pos.east().up_height(y as i32));
             }
-            if placer.try_place(
-                chunk,
-                &pos.offset(Vector3::new(1, y as i32, 1)),
-                trunk_block,
-            ) {
-                trunk_poses.push(pos.offset(Vector3::new(1, y as i32, 1)));
+            if placer.try_place(chunk, &pos.east().south().up_height(y as i32), trunk_block) {
+                trunk_poses.push(pos.east().south().up_height(y as i32));
             }
-            if placer.try_place(
-                chunk,
-                &pos.offset(Vector3::new(0, y as i32, 1)),
-                trunk_block,
-            ) {
-                trunk_poses.push(pos.offset(Vector3::new(0, y as i32, 1)));
+            if placer.try_place(chunk, &pos.south().up_height(y as i32), trunk_block) {
+                trunk_poses.push(pos.south().up_height(y as i32));
             }
         }
         (


### PR DESCRIPTION
## Description

Before:
<img width="1920" height="1022" alt="2026-04-23_11 57 43" src="https://github.com/user-attachments/assets/5c10b92b-71b5-437c-a0e7-293ae37c15d0" />

After:
<img width="1920" height="1022" alt="2026-04-23_11 51 40" src="https://github.com/user-attachments/assets/331055c7-4746-4ad5-a8f0-979948bf8f4b" />

I also fixed a typo in dirt placing (below a giant tree trunk) where it was doing .south() twice instead of south().east()