### PR TITLE
Add custom tablist names for players

### DIFF
--- a/pumpkin-plugin-wit/v0.1/player.wit
+++ b/pumpkin-plugin-wit/v0.1/player.wit
@@ -90,6 +90,10 @@ interface player {
         get-display-name: func () -> text-component;
         /// Sets the player's display name.
         set-display-name: func (display-name: text-component);
+        /// Gets the player's custom tab list name.
+        get-tab-list-name: func () -> option<text-component>;
+        /// Sets the player's custom tab list name.
+        set-tab-list-name: func (name: option<text-component>);
 
         // Messaging & titles
 

--- a/pumpkin/src/entity/player.rs
+++ b/pumpkin/src/entity/player.rs
@@ -462,6 +462,7 @@ pub struct Player {
     pub tab_list_header: Mutex<TextComponent>,
     pub tab_list_footer: Mutex<TextComponent>,
     pub display_name: Mutex<Option<TextComponent>>,
+    pub tab_list_name: Mutex<Option<TextComponent>>,
     pub tab_list_order: AtomicI32,
     pub tab_list_latency: AtomicI32,
     pub tab_list_listed: AtomicBool,
@@ -594,6 +595,7 @@ impl Player {
             tab_list_header: Mutex::new(TextComponent::text("")),
             tab_list_footer: Mutex::new(TextComponent::text("")),
             display_name: Mutex::new(None),
+            tab_list_name: Mutex::new(None),
             tab_list_order: AtomicI32::new(0),
             tab_list_latency: AtomicI32::new(0),
             tab_list_listed: AtomicBool::new(false),
@@ -618,6 +620,24 @@ impl Player {
                 &[pumpkin_protocol::java::client::play::Player {
                     uuid: self.gameprofile.id,
                     actions: &[PlayerAction::UpdateDisplayName(display_name.as_ref())],
+                }],
+            ))
+            .await;
+    }
+
+    pub async fn get_tab_list_name(&self) -> Option<TextComponent> {
+        self.tab_list_name.lock().await.clone()
+    }
+
+    pub async fn set_tab_list_name(&self, name: Option<TextComponent>) {
+        *self.tab_list_name.lock().await = name.clone();
+        let world = self.world();
+        world
+            .broadcast_packet_all(&CPlayerInfoUpdate::new(
+                PlayerInfoFlags::UPDATE_DISPLAY_NAME.bits(),
+                &[pumpkin_protocol::java::client::play::Player {
+                    uuid: self.gameprofile.id,
+                    actions: &[PlayerAction::UpdateDisplayName(name.as_ref())],
                 }],
             ))
             .await;

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -313,6 +313,32 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
         Ok(())
     }
 
+    async fn get_tab_list_name(
+        &mut self,
+        player: Resource<Player>,
+    ) -> wasmtime::Result<Option<Resource<pumpkin::plugin::text::TextComponent>>> {
+        let player = player_from_resource(self, &player)?;
+        let tab_list_name = player.get_tab_list_name().await;
+        match tab_list_name {
+            Some(name) => self
+                .add_text_component(name)
+                .map(Some)
+                .map_err(|_| wasmtime::Error::msg("failed to add text-component resource")),
+            None => Ok(None),
+        }
+    }
+
+    async fn set_tab_list_name(
+        &mut self,
+        player: Resource<Player>,
+        name: Option<wasmtime::component::Resource<pumpkin::plugin::text::TextComponent>>,
+    ) -> wasmtime::Result<()> {
+        let name = name.map(|n| text_component_from_resource(self, &n));
+        let player = player_from_resource(self, &player)?;
+        player.set_tab_list_name(name).await;
+        Ok(())
+    }
+
     async fn send_system_message(
         &mut self,
         player: Resource<Player>,

--- a/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
+++ b/pumpkin/src/plugin/loader/wasm/wasm_host/wit/v0_1/player.rs
@@ -319,13 +319,14 @@ impl pumpkin::plugin::player::HostPlayer for PluginHostState {
     ) -> wasmtime::Result<Option<Resource<pumpkin::plugin::text::TextComponent>>> {
         let player = player_from_resource(self, &player)?;
         let tab_list_name = player.get_tab_list_name().await;
-        match tab_list_name {
-            Some(name) => self
-                .add_text_component(name)
-                .map(Some)
-                .map_err(|_| wasmtime::Error::msg("failed to add text-component resource")),
-            None => Ok(None),
-        }
+        tab_list_name.map_or_else(
+            || Ok(None),
+            |name| {
+                self.add_text_component(name)
+                    .map(Some)
+                    .map_err(|_| wasmtime::Error::msg("failed to add text-component resource"))
+            },
+        )
     }
 
     async fn set_tab_list_name(

--- a/pumpkin/src/world/mod.rs
+++ b/pumpkin/src/world/mod.rs
@@ -1935,7 +1935,20 @@ impl World {
             }],
         ))
         .await;
+
+        // If the player has a custom tab_list_name, send an update for it
+        if let Some(tab_list_name) = player.get_tab_list_name().await {
+            self.broadcast_packet_all(&CPlayerInfoUpdate::new(
+                PlayerInfoFlags::UPDATE_DISPLAY_NAME.bits(),
+                &[pumpkin_protocol::java::client::play::Player {
+                    uuid: gameprofile.id,
+                    actions: &[PlayerAction::UpdateDisplayName(Some(&tab_list_name))],
+                }],
+            ))
+            .await;
+        }
         // Here, we send all the infos of players who already joined.
+        let mut players_tab_list_names = Vec::new();
         {
             let mut current_player_data = Vec::new();
             let players = self.players.load();
@@ -1944,6 +1957,7 @@ impl World {
                 .filter(|p| p.gameprofile.id != player.gameprofile.id)
             {
                 let chat_session = player.chat_session.lock().await;
+                let tab_list_name = player.get_tab_list_name().await;
 
                 let mut player_actions = vec![
                     PlayerAction::AddPlayer {
@@ -1970,6 +1984,11 @@ impl World {
                 drop(chat_session);
 
                 current_player_data.push((&player.gameprofile.id, player_actions));
+
+                // Collect tab_list_names for sending later
+                if tab_list_name.is_some() {
+                    players_tab_list_names.push((player.gameprofile.id, tab_list_name));
+                }
             }
 
             let mut action_flags = PlayerInfoFlags::ADD_PLAYER
@@ -1992,6 +2011,21 @@ impl World {
             client
                 .enqueue_packet(&CPlayerInfoUpdate::new(action_flags.bits(), &entries))
                 .await;
+
+            // Send tab_list_names for existing players with custom names
+            for (player_id, tab_list_name) in &players_tab_list_names {
+                if let Some(name) = tab_list_name {
+                    client
+                        .enqueue_packet(&CPlayerInfoUpdate::new(
+                            PlayerInfoFlags::UPDATE_DISPLAY_NAME.bits(),
+                            &[pumpkin_protocol::java::client::play::Player {
+                                uuid: *player_id,
+                                actions: &[PlayerAction::UpdateDisplayName(Some(name))],
+                            }],
+                        ))
+                        .await;
+                }
+            }
         };
 
         let gameprofile = &player.gameprofile;


### PR DESCRIPTION
<!-- Empty or bad Descriptions are not welcome, Don't waste my time -->

## Description
Adds support for modifying the name that is shown in the tablist for a specific player, also adds api methods to the wasm api

## Testing

Please follow our [Coding Guidelines](https://github.com/Pumpkin-MC/Pumpkin/blob/master/CONTRIBUTING.md#coding-guidelines)
