### PR TITLE
Add base implementation for plugin command list in help menu

### DIFF
--- a/pumpkin/src/command/commands/help.rs
+++ b/pumpkin/src/command/commands/help.rs
@@ -282,7 +282,7 @@ impl HelpCommandExecutor {
                 return Err(PLUGIN_NOT_FOUND_ERROR_TYPE.create_without_context());
             }
 
-            let header_text = format!(" Help - Plugin: {} ", plugin_name);
+            let header_text = format!(" Help - Plugin: {plugin_name} ");
             let dashes = 52usize.saturating_sub(header_text.len() + 3) / 2;
 
             let mut message = TextComponent::empty()
@@ -297,7 +297,7 @@ impl HelpCommandExecutor {
 
             let commands_len = commands.len();
             for (command, (description, usage)) in commands {
-                let command_declaration = format!("/{}", command);
+                let command_declaration = format!("/{command}");
                 message = message.add_child(
                     TextComponent::text(command_declaration.clone())
                         .color_named(NamedColor::Gold)
@@ -366,10 +366,8 @@ impl CommandExecutor for HelpCommandExecutor {
         let arg = context.get_argument(ARG).unwrap_or(&HelpArgument::Page(1));
 
         match arg {
-            HelpArgument::CommandOrPlugin(input) => {
-                HelpCommandExecutor::command_or_plugin(context, input)
-            }
-            HelpArgument::Page(page_number) => HelpCommandExecutor::page(context, *page_number),
+            HelpArgument::CommandOrPlugin(input) => Self::command_or_plugin(context, input),
+            HelpArgument::Page(page_number) => Self::page(context, *page_number),
         }
     }
 }

--- a/pumpkin/src/command/commands/help.rs
+++ b/pumpkin/src/command/commands/help.rs
@@ -18,6 +18,8 @@ use pumpkin_util::text::color::{Color, NamedColor};
 const NO_COMMANDS_ERROR_TYPE: LiteralCommandErrorType =
     LiteralCommandErrorType::new("No commands are available to show help for");
 const FAILED_ERROR_TYPE: CommandErrorType<0> = CommandErrorType::new("commands.help.failed");
+const PLUGIN_NOT_FOUND_ERROR_TYPE: LiteralCommandErrorType =
+    LiteralCommandErrorType::new("Plugin not found or has no commands");
 
 const DESCRIPTION: &str = "Print a help message.";
 const PERMISSION: &str = "minecraft:command.help";
@@ -27,7 +29,7 @@ const ARG: &str = "commandOrPage";
 const COMMANDS_PER_PAGE: usize = 7;
 
 enum HelpArgument {
-    Command(String),
+    CommandOrPlugin(String),
     Page(usize),
 }
 
@@ -86,7 +88,7 @@ impl ArgumentType for HelpArgumentType {
                     text.remove(0);
                 }
 
-                Ok(HelpArgument::Command(text))
+                Ok(HelpArgument::CommandOrPlugin(text))
             }
         }
     }
@@ -267,6 +269,95 @@ impl HelpCommandExecutor {
             Ok(1)
         })
     }
+
+    fn plugin<'a>(context: &'a CommandContext, plugin_name: &'a str) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            let server = context.server();
+            let dispatcher = server.command_dispatcher.read().await;
+            let commands = dispatcher
+                .get_all_permitted_commands_usage_by_plugin(&context.source, plugin_name)
+                .await;
+
+            if commands.is_empty() {
+                return Err(PLUGIN_NOT_FOUND_ERROR_TYPE.create_without_context());
+            }
+
+            let header_text = format!(" Help - Plugin: {} ", plugin_name);
+            let dashes = 52usize.saturating_sub(header_text.len() + 3) / 2;
+
+            let mut message = TextComponent::empty()
+                .add_child(
+                    TextComponent::text("-".repeat(dashes) + " ").color_named(NamedColor::Yellow),
+                )
+                .add_child(TextComponent::text(header_text.clone()))
+                .add_child(
+                    TextComponent::text(" ".to_owned() + &"-".repeat(dashes) + "\n")
+                        .color_named(NamedColor::Yellow),
+                );
+
+            let commands_len = commands.len();
+            for (command, (description, usage)) in commands {
+                let command_declaration = format!("/{}", command);
+                message = message.add_child(
+                    TextComponent::text(command_declaration.clone())
+                        .color_named(NamedColor::Gold)
+                        .add_child(TextComponent::text(" - ").color_named(NamedColor::Yellow))
+                        .add_child(
+                            TextComponent::text(description.to_owned() + "\n")
+                                .color_named(NamedColor::White),
+                        )
+                        .add_child(
+                            TextComponent::text("    Usage: ").color_named(NamedColor::Yellow),
+                        )
+                        .add_child(
+                            TextComponent::text(usage.into_string()).color_named(NamedColor::White),
+                        )
+                        .add_child(TextComponent::text("\n").color_named(NamedColor::White))
+                        .click_event(ClickEvent::SuggestCommand {
+                            command: command_declaration.into(),
+                        }),
+                );
+            }
+
+            message = message
+                .add_child(TextComponent::text("-".repeat(52)).color_named(NamedColor::Yellow));
+
+            context.source.send_message(message).await;
+            Ok(commands_len as i32)
+        })
+    }
+
+    fn command_or_plugin<'a>(
+        context: &'a CommandContext,
+        input: &'a str,
+    ) -> CommandExecutorResult<'a> {
+        Box::pin(async move {
+            // Prioritize commands ig
+            {
+                let dispatcher = context.server().command_dispatcher.read().await;
+                if dispatcher
+                    .get_permitted_command_usage(&context.source, input)
+                    .await
+                    .is_some()
+                {
+                    return Self::command(context, input).await;
+                }
+            }
+
+            {
+                let dispatcher = context.server().command_dispatcher.read().await;
+                let plugin_commands = dispatcher
+                    .get_all_permitted_commands_usage_by_plugin(&context.source, input)
+                    .await;
+
+                if !plugin_commands.is_empty() {
+                    return Self::plugin(context, input).await;
+                }
+            }
+
+            Err(FAILED_ERROR_TYPE.create_without_context())
+        })
+    }
 }
 
 struct HelpCommandExecutor;
@@ -275,8 +366,10 @@ impl CommandExecutor for HelpCommandExecutor {
         let arg = context.get_argument(ARG).unwrap_or(&HelpArgument::Page(1));
 
         match arg {
-            HelpArgument::Command(command) => Self::command(context, command),
-            HelpArgument::Page(page_number) => Self::page(context, *page_number),
+            HelpArgument::CommandOrPlugin(input) => {
+                HelpCommandExecutor::command_or_plugin(context, input)
+            }
+            HelpArgument::Page(page_number) => HelpCommandExecutor::page(context, *page_number),
         }
     }
 }

--- a/pumpkin/src/command/node/dispatcher.rs
+++ b/pumpkin/src/command/node/dispatcher.rs
@@ -681,27 +681,24 @@ impl CommandDispatcher {
         let mut commands: BTreeMap<&str, (&str, Box<str>)> = BTreeMap::new();
 
         for fallback_command in self.fallback_dispatcher.commands.values() {
-            if let Command::Tree(command_tree) = fallback_command {
-                if let Some(source_name) = &command_tree.source {
-                    if source_name == plugin_name {
-                        if let Some(permission) = self
-                            .fallback_dispatcher
-                            .permissions
-                            .get(&command_tree.names[0])
-                            && source.has_permission(permission).await
-                        {
-                            let usage = command_tree.to_string();
-                            for name in &command_tree.names {
-                                commands.insert(
-                                    name,
-                                    (
-                                        command_tree.description.as_ref(),
-                                        usage.clone().into_boxed_str(),
-                                    ),
-                                );
-                            }
-                        }
-                    }
+            if let Command::Tree(command_tree) = fallback_command
+                && let Some(source_name) = &command_tree.source
+                && source_name == plugin_name
+                && let Some(permission) = self
+                    .fallback_dispatcher
+                    .permissions
+                    .get(&command_tree.names[0])
+                && source.has_permission(permission).await
+            {
+                let usage = command_tree.to_string();
+                for name in &command_tree.names {
+                    commands.insert(
+                        name,
+                        (
+                            command_tree.description.as_ref(),
+                            usage.clone().into_boxed_str(),
+                        ),
+                    );
                 }
             }
         }

--- a/pumpkin/src/command/node/dispatcher.rs
+++ b/pumpkin/src/command/node/dispatcher.rs
@@ -671,6 +671,44 @@ impl CommandDispatcher {
         commands
     }
 
+    /// Gets the description and usage of commands from a specific plugin.
+    /// Only returns commands that the source has permission to use.
+    pub async fn get_all_permitted_commands_usage_by_plugin(
+        &self,
+        source: &CommandSource,
+        plugin_name: &str,
+    ) -> BTreeMap<&str, (&str, Box<str>)> {
+        let mut commands: BTreeMap<&str, (&str, Box<str>)> = BTreeMap::new();
+
+        for fallback_command in self.fallback_dispatcher.commands.values() {
+            if let Command::Tree(command_tree) = fallback_command {
+                if let Some(source_name) = &command_tree.source {
+                    if source_name == plugin_name {
+                        if let Some(permission) = self
+                            .fallback_dispatcher
+                            .permissions
+                            .get(&command_tree.names[0])
+                            && source.has_permission(permission).await
+                        {
+                            let usage = command_tree.to_string();
+                            for name in &command_tree.names {
+                                commands.insert(
+                                    name,
+                                    (
+                                        command_tree.description.as_ref(),
+                                        usage.clone().into_boxed_str(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        commands
+    }
+
     /// Gets the description and usage of a given command of the given source.
     /// Returns `None` if not found or the source has insufficient permissions.
     ///

--- a/pumpkin/src/command/tree/builder.rs
+++ b/pumpkin/src/command/tree/builder.rs
@@ -29,6 +29,7 @@ impl CommandTree {
             children: Vec::new(),
             names: names_vec,
             description: description.into(),
+            source: None,
         }
     }
 

--- a/pumpkin/src/command/tree/mod.rs
+++ b/pumpkin/src/command/tree/mod.rs
@@ -78,6 +78,7 @@ pub struct CommandTree {
     pub children: Vec<usize>,
     pub names: Vec<String>,
     pub description: Cow<'static, str>,
+    pub source: Option<String>,
 }
 
 impl CommandTree {

--- a/pumpkin/src/plugin/api/context.rs
+++ b/pumpkin/src/plugin/api/context.rs
@@ -158,6 +158,9 @@ impl Context {
     ) {
         let permission = permission.into();
 
+        let mut tree = tree.clone();
+        tree.source = Some(self.metadata.name.clone());
+
         let full_permission_node = if permission.contains(':') {
             permission
         } else {


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Adds the ability to list all commands registered by a specific plugin by using the help command along with the name of a plugin.

According to discussion on discord, in the case of a plugin and command both sharing the same name, the command is prioritized.

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
