### PR TITLE
Fix: truncate query packet buffer to actual UDP packet length

### DIFF
--- a/pumpkin/src/net/query.rs
+++ b/pumpkin/src/net/query.rs
@@ -61,9 +61,11 @@ pub async fn start_query_handler(server: Arc<Server>, query_addr: SocketAddr) {
             () = STOP_INTERRUPT.cancelled() => None,
         };
 
-        let Some(Ok((_, addr))) = recv_result else {
+        let Some(Ok((length, addr))) = recv_result else {
             break;
         };
+
+        buf.truncate(length);
 
         tokio::spawn(async move {
             if let Err(err) = handle_packet(


### PR DESCRIPTION
## Description

In the Minecraft query protocol, the only difference between a basic stat request and a full stat request is 4 bytes of padding at the end of the packet. `SStatusRequest` therefore uses the buffer length to determine which one it is and returns an error if the length matches neither of those types. Currently, however, the length of the buffer is always 1024, as allocated in `start_query_handler`. Therefore, neither basic stat nor full stat requests work at the moment.

This PR uses the actual packet size from the recv_result and truncates the buffer to that length before passing it to the handler function.
